### PR TITLE
remove tf global variables initializer

### DIFF
--- a/trulens/nn/attribution.py
+++ b/trulens/nn/attribution.py
@@ -579,10 +579,7 @@ class IntegratedGradients(InputAttribution):
     """
 
     def __init__(
-            self,
-            model: ModelWrapper,
-            baseline=None,
-            resolution: int = 50):
+            self, model: ModelWrapper, baseline=None, resolution: int = 50):
         """
         Parameters:
             model:

--- a/trulens/nn/models/__init__.py
+++ b/trulens/nn/models/__init__.py
@@ -1,4 +1,3 @@
-
 from trulens.nn import backend as B
 
 if B.backend == 'keras' or B.backend == 'tf.keras':

--- a/trulens/nn/models/_model_base.py
+++ b/trulens/nn/models/_model_base.py
@@ -10,7 +10,6 @@ it should be wrapped as a `ModelWrapper` instance.
 from abc import ABC as AbstractBaseClass
 from abc import abstractmethod
 
-
 DATA_CONTAINER_TYPE = (list, tuple)
 
 

--- a/trulens/nn/models/keras.py
+++ b/trulens/nn/models/keras.py
@@ -400,7 +400,7 @@ class KerasModelWrapper(ModelWrapper):
 
         gradients = [
             keras.backend.function(
-                doi_tensors, B.gradient(q, attribution_tensors))(intervention) 
+                doi_tensors, B.gradient(q, attribution_tensors))(intervention)
             for q in Q
         ] if isinstance(Q, DATA_CONTAINER_TYPE) else keras.backend.function(
             doi_tensors, B.gradient(Q, attribution_tensors))(intervention)

--- a/trulens/nn/models/pytorch.py
+++ b/trulens/nn/models/pytorch.py
@@ -294,7 +294,7 @@ class PytorchModelWrapper(ModelWrapper):
                 nonlocal counter, input_timestep, doi_cut, intervention
 
                 if input_timestep is None or input_timestep == counter:
-                    # FIXME: generalize to multi-input layers. Currently can 
+                    # FIXME: generalize to multi-input layers. Currently can
                     #   only intervene on one layer.
                     inpt = inpt[0] if len(inpt) == 1 else inpt
                     if doi_cut.anchor == 'in':
@@ -458,9 +458,9 @@ class PytorchModelWrapper(ModelWrapper):
 
             grads = [
                 ModelWrapper._unflatten(g, z, count=[0]) for g in grads_flat
-            ] if isinstance(
-                qoi_out, DATA_CONTAINER_TYPE) else ModelWrapper._unflatten(
-                    grads_flat, z, count=[0])
+            ] if isinstance(qoi_out,
+                            DATA_CONTAINER_TYPE) else ModelWrapper._unflatten(
+                                grads_flat, z, count=[0])
 
             grads = [
                 attribution_cut.access_layer(g) for g in grads
@@ -470,7 +470,7 @@ class PytorchModelWrapper(ModelWrapper):
 
             grads = [B.as_array(g) for g in grads] if isinstance(
                 qoi_out, DATA_CONTAINER_TYPE) else B.as_array(grads)
-            
+
             grads_list.append(grads)
 
         del y  # TODO: garbage collection

--- a/trulens/nn/models/tensorflow_v2.py
+++ b/trulens/nn/models/tensorflow_v2.py
@@ -149,11 +149,7 @@ class Tensorflow2ModelWrapper(KerasModelWrapper):
         """
         if not self._eager:
             return super().fprop(
-                model_args, 
-                model_kwargs, 
-                doi_cut, 
-                to_cut, 
-                attribution_cut,
+                model_args, model_kwargs, doi_cut, to_cut, attribution_cut,
                 intervention)
 
         if doi_cut is None:
@@ -198,9 +194,8 @@ class Tensorflow2ModelWrapper(KerasModelWrapper):
                 if not isinstance(doi_cut, InputCut):
                     from_layers = (
                         self._get_logit_layer() if isinstance(
-                            doi_cut, LogitCut) else 
-                        self._get_output_layer() if isinstance(
-                            doi_cut, OutputCut) else
+                            doi_cut, LogitCut) else self._get_output_layer()
+                        if isinstance(doi_cut, OutputCut) else
                         self._get_layers_by_name(doi_cut.name))
 
                     for layer, x_i in zip(from_layers, intervention):
@@ -210,12 +205,12 @@ class Tensorflow2ModelWrapper(KerasModelWrapper):
                             layer.output_intervention = lambda _: x_i
                 else:
                     arg_wrapped_list = False
-                    # Take care of the Keras Module case where args is a tuple 
+                    # Take care of the Keras Module case where args is a tuple
                     # of list of inputs corresponding to `model._inputs`. This
                     # would have gotten unwrapped as the logic operates on the
                     # list of inputs. so needs to be re-wrapped in tuple for the
                     # model arg execution.
-                    if (isinstance(model_args, DATA_CONTAINER_TYPE) and 
+                    if (isinstance(model_args, DATA_CONTAINER_TYPE) and
                             isinstance(model_args[0], DATA_CONTAINER_TYPE)):
 
                         arg_wrapped_list = True
@@ -261,7 +256,7 @@ class Tensorflow2ModelWrapper(KerasModelWrapper):
 
             if attribution_cut:
                 if isinstance(attribution_cut, InputCut):
-                    # The attribution must be the watched tensor given from 
+                    # The attribution must be the watched tensor given from
                     # `qoi_bprop`.
                     attribution_results = intervention
 
@@ -402,10 +397,9 @@ class Tensorflow2ModelWrapper(KerasModelWrapper):
             if isinstance(Q, DATA_CONTAINER_TYPE) and len(Q) == 1:
                 Q = B.sum(Q)
 
-        grads = [
-            tape.gradient(q, attribution_features) for q in Q
-        ] if isinstance(Q, DATA_CONTAINER_TYPE) else tape.gradient(
-            Q, attribution_features)
+        grads = [tape.gradient(q, attribution_features) for q in Q
+                ] if isinstance(Q, DATA_CONTAINER_TYPE) else tape.gradient(
+                    Q, attribution_features)
 
         grads = grads[0] if isinstance(
             grads, DATA_CONTAINER_TYPE) and len(grads) == 1 else grads


### PR DESCRIPTION
tf global variables initializer will overwrite saved variables and cause non determinism in gradient calculations.
Usually an issue because saved checkpoints do not save the same variables as needed for training with gradients.
The solution is to save the right variables, or pass the session with the variables already instantiated.