### PR TITLE
Correctly set None slice output as OutputCut

### DIFF
--- a/tests/keras/unit/keras_model_test.py
+++ b/tests/keras/unit/keras_model_test.py
@@ -35,6 +35,7 @@ class ModelWrapperTest(ModelWrapperTestBase, TestCase):
         self.layer0 = 0
         self.layer1 = 1
         self.layer2 = 2
+        self.out = 'logits'
 
     def test_wrong_keras_version(self):
         import tensorflow as tf

--- a/tests/pytorch/unit/model_wrapper_test.py
+++ b/tests/pytorch/unit/model_wrapper_test.py
@@ -49,6 +49,7 @@ class ModelWrapperTest(ModelWrapperTestBase, TestCase):
         self.layer0 = None
         self.layer1 = 'l1_relu'
         self.layer2 = 'l2_relu'
+        self.out = 'logits'
 
     # Overriden tests.
 

--- a/tests/tf/unit/model_wrapper_test.py
+++ b/tests/tf/unit/model_wrapper_test.py
@@ -31,6 +31,7 @@ class ModelWrapperTest(ModelWrapperTestBase, TestCase):
         self.layer0 = 'x'
         self.layer1 = 'z1'
         self.layer2 = z2.name
+        self.out = y.name
 
 
 if __name__ == '__main__':

--- a/tests/tf2/unit/model_wrapper_test.py
+++ b/tests/tf2/unit/model_wrapper_test.py
@@ -32,6 +32,7 @@ class ModelWrapperTest(ModelWrapperTestBase, TestCase):
         self.layer0 = 0
         self.layer1 = 1
         self.layer2 = 2
+        self.out = 'logits'
 
 
 if __name__ == '__main__':

--- a/tests/tf2/unit/model_wrapper_tf_function_test.py
+++ b/tests/tf2/unit/model_wrapper_tf_function_test.py
@@ -47,6 +47,7 @@ class ModelWrapperTest(ModelWrapperTestBase, TestCase):
         self.layer0 = None
         self.layer1 = 0
         self.layer2 = 1
+        self.out = 'logits'
 
     @unittest.skip(
         "Base class uses layer 0 as multi-input but does not exist in subclass")

--- a/tests/tf2/unit/model_wrapper_tf_subclassed_test.py
+++ b/tests/tf2/unit/model_wrapper_tf_subclassed_test.py
@@ -46,6 +46,7 @@ class ModelWrapperTest(ModelWrapperTestBase, TestCase):
         self.layer0 = None
         self.layer1 = 0
         self.layer2 = 1
+        self.out = 'logits'
 
     @unittest.skip(
         "Base class uses layer 0 as multi-input but does not exist in subclass")

--- a/tests/tf_keras/unit/keras_model_test.py
+++ b/tests/tf_keras/unit/keras_model_test.py
@@ -35,6 +35,7 @@ class ModelWrapperTest(ModelWrapperTestBase, TestCase):
         self.layer0 = 0
         self.layer1 = 1
         self.layer2 = 2
+        self.out = 'logits'
 
 
 if __name__ == '__main__':

--- a/tests/unit/model_wrapper_test_base.py
+++ b/tests/unit/model_wrapper_test_base.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from trulens.nn.attribution import InternalInfluence, InputAttribution
 from trulens.nn.quantities import MaxClassQoI
 from trulens.nn.slices import Cut, InputCut, LogitCut
 
@@ -161,3 +162,23 @@ class ModelWrapperTestBase(object):
         self.assertEqual(len(r), 2)
         self.assertTrue(np.allclose(r[0], np.array([[3., -1.], [0., 2.]])))
         self.assertTrue(np.allclose(r[1], np.array([[3., 2.], [2., 2.]])))
+
+    def test_out_cut(self):
+        input_array = np.array(
+            [[2., 1.], [1., 2.], [1., 1.], [1., 0.], [0., -1.]])
+
+        input_infl = InputAttribution(self.model,
+                                      self.out).attributions(input_array)
+        input_infl_none_out = InputAttribution(
+            self.model).attributions(input_array)
+        np.testing.assert_array_equal(input_infl, input_infl_none_out)
+
+        internal_infl = InternalInfluence(
+            self.model, cuts=(None, self.out), qoi='max',
+            doi='point').attributions(input_array)
+        internal_infl_none_out = InternalInfluence(
+            self.model, cuts=None, qoi='max',
+            doi='point').attributions(input_array)
+        np.testing.assert_array_equal(internal_infl, internal_infl_none_out)
+
+        np.testing.assert_array_equal(internal_infl, input_infl)

--- a/trulens/nn/attribution.py
+++ b/trulens/nn/attribution.py
@@ -389,9 +389,13 @@ class InternalInfluence(AttributionMethod):
             # If we receive a DATA_CONTAINER_TYPE, we take it to be the start
             # and end layer of the slice.
             if len(slice_arg) is 2:
-                return Slice(
-                    InternalInfluence.__get_cut(slice_arg[0]),
-                    InternalInfluence.__get_cut(slice_arg[1]))
+                if slice_arg[1] is None:
+                    return Slice(
+                        InternalInfluence.__get_cut(slice_arg[0]), OutputCut())
+                else:
+                    return Slice(
+                        InternalInfluence.__get_cut(slice_arg[0]),
+                        InternalInfluence.__get_cut(slice_arg[1]))
 
             else:
                 raise ValueError(


### PR DESCRIPTION
Fix line that interprets any None value to InputCut, and correctly chooses OutputCut in the case of the second slice parameter set to None.

Unittest added to modelwrapper_test_base

Fixes #26

