### PR TITLE
fix kwarg not propograting correctly in pytorch fprop

### DIFF
--- a/trulens/nn/models/pytorch.py
+++ b/trulens/nn/models/pytorch.py
@@ -369,7 +369,7 @@ class PytorchModelWrapper(ModelWrapper):
             if name is not None
         ]
         # Run the network.
-        output = self._model(*model_args, *model_kwargs)
+        output = self._model(*model_args, **model_kwargs)
         if isinstance(output, tuple):
             output = output[0]
 


### PR DESCRIPTION
Fix the keyword argument dictionary not propagating correctly. (*kwargs returns a string of argument names while **kwargs is the correct way to propagate a arg dict). 