### PR TITLE
44 tensor type

### DIFF
--- a/.azure_pipelines/ci.yaml
+++ b/.azure_pipelines/ci.yaml
@@ -48,6 +48,11 @@ jobs:
           requirementsFile: "tests/notebooks/requirements.txt"
           testSubdirectory: "tests/notebooks"
 
+        py37_notebooks_latest:
+          condaEnvFileSuffix: "python37"
+          requirementsFile: "tests/notebooks/requirements_latest.txt"
+          testSubdirectory: "tests/notebooks"
+
     steps:
       - checkout: self
         clean: true

--- a/tests/notebooks/requirements_latest.txt
+++ b/tests/notebooks/requirements_latest.txt
@@ -1,0 +1,8 @@
+nbformat==5.0.8
+nbconvert==6.0.7
+matplotlib
+scipy
+tensorflow
+torch==1.6.0
+torchvision
+ipywidgets

--- a/tests/notebooks/test_notebooks.py
+++ b/tests/notebooks/test_notebooks.py
@@ -13,9 +13,9 @@ def get_unit_test_for_filename(filename):
     def test(self):
         with open(f'notebooks/{filename}') as f:
             nb = read(f, as_version=4)
-            (
-                ExecutePreprocessor(timeout=600,
-                                    kernel_name='python37').preprocess(nb, {}))
+            ExecutePreprocessor(
+                timeout=600,
+                kernel_name='python37').preprocess(nb, {})
 
     return test
 

--- a/trulens/nn/backend/__init__.py
+++ b/trulens/nn/backend/__init__.py
@@ -3,6 +3,7 @@ from enum import Enum
 import traceback
 import importlib
 from trulens.utils import tru_logger
+
 # Do not use directly, use get_backend
 _TRULENS_BACKEND_IMPL = None
 
@@ -29,7 +30,9 @@ class Backend(Enum):
             return Backend.UNKNOWN
 
     def is_keras_derivative(self):
-        return self.value == Backend.KERAS.value or self.value == Backend.TF_KERAS.value
+        return (
+        	self.value == Backend.KERAS.value or 
+        	self.value == Backend.TF_KERAS.value)
 
 
 def get_backend(suppress_warnings=False):
@@ -42,26 +45,30 @@ def get_backend(suppress_warnings=False):
         if _TRULENS_BACKEND == Backend.PYTORCH:
             _TRULENS_BACKEND_IMPL = importlib.import_module(
                 name='trulens.nn.backend.pytorch_backend.pytorch')
+
         elif _TRULENS_BACKEND.is_keras_derivative():
             _TRULENS_BACKEND_IMPL = importlib.import_module(
                 name='trulens.nn.backend.keras_backend.keras')
-            # KerasBackend has multiple backend implementations of the keras library,
-            # so reload should be called to refresh if backend changes between keras vs tf.keras
+            # KerasBackend has multiple backend implementations of the keras 
+            # library, so reload should be called to refresh if backend changes
+            # between keras vs tf.keras.
             if _TRULENS_BACKEND != _TRULENS_BACKEND_IMPL.backend:
                 importlib.reload(_TRULENS_BACKEND_IMPL)
+
         elif _TRULENS_BACKEND == Backend.TENSORFLOW:
             _TRULENS_BACKEND_IMPL = importlib.import_module(
                 name='trulens.nn.backend.tf_backend.tf')
+
         elif _TRULENS_BACKEND == Backend.UNKNOWN:
             if not suppress_warnings:
                 tru_logger.warn(
-                    'The current backend is unset or unknown. ' +
-                    'Trulens will attempt to use any previously loaded backends, but may cause problems. '
-                    +
-                    'Valid backends are `pytorch`, `tensorflow`, `keras`, and `tf.keras`. '
-                    +
-                    'You can manually set this with `os.environ[\'TRULENS_BACKEND\']=backend_str`. '
-                    + 'Current loaded backend is {}.'.format(
+                    'The current backend is unset or unknown. Trulens will '
+                    'attempt to use any previously loaded backends, but may '
+                    'cause problems. Valid backends are `pytorch`, '
+                    '`tensorflow`, `keras`, and `tf.keras`. You can manually '
+                    'set this with '
+                    '`os.environ[\'TRULENS_BACKEND\']=backend_str`. Current '
+                    'loaded backend is {}.'.format(
                         str(_TRULENS_BACKEND_IMPL)))
 
     except (ImportError, ModuleNotFoundError):

--- a/trulens/nn/backend/__init__.py
+++ b/trulens/nn/backend/__init__.py
@@ -84,7 +84,6 @@ def get_backend(suppress_warnings=False):
 _ALL_BACKEND_API_FUNCTIONS = [
     'dim_order',
     'channel_axis',
-    'Tensor',
     'floatX',
     'backend',
     'gradient',

--- a/trulens/nn/backend/keras_backend/keras.py
+++ b/trulens/nn/backend/keras_backend/keras.py
@@ -440,6 +440,9 @@ def is_tensor(x):
     ----------
     x : backend.Tensor or other
     """
-    if isinstance(x, Tensor) or isinstance(x, TensorVar):
-        return True
-    return False
+    try:
+        is_keras_tensor = K.is_keras_tensor(x)
+    except:
+        is_keras_tensor = False
+
+    return isinstance(x, Tensor) or isinstance(x, TensorVar) or is_keras_tensor

--- a/trulens/nn/backend/tf_backend/tf.py
+++ b/trulens/nn/backend/tf_backend/tf.py
@@ -429,4 +429,4 @@ def is_tensor(x):
     ----------
     x : backend.Tensor or other
     """
-    return isinstance(x, Tensor):
+    return isinstance(x, Tensor)

--- a/trulens/nn/backend/tf_backend/tf.py
+++ b/trulens/nn/backend/tf_backend/tf.py
@@ -429,6 +429,4 @@ def is_tensor(x):
     ----------
     x : backend.Tensor or other
     """
-    if isinstance(x, Tensor):
-        return True
-    return False
+    return isinstance(x, Tensor):

--- a/trulens/nn/distributions.py
+++ b/trulens/nn/distributions.py
@@ -108,8 +108,7 @@ class DoI(AbstractBaseClass):
                 '`__call__` is expected/allowed to be a list of {} tensors.'.
                 format(self.__class__.__name__, len(x), len(x)))
 
-        elif not (isinstance(x, np.ndarray) or
-                  isinstance(x, get_backend().Tensor)):
+        elif not (isinstance(x, np.ndarray) or get_backend().is_tensor(x)):
             raise ValueError(
                 '`{}` expected to receive an instance of `Tensor` or '
                 '`np.ndarray`, but received an instance of {}'.format(

--- a/trulens/nn/models/__init__.py
+++ b/trulens/nn/models/__init__.py
@@ -25,22 +25,37 @@ def discern_backend(model):
         type_str = str(base_class).lower()
         if 'torch' in type_str:
             return Backend.PYTORCH
+
         else:
             try:
                 import tensorflow as tf
-                # graph objects are currently limited to TF1 and Keras backend implies keras backed with TF1 or Theano.
-                # TF2 Keras objects are handled by the TF2 backend
-                if 'graph' in type_str or ('tensorflow' in type_str and
-                                           tf.__version__.startswith('2')):
+                # Graph objects are currently limited to TF1 and Keras backend 
+                # implies keras backed with TF1 or Theano. TF2 Keras objects are
+                # handled by the TF2 backend.
+                if 'graph' in type_str:
                     return Backend.TENSORFLOW
+
+                if tf.__version__.startswith('2') and (
+                        'tensorflow' in type_str or 'keras' in type_str):
+                    return Backend.TENSORFLOW
+
+                # Note that in these cases, the TensorFlow version is 1.x.
                 elif 'tensorflow' in type_str and 'keras' in type_str and (
                         type_str.index('tensorflow') < type_str.index('keras')):
                     return Backend.TF_KERAS
+
                 elif 'keras' in type_str:
                     return Backend.KERAS
+
             except (ModuleNotFoundError, ImportError):
+                # Note: we can still use Keras without TensorFlow, if the
+                #   backend is Theano.
                 tru_logger.debug('Error importing tensorflow.')
                 tru_logger.debug(traceback.format_exc())
+
+                if 'keras' in type_str:
+                    return Backend.KERAS
+
     return Backend.UNKNOWN
 
 

--- a/trulens/nn/quantities.py
+++ b/trulens/nn/quantities.py
@@ -71,7 +71,7 @@ class QoI(AbstractBaseClass):
                 '`__call__` is expected/allowed to be a list of {} tensors.'.
                 format(self.__class__.__name__, len(x), len(x)))
 
-        elif not isinstance(x, get_backend().Tensor):
+        elif not get_backend().is_tensor(x):
             raise ValueError(
                 '`{}` expected to receive an instance of `Tensor`, but '
                 'received an instance of {}'.format(


### PR DESCRIPTION
Addresses #44. The issue was that the output of a keras model is `KerasTensor` which does not extend the base tensorflow `Tensor` type, so the check in QoI that requires the input to the QoI to be of type `get_backend().Tensor` was failing.

The proposed solution here is to use `get_backend().is_tensor(x)` instead of `isinstance(x, get_backend().Tensor)`. The former was updated to accept `KerasTensor`s in addition to the previously accepted types. Note that now `get_backend().Tensor` should not be used (except internally within the backend module).