### PR TITLE
fix error with tensor assignment for pytorch 1.8+

### DIFF
--- a/tests/notebooks/test_notebooks.py
+++ b/tests/notebooks/test_notebooks.py
@@ -14,8 +14,7 @@ def get_unit_test_for_filename(filename):
         with open(f'notebooks/{filename}') as f:
             nb = read(f, as_version=4)
             ExecutePreprocessor(
-                timeout=600,
-                kernel_name='python37').preprocess(nb, {})
+                timeout=600, kernel_name='python37').preprocess(nb, {})
 
     return test
 

--- a/trulens/nn/backend/__init__.py
+++ b/trulens/nn/backend/__init__.py
@@ -31,8 +31,8 @@ class Backend(Enum):
 
     def is_keras_derivative(self):
         return (
-        	self.value == Backend.KERAS.value or 
-        	self.value == Backend.TF_KERAS.value)
+            self.value == Backend.KERAS.value or
+            self.value == Backend.TF_KERAS.value)
 
 
 def get_backend(suppress_warnings=False):
@@ -49,7 +49,7 @@ def get_backend(suppress_warnings=False):
         elif _TRULENS_BACKEND.is_keras_derivative():
             _TRULENS_BACKEND_IMPL = importlib.import_module(
                 name='trulens.nn.backend.keras_backend.keras')
-            # KerasBackend has multiple backend implementations of the keras 
+            # KerasBackend has multiple backend implementations of the keras
             # library, so reload should be called to refresh if backend changes
             # between keras vs tf.keras.
             if _TRULENS_BACKEND != _TRULENS_BACKEND_IMPL.backend:
@@ -68,8 +68,7 @@ def get_backend(suppress_warnings=False):
                     '`tensorflow`, `keras`, and `tf.keras`. You can manually '
                     'set this with '
                     '`os.environ[\'TRULENS_BACKEND\']=backend_str`. Current '
-                    'loaded backend is {}.'.format(
-                        str(_TRULENS_BACKEND_IMPL)))
+                    'loaded backend is {}.'.format(str(_TRULENS_BACKEND_IMPL)))
 
     except (ImportError, ModuleNotFoundError):
         _TRULENS_BACKEND_IMPL = None

--- a/trulens/nn/backend/pytorch_backend/pytorch.py
+++ b/trulens/nn/backend/pytorch_backend/pytorch.py
@@ -57,8 +57,8 @@ def as_array(t, dtype=None):
         return t if dtype is None else t.astype(dtype)
 
     return (
-        t.cpu().detach().numpy() if dtype is None else 
-        t.cpu().detach().numpy().astype(dtype))
+        t.cpu().detach().numpy()
+        if dtype is None else t.cpu().detach().numpy().astype(dtype))
 
 
 def as_tensor(x, dtype=None, device=None):

--- a/trulens/nn/models/__init__.py
+++ b/trulens/nn/models/__init__.py
@@ -29,14 +29,14 @@ def discern_backend(model):
         else:
             try:
                 import tensorflow as tf
-                # Graph objects are currently limited to TF1 and Keras backend 
+                # Graph objects are currently limited to TF1 and Keras backend
                 # implies keras backed with TF1 or Theano. TF2 Keras objects are
                 # handled by the TF2 backend.
                 if 'graph' in type_str:
                     return Backend.TENSORFLOW
 
-                if tf.__version__.startswith('2') and (
-                        'tensorflow' in type_str or 'keras' in type_str):
+                if tf.__version__.startswith('2') and ('tensorflow' in type_str
+                                                       or 'keras' in type_str):
                     return Backend.TENSORFLOW
 
                 # Note that in these cases, the TensorFlow version is 1.x.
@@ -48,11 +48,9 @@ def discern_backend(model):
                     return Backend.KERAS
 
             except (ModuleNotFoundError, ImportError):
+                # If tensorflow is not installed, the passed model should not be able to be tensorflow.
                 # Note: we can still use Keras without TensorFlow, if the
                 #   backend is Theano.
-                tru_logger.debug('Error importing tensorflow.')
-                tru_logger.debug(traceback.format_exc())
-
                 if 'keras' in type_str:
                     return Backend.KERAS
 

--- a/trulens/nn/models/_model_base.py
+++ b/trulens/nn/models/_model_base.py
@@ -250,7 +250,14 @@ class ModelWrapper(AbstractBaseClass):
             for i in range(len(y)):
                 ModelWrapper._nested_assign(x[i], y[i])
         else:
-            x[:] = y[:]
+            try:
+                x[:] = y[:]
+            except RuntimeError:
+                # torch > 1.7.1 does not allow view assignment.
+                # We want to keep grads. Using solution from https://discuss.pytorch.org/t/leaf-variable-was-used-in-an-inplace-operation/308/2
+                # Assign directly to Tensor with below.
+                x.data = x.data.clone()
+                x.data[:] = y[:]
 
     @staticmethod
     def _nested_apply(y, fn):


### PR DESCRIPTION
Pytorch 1.8+ does not allow view assignment.
Using solution from https://discuss.pytorch.org/t/leaf-variable-was-used-in-an-inplace-operation/308/2
We want to preserve gradients so the clone method is used