### PR TITLE
removing unused get_model_wrapper parameters

### DIFF
--- a/notebooks/cuda/memtest_pytorch.ipynb
+++ b/notebooks/cuda/memtest_pytorch.ipynb
@@ -232,7 +232,7 @@
     "from trulens.nn.attribution import Cut, OutputCut\n",
     "from trulens.utils.typing import ModelInputs\n",
     "\n",
-    "task.wrapper = get_model_wrapper(task.model, input_shape=(None, task.tokenizer.model_max_length), device=task.device)"
+    "task.wrapper = get_model_wrapper(task.model, device=task.device)"
    ]
   },
   {
@@ -456,10 +456,10 @@
  "metadata": {
   "anaconda-cloud": {},
   "interpreter": {
-   "hash": "51eb71198507ab2c2a4108a27eda9d9658549732e67153fc0e371d8439827db7"
+   "hash": "5c887fbf053ca26987bbc53439e0f6b5aed35740853e2f251f93c3825002a8ec"
   },
   "kernelspec": {
-   "display_name": "test-fresh-11-29",
+   "display_name": "Python 3.7.13 ('python37_pytorch_cuda')",
    "language": "python",
    "name": "python3"
   },
@@ -473,7 +473,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/intro_demo_pytorch.ipynb
+++ b/notebooks/intro_demo_pytorch.ipynb
@@ -78,7 +78,7 @@
     "pytorch_model = models.vgg16(pretrained=True)\n",
     "device = 'cpu'\n",
     "# Produce a wrapped model from the pytorch model.\n",
-    "model = get_model_wrapper(pytorch_model, input_shape=(3,224,224), device=device)"
+    "model = get_model_wrapper(pytorch_model, device=device)"
    ]
   },
   {

--- a/notebooks/nlp_demo_pytorch.ipynb
+++ b/notebooks/nlp_demo_pytorch.ipynb
@@ -248,7 +248,7 @@
     "from trulens.nn.attribution import Cut, OutputCut\n",
     "from trulens.utils.typing import ModelInputs\n",
     "\n",
-    "task.wrapper = get_model_wrapper(task.model, input_shape=(None, task.tokenizer.model_max_length), device=task.device)"
+    "task.wrapper = get_model_wrapper(task.model, device=task.device)"
    ]
   },
   {

--- a/tests/pytorch/unit/attribution_axioms_test.py
+++ b/tests/pytorch/unit/attribution_axioms_test.py
@@ -33,9 +33,7 @@ class AxiomsTest(AxiomsTestBase, TestCase):
             def forward(this, x):
                 return this.layer(x)
 
-        self.model_lin = get_model_wrapper(
-            M_lin(), input_shape=(self.input_size,)
-        )
+        self.model_lin = get_model_wrapper(M_lin())
 
         # Make a deeper model for testing.
         class M_deep(Module):
@@ -63,9 +61,7 @@ class AxiomsTest(AxiomsTestBase, TestCase):
                 x = this.l2_relu(x)
                 return this.l3(x)
 
-        self.model_deep = get_model_wrapper(
-            M_deep(), input_shape=(self.input_size,)
-        )
+        self.model_deep = get_model_wrapper(M_deep())
 
         self.layer2 = 'l1_relu'
         self.layer3 = 'l2'

--- a/tests/pytorch/unit/batch_test.py
+++ b/tests/pytorch/unit/batch_test.py
@@ -33,9 +33,7 @@ class BatchTest(BatchTestBase, TestCase):
             def forward(this, x):
                 return this.layer(x)
 
-        self.model_lin = get_model_wrapper(
-            M_lin(), input_shape=(self.input_size,)
-        )
+        self.model_lin = get_model_wrapper(M_lin())
 
         # Make a deeper model for testing.
         class M_deep(Module):
@@ -63,9 +61,7 @@ class BatchTest(BatchTestBase, TestCase):
                 x = this.l2_relu(x)
                 return this.l3(x)
 
-        self.model_deep = get_model_wrapper(
-            M_deep(), input_shape=(self.input_size,)
-        )
+        self.model_deep = get_model_wrapper(M_deep())
 
 
 if __name__ == '__main__':

--- a/tests/pytorch/unit/determinism_test.py
+++ b/tests/pytorch/unit/determinism_test.py
@@ -28,7 +28,7 @@ class DeterminismTest(DeterminismTestBase, TestCase):
             def forward(this, x):
                 return this.dropout1(x) * this.dropout2(x)
 
-        self.model_nondet = get_model_wrapper(NonDet(), input_shape=(10,))
+        self.model_nondet = get_model_wrapper(NonDet())
 
 
 if __name__ == '__main__':

--- a/tests/pytorch/unit/doi_test.py
+++ b/tests/pytorch/unit/doi_test.py
@@ -42,7 +42,7 @@ class DoiTest(DoiTestBase, TestCase):
             def forward(this, x):
                 return this.layer2(this.layer1(x))
 
-        self.model = get_model_wrapper(DoubleExponential(), input_shape=(1,))
+        self.model = get_model_wrapper(DoubleExponential())
 
         self.layer0 = None
         self.layer1 = "layer1"

--- a/tests/pytorch/unit/environment_test.py
+++ b/tests/pytorch/unit/environment_test.py
@@ -31,6 +31,6 @@ class EnvironmentTest(EnvironmentTestBase, TestCase):
                 return this.layer(x)
 
         self.models = [M()]
-        self.models_wrapper_kwargs = [{'input_shape': (self.input_size,)}]
+        self.models_wrapper_kwargs = [{}]
         self.correct_backend = Backend.PYTORCH
         self.model_wrapper_type = PytorchModelWrapper

--- a/tests/pytorch/unit/ffn_edge_case_architectures_test.py
+++ b/tests/pytorch/unit/ffn_edge_case_architectures_test.py
@@ -38,7 +38,7 @@ class FfnEdgeCaseArchitecturesTest(TestCase):
                 z = this.z3(z)
                 return this.y(z)
 
-        model = get_model_wrapper(M(), input_shape=[(5,), (1,)])
+        model = get_model_wrapper(M())
 
         infl = InternalInfluence(model, InputCut(), ClassQoI(1), PointDoi())
 
@@ -73,7 +73,7 @@ class FfnEdgeCaseArchitecturesTest(TestCase):
                 z = this.z3(z)
                 return this.y(z)
 
-        model = get_model_wrapper(M(), input_shape=[(5,), (1,)])
+        model = get_model_wrapper(M())
 
         infl = InternalInfluence(
             model, Cut('concat', anchor='in'), ClassQoI(1), PointDoi()
@@ -108,7 +108,7 @@ class FfnEdgeCaseArchitecturesTest(TestCase):
                 z5 = this.z5(z4)
                 return this.y(z5)
 
-        model = get_model_wrapper(M(), input_shape=[(5,), (1,)])
+        model = get_model_wrapper(M())
 
         infl = InternalInfluence(
             model, Cut(['cut_layer1', 'cut_layer2']), ClassQoI(1), PointDoi()
@@ -146,7 +146,7 @@ class FfnEdgeCaseArchitecturesTest(TestCase):
                 z2 = this.z2(z1)
                 return this.y(z2)
 
-        model = get_model_wrapper(M(), input_shape=(2,))
+        model = get_model_wrapper(M())
 
         infl_out = InternalInfluence(
             model,
@@ -187,7 +187,7 @@ class FfnEdgeCaseArchitecturesTest(TestCase):
                 z2 = this.z2(z1)
                 return this.y(z2)
 
-        model = get_model_wrapper(M(), input_shape=(2,))
+        model = get_model_wrapper(M())
 
         with self.assertRaises(ValueError):
             infl = InternalInfluence(

--- a/tests/pytorch/unit/model_wrapper_test.py
+++ b/tests/pytorch/unit/model_wrapper_test.py
@@ -48,7 +48,7 @@ class ModelWrapperTest(ModelWrapperTestBase, TestCase):
                 x = this.l2_relu(x)
                 return this.logits(x)
 
-        self.model = PytorchModelWrapper(M(), (2,))
+        self.model = PytorchModelWrapper(M())
 
         self.layer0 = None
         self.layer1 = 'l1_relu'
@@ -84,7 +84,7 @@ class ModelWrapperTest(ModelWrapperTestBase, TestCase):
 
                 return layer2
 
-        self.model_kwargs = PytorchModelWrapper(Mkwargs(), (3,))
+        self.model_kwargs = PytorchModelWrapper(Mkwargs())
         self.model_kwargs_layer1 = "layer1"
         self.model_kwargs_layer2 = "layer2"
 

--- a/tests/pytorch/unit/multi_qoi_test.py
+++ b/tests/pytorch/unit/multi_qoi_test.py
@@ -41,9 +41,7 @@ class MultiQoiTest(MultiQoiTestBase, TestCase):
         torch.backends.cudnn.enabled = False
         # We have the same problem as this: https://github.com/pytorch/captum/issues/564
 
-        model = get_model_wrapper(
-            M(), input_shape=(num_timesteps, num_features)
-        )
+        model = get_model_wrapper(M())
         super(MultiQoiTest, self).per_timestep_qoi(
             model, num_classes, num_features, num_timesteps, batch_size
         )

--- a/tests/tf/unit/model_wrapper_test.py
+++ b/tests/tf/unit/model_wrapper_test.py
@@ -30,7 +30,7 @@ class ModelWrapperTest(ModelWrapperTestBase, TestCase):
             y = z2 @ self.layer3_weights + self.bias
 
         self.model = TensorflowModelWrapper(
-            graph, x, y, dict(x=x, z1=z1, z2=z2, logits=y)
+            graph, input_tensors=x, output_tensors=y, internal_tensor_dict=dict(x=x, z1=z1, z2=z2, logits=y)
         )
 
         self.layer0 = 'x'

--- a/trulens/nn/attribution.py
+++ b/trulens/nn/attribution.py
@@ -205,7 +205,7 @@ class AttributionMethod(AbstractBaseClass):
                                      np.ndarray]] = om_of_many(attributions)
 
         if pieces.gradients is not None or pieces.interventions is not None:
-            tru_logger.warn(
+            tru_logger.warning(
                 "AttributionMethod configured to return gradients or interventions. "
                 "Use the internal _attribution call to retrieve those."
             )

--- a/trulens/nn/backend/__init__.py
+++ b/trulens/nn/backend/__init__.py
@@ -133,7 +133,7 @@ def tile(what: Tensors, onto: Tensors) -> Tensors:
         dimension. Otherwise return original val unchanged."""
 
         if val.shape[0] != inputs_dim:
-            tru_logger.warn(
+            tru_logger.warning(
                 f"Value {val} of shape {val.shape} is assumed to not be "
                 f"batchable due to its shape not matching prior batchable "
                 f"values of shape ({inputs_dim},...). If this is "
@@ -213,7 +213,7 @@ def get_backend(suppress_warnings=False):
 
         elif _TRULENS_BACKEND == Backend.UNKNOWN:
             if not suppress_warnings:
-                tru_logger.warn(
+                tru_logger.warning(
                     'The current backend is unset or unknown. Trulens will '
                     'attempt to use any previously loaded backends, but may '
                     'cause problems. Valid backends are `pytorch`, '

--- a/trulens/nn/models/__init__.py
+++ b/trulens/nn/models/__init__.py
@@ -144,10 +144,12 @@ def get_model_wrapper(
         tru_logger.deprecate(
             f"get_model_wrapper: input_shape parameter is no longer used and will be removed in the future"
         )
+        del kwargs['input_shape']
     if 'input_dtype' in kwargs:
         tru_logger.deprecate(
             f"get_model_wrapper: input_dtype parameter is no longer used and will be removed in the future"
         )
+        del kwargs['input_dtype']
 
     # get existing backend
     B = get_backend(suppress_warnings=True)

--- a/trulens/nn/models/__init__.py
+++ b/trulens/nn/models/__init__.py
@@ -62,12 +62,11 @@ def discern_backend(model: ModelLike):
 
 def get_model_wrapper(
     model: ModelLike,
+    *,
     logit_layer=None,
     replace_softmax: bool = False,
     softmax_layer=-1,
     custom_objects=None,
-    input_shape=None,
-    input_dtype=None,
     device: str = None,
     input_tensors=None,
     output_tensors=None,
@@ -103,13 +102,6 @@ def get_model_wrapper(
             _Optional, for use with Keras models only._ A dictionary of
             custom objects used by the Keras model.
 
-        input_shape:
-            _Required for use with Pytorch models only._ Tuple specifying
-            the input shape (excluding the batch dimension) expected by the
-            model.
-        
-        input_dtype: torch.dtype
-            _Optional, for use with Pytorch models only._, The dtype of the input.
 
         device:
             _Optional, for use with Pytorch models only._ A string
@@ -184,14 +176,8 @@ def get_model_wrapper(
 
     elif B.backend == Backend.PYTORCH:
         from trulens.nn.models.pytorch import PytorchModelWrapper
-        if input_shape is None:
-            tru_logger.error('pytorch model must pass parameter: input_shape')
         return PytorchModelWrapper(
-            model,
-            input_shape,
-            input_dtype=input_dtype,
-            logit_layer=logit_layer,
-            device=device
+            model, logit_layer=logit_layer, device=device
         )
     elif B.backend == Backend.TENSORFLOW:
         import tensorflow as tf

--- a/trulens/nn/models/__init__.py
+++ b/trulens/nn/models/__init__.py
@@ -73,7 +73,8 @@ def get_model_wrapper(
     internal_tensor_dict=None,
     default_feed_dict=None,
     session=None,
-    backend=None
+    backend=None,
+    **kwargs
 ):
     """
     Returns a ModelWrapper implementation that exposes the components needed for computing attributions.
@@ -101,7 +102,6 @@ def get_model_wrapper(
         custom_objects:
             _Optional, for use with Keras models only._ A dictionary of
             custom objects used by the Keras model.
-
 
         device:
             _Optional, for use with Pytorch models only._ A string
@@ -139,6 +139,16 @@ def get_model_wrapper(
 
     Returns: ModelWrapper
     """
+
+    if 'input_shape' in kwargs:
+        tru_logger.deprecate(
+            f"get_model_wrapper: input_shape parameter is no longer used and will be removed in the future"
+        )
+    if 'input_dtype' in kwargs:
+        tru_logger.deprecate(
+            f"get_model_wrapper: input_dtype parameter is no longer used and will be removed in the future"
+        )
+
     # get existing backend
     B = get_backend(suppress_warnings=True)
 

--- a/trulens/nn/models/__init__.py
+++ b/trulens/nn/models/__init__.py
@@ -212,8 +212,8 @@ def get_model_wrapper(
                 )
             return TensorflowModelWrapper(
                 model,
-                input_tensors,
-                output_tensors,
+                input_tensors=input_tensors,
+                output_tensors=output_tensors,
                 internal_tensor_dict=internal_tensor_dict,
                 session=session
             )

--- a/trulens/nn/models/_model_base.py
+++ b/trulens/nn/models/_model_base.py
@@ -58,7 +58,8 @@ class ModelWrapper(AbstractBaseClass):
         output_tensors=None,
         internal_tensor_dict=None,
         default_feed_dict=None,
-        session=None
+        session=None,
+        **kwargs
     ):
         """
         Parameters:
@@ -114,7 +115,10 @@ class ModelWrapper(AbstractBaseClass):
                 `tf.Session` object to run the model graph in. If `None`, a new
                 temporary session will be generated every time the model is run.
         """
-        self._model = model
+
+        if model is not None:
+            self._model = model
+        # tf1 backend stores "graph" instead
 
     @property
     def model(self):

--- a/trulens/nn/models/_model_base.py
+++ b/trulens/nn/models/_model_base.py
@@ -84,14 +84,6 @@ class ModelWrapper(AbstractBaseClass):
                 _Optional, for use with Keras models only._ A dictionary of
                 custom objects used by the Keras model.
 
-            #input_shape:
-            #    _Required for use with Pytorch models only._ Tuple specifying
-            #    the input shape (excluding the batch dimension) expected by the
-            #    model.
-            #
-            #input_dtype: torch.dtype
-            #    _Optional, for use with Pytorch models only._ The dtype of the input.
-
             device:
                 _Optional, for use with Pytorch models only._ A string
                 specifying the device to run the model on.

--- a/trulens/nn/models/_model_base.py
+++ b/trulens/nn/models/_model_base.py
@@ -48,12 +48,11 @@ class ModelWrapper(AbstractBaseClass):
     def __init__(
         self,
         model,
+        *,
         logit_layer=None,
         replace_softmax=False,
         softmax_layer=-1,
         custom_objects=None,
-        input_shape=None,
-        input_dtype=None,
         device=None,
         input_tensors=None,
         output_tensors=None,
@@ -85,13 +84,13 @@ class ModelWrapper(AbstractBaseClass):
                 _Optional, for use with Keras models only._ A dictionary of
                 custom objects used by the Keras model.
 
-            input_shape:
-                _Required for use with Pytorch models only._ Tuple specifying
-                the input shape (excluding the batch dimension) expected by the
-                model.
-            
-            input_dtype: torch.dtype
-                _Optional, for use with Pytorch models only._ The dtype of the input.
+            #input_shape:
+            #    _Required for use with Pytorch models only._ Tuple specifying
+            #    the input shape (excluding the batch dimension) expected by the
+            #    model.
+            #
+            #input_dtype: torch.dtype
+            #    _Optional, for use with Pytorch models only._ The dtype of the input.
 
             device:
                 _Optional, for use with Pytorch models only._ A string
@@ -297,7 +296,7 @@ class ModelWrapper(AbstractBaseClass):
                     model_inputs = intervention.as_model_inputs()
 
                     if len(model_inputs.kwargs) > 0:
-                        tru_logger.warn(
+                        tru_logger.warning(
                             "Intervention for InputCut DoI specified but contains only positional arguments. "
                             "The rest will be taken from model_kwargs. If you need to intervene on keyword "
                             "arguments, provide the intervention as a ModelInputs container."

--- a/trulens/nn/models/keras.py
+++ b/trulens/nn/models/keras.py
@@ -39,10 +39,12 @@ class KerasModelWrapper(ModelWrapper):
     def __init__(
         self,
         model,
+        *,
         logit_layer=None,
         replace_softmax=False,
         softmax_layer=-1,
-        custom_objects=None
+        custom_objects=None,
+        **kwargs
     ):
         """
         __init__ Constructor
@@ -72,7 +74,7 @@ class KerasModelWrapper(ModelWrapper):
             )
 
         if replace_softmax:
-            self._model = KerasModelWrapper._replace_probits_with_logits(
+            model = KerasModelWrapper._replace_probits_with_logits(
                 model,
                 probits_layer_name=softmax_layer,
                 custom_objects=custom_objects
@@ -81,8 +83,10 @@ class KerasModelWrapper(ModelWrapper):
             self._logit_layer = softmax_layer
 
         else:
-            self._model = model
             self._logit_layer = logit_layer
+
+        super().__init__(model, **kwargs)
+        # sets self._model, issues cross-backend messages
 
         self._layers = model.layers
         self._layernames = [l.name for l in self._layers]

--- a/trulens/nn/models/keras.py
+++ b/trulens/nn/models/keras.py
@@ -134,7 +134,7 @@ class KerasModelWrapper(ModelWrapper):
         # sigmoid.
         if not (activation == self.keras.activations.softmax or
                 activation == self.keras.activations.sigmoid):
-            tru_logger.warn(
+            tru_logger.warning(
                 'The activation of the specified layer to '
                 '`_replace_probits_with_logits` is not a softmax or a sigmoid; '
                 'it may not currently convert its input to probits.'

--- a/trulens/nn/models/pytorch.py
+++ b/trulens/nn/models/pytorch.py
@@ -48,6 +48,17 @@ class PytorchModelWrapper(ModelWrapper):
             device on which to run model, by default None
         """
 
+        if 'input_shape' in kwargs:
+            tru_logger.deprecate(
+                f"PytorchModelWrapper: input_shape parameter is no longer used and will be removed in the future"
+            )
+            del kwargs['input_shape']
+        if 'input_dtype' in kwargs:
+            tru_logger.deprecate(
+                f"PytorchModelWrapper: input_dtype parameter is no longer used and will be removed in the future"
+            )
+            del kwargs['input_dtype']
+
         super().__init__(model, **kwargs)
         # sets self._model, issues cross-backend messages
 

--- a/trulens/nn/models/pytorch.py
+++ b/trulens/nn/models/pytorch.py
@@ -48,14 +48,8 @@ class PytorchModelWrapper(ModelWrapper):
             device on which to run model, by default None
         """
 
-        if 'input_shape' in kwargs:
-            tru_logger.deprecate(
-                f"input_shape parameter is no longer used and will be removed in the future"
-            )
-        if 'input_dtype' in kwargs:
-            tru_logger.deprecate(
-                f"input_dtype parameter is no longer used and will be removed in the future"
-            )
+        super().__init__(model, **kwargs)
+        # sets self._model, issues cross-backend messages
 
         model.eval()
 
@@ -66,7 +60,6 @@ class PytorchModelWrapper(ModelWrapper):
         self.device = device
         model.to(self.device)
 
-        self._model = model
         self._logit_layer = logit_layer
 
         layers = OrderedDict(PytorchModelWrapper._get_model_layers(model))

--- a/trulens/nn/models/pytorch.py
+++ b/trulens/nn/models/pytorch.py
@@ -33,14 +33,7 @@ class PytorchModelWrapper(ModelWrapper):
     of Pytorch nn.Module objects.
     """
 
-    def __init__(
-        self,
-        model,
-        input_shape,
-        input_dtype=torch.float32,
-        logit_layer=None,
-        device=None
-    ):
+    def __init__(self, model, *, logit_layer=None, device=None, **kwargs):
         """
         __init__ Constructor
 
@@ -48,25 +41,22 @@ class PytorchModelWrapper(ModelWrapper):
         ----------
         model : pytorch.nn.Module
             Pytorch model implemented as nn.Module
-        input_shape: tuple
-            The shape of the input without the batch dimension.
-        input_dtype: torch.dtype
-            The dtype of the input.
         logit_layer: str
             The name of the logit layer. If not supplied, it will assume any 
             layer named 'logits' is the logit layer.
         device : string, optional
             device on which to run model, by default None
         """
-        if input_dtype is None:
-            tru_logger.debug(
-                "Input dtype was not passed in. Defaulting to `torch.float32`."
+
+        if 'input_shape' in kwargs:
+            tru_logger.deprecate(
+                f"input_shape parameter is no longer used and will be removed in the future"
             )
-            input_dtype = torch.float32
-        if input_shape is None:
-            raise ValueError(
-                'pytorch model wrapper must pass the input_shape parameter'
+        if 'input_dtype' in kwargs:
+            tru_logger.deprecate(
+                f"input_dtype parameter is no longer used and will be removed in the future"
             )
+
         model.eval()
 
         if device is None:
@@ -77,8 +67,6 @@ class PytorchModelWrapper(ModelWrapper):
         model.to(self.device)
 
         self._model = model
-        self._input_shape = input_shape
-        self._input_dtype = input_dtype
         self._logit_layer = logit_layer
 
         layers = OrderedDict(PytorchModelWrapper._get_model_layers(model))
@@ -87,7 +75,7 @@ class PytorchModelWrapper(ModelWrapper):
         self._tensors = list(layers.values())
 
         if len(self._tensors) == 0:
-            tru_logger.warn(
+            tru_logger.warning(
                 "model has no visible components, you will not be able to specify cuts"
             )
 
@@ -401,7 +389,7 @@ class PytorchModelWrapper(ModelWrapper):
                 # Adding warning here only if there is more than 1 dimension
                 # being summed. If there is only 1 dim, its likely the batching
                 # dimension so sum there is probably expected.
-                tru_logger.warn(
+                tru_logger.warning(
                     f"Attribution tensor is not scalar (it is of shape {t.shape} "
                     f"and will be summed. This may not be your intention."
                 )

--- a/trulens/nn/models/tensorflow_v1.py
+++ b/trulens/nn/models/tensorflow_v1.py
@@ -148,7 +148,7 @@ class TensorflowModelWrapper(ModelWrapper):
             )
 
         if num_args > 0 and num_kwargs > 0:
-            tru_logger.warn(
+            tru_logger.warning(
                 "Got both args and kwargs as inputs; we assume the args correspond to the first input tensors."
             )
 

--- a/trulens/nn/models/tensorflow_v1.py
+++ b/trulens/nn/models/tensorflow_v1.py
@@ -32,8 +32,8 @@ class TensorflowModelWrapper(ModelWrapper):
 
     def __init__(
         self,
-        *,
         graph,
+        *,
         input_tensors,
         output_tensors,
         internal_tensor_dict=None,

--- a/trulens/nn/models/tensorflow_v1.py
+++ b/trulens/nn/models/tensorflow_v1.py
@@ -62,7 +62,9 @@ class TensorflowModelWrapper(ModelWrapper):
         """
 
         if "model" in kwargs:
-            raise ValueError("TensorflowModelWrapper takes in a graph instead of a model.")
+            raise ValueError(
+                "TensorflowModelWrapper takes in a graph instead of a model."
+            )
 
         super().__init__(None, **kwargs)
         # sets self._model (but not in this case), issues cross-backend messages

--- a/trulens/nn/models/tensorflow_v1.py
+++ b/trulens/nn/models/tensorflow_v1.py
@@ -32,11 +32,13 @@ class TensorflowModelWrapper(ModelWrapper):
 
     def __init__(
         self,
+        *,
         graph,
         input_tensors,
         output_tensors,
         internal_tensor_dict=None,
-        session=None
+        session=None,
+        **kwargs
     ):
         """
         Parameters
@@ -58,6 +60,13 @@ class TensorflowModelWrapper(ModelWrapper):
             `internal_tensor_dict` can be accessed via the name given to them by
             tensorflow.
         """
+
+        if "model" in kwargs:
+            raise ValueError("TensorflowModelWrappers take in graph instead of model.")
+
+        super().__init__(None, **kwargs)
+        # sets self._model (but not in this case), issues cross-backend messages
+
         if input_tensors is None:
             raise ValueError(
                 'Tensorflow1 model wrapper must pass the input_tensors parameter'

--- a/trulens/nn/models/tensorflow_v1.py
+++ b/trulens/nn/models/tensorflow_v1.py
@@ -62,7 +62,7 @@ class TensorflowModelWrapper(ModelWrapper):
         """
 
         if "model" in kwargs:
-            raise ValueError("TensorflowModelWrappers take in graph instead of model.")
+            raise ValueError("TensorflowModelWrapper takes in a graph instead of a model.")
 
         super().__init__(None, **kwargs)
         # sets self._model (but not in this case), issues cross-backend messages

--- a/trulens/nn/models/tensorflow_v2.py
+++ b/trulens/nn/models/tensorflow_v2.py
@@ -32,11 +32,13 @@ class Tensorflow2ModelWrapper(KerasModelWrapper
 
     def __init__(
         self,
+        *,
         model,
         logit_layer=None,
         replace_softmax=False,
         softmax_layer=-1,
-        custom_objects=None
+        custom_objects=None,
+        **kwargs
     ):
         """
         __init__ Constructor
@@ -53,7 +55,8 @@ class Tensorflow2ModelWrapper(KerasModelWrapper
             logit_layer=logit_layer,
             replace_softmax=replace_softmax,
             softmax_layer=softmax_layer,
-            custom_objects=custom_objects
+            custom_objects=custom_objects,
+            **kwargs
         )
 
         self._eager = tf.executing_eagerly()

--- a/trulens/nn/models/tensorflow_v2.py
+++ b/trulens/nn/models/tensorflow_v2.py
@@ -32,8 +32,8 @@ class Tensorflow2ModelWrapper(KerasModelWrapper
 
     def __init__(
         self,
-        *,
         model,
+        *,
         logit_layer=None,
         replace_softmax=False,
         softmax_layer=-1,

--- a/trulens/nn/models/tensorflow_v2.py
+++ b/trulens/nn/models/tensorflow_v2.py
@@ -99,7 +99,7 @@ class Tensorflow2ModelWrapper(KerasModelWrapper
     def _warn_keras_layers(self, layers):
         keras_layers = [l for l in layers if 'KerasLayer' in str(type(l))]
         if (keras_layers):
-            tru_logger.warn('Detected a KerasLayer in the model. This can sometimes create issues during attribution runs or subsequent model calls. \
+            tru_logger.warning('Detected a KerasLayer in the model. This can sometimes create issues during attribution runs or subsequent model calls. \
                 If failures occur: try saving the model, deactivating eager mode with tf.compat.v1.disable_eager_execution(), \
                 setting tf.config.run_functions_eagerly(False), and reloading the model.'\
                     'Detected KerasLayers from model.layers: %s' % str(keras_layers))

--- a/trulens/nn/slices.py
+++ b/trulens/nn/slices.py
@@ -13,9 +13,9 @@ thought of as a sub-model that uses the features computed by $h$.
 #from __future__ import annotations # Avoid expanding type aliases in mkdocs.
 
 from typing import Any, Callable, List, Optional, Union
-from warnings import warn
 
 from trulens.nn.backend import get_backend
+from trulens.utils import tru_logger
 
 # Define some type aliases.
 LayerIdentifier = Union[int, str, List[Union[int, str]]]
@@ -59,7 +59,7 @@ class Cut(object):
             if (isinstance(name, int) or
                 (isinstance(name, list) and isinstance(name[0], int))):
 
-                warn(
+                tru_logger.warning(
                     '\n\nPytorch does not have native support for indexed '
                     'layers. Using layer indices is not recommended.\n'
                 )

--- a/trulens/utils/tru_logger.py
+++ b/trulens/utils/tru_logger.py
@@ -23,11 +23,11 @@ def info(msg, *args, **kwargs):
     get_logger().info(msg, *args, **kwargs)
 
 
-def warn(msg, *args, **kwargs):
+def warning(msg, *args, **kwargs):
     get_logger().warning(msg, *args, **kwargs)
 
 
-def warning(msg, *args, **kwargs):
+def deprecate(msg, *args, **kwargs):
     get_logger().warning(msg, *args, **kwargs)
 
 


### PR DESCRIPTION
input_shape and input_dtype were not used. Removed them but kept in place a deprecation warning in case they are still being provided.