### PR TITLE
Optional param to call model.eval()

### DIFF
--- a/trulens/nn/models/__init__.py
+++ b/trulens/nn/models/__init__.py
@@ -74,6 +74,7 @@ def get_model_wrapper(
     default_feed_dict=None,
     session=None,
     backend=None,
+    force_eval_mode=True,
     **kwargs
 ):
     """
@@ -136,6 +137,10 @@ def get_model_wrapper(
         backend:
             _Optional, for forcing a specific backend._ String values recognized
             are pytorch, tensorflow, keras, or tf.keras.
+        
+        force_eval_mode:
+            _Optional, True will force a model.eval() call for PyTorch models. False
+            will retain current model state
 
     Returns: ModelWrapper
     """
@@ -189,7 +194,10 @@ def get_model_wrapper(
     elif B.backend == Backend.PYTORCH:
         from trulens.nn.models.pytorch import PytorchModelWrapper
         return PytorchModelWrapper(
-            model, logit_layer=logit_layer, device=device
+            model,
+            logit_layer=logit_layer,
+            device=device,
+            force_eval_mode=force_eval_mode
         )
     elif B.backend == Backend.TENSORFLOW:
         import tensorflow as tf

--- a/trulens/nn/models/__init__.py
+++ b/trulens/nn/models/__init__.py
@@ -74,7 +74,7 @@ def get_model_wrapper(
     default_feed_dict=None,
     session=None,
     backend=None,
-    force_eval_mode=True,
+    force_eval=True,
     **kwargs
 ):
     """
@@ -138,7 +138,7 @@ def get_model_wrapper(
             _Optional, for forcing a specific backend._ String values recognized
             are pytorch, tensorflow, keras, or tf.keras.
         
-        force_eval_mode:
+        force_eval:
             _Optional, True will force a model.eval() call for PyTorch models. False
             will retain current model state
 
@@ -197,7 +197,7 @@ def get_model_wrapper(
             model,
             logit_layer=logit_layer,
             device=device,
-            force_eval_mode=force_eval_mode
+            force_eval=force_eval
         )
     elif B.backend == Backend.TENSORFLOW:
         import tensorflow as tf

--- a/trulens/nn/models/pytorch.py
+++ b/trulens/nn/models/pytorch.py
@@ -39,7 +39,7 @@ class PytorchModelWrapper(ModelWrapper):
         *,
         logit_layer=None,
         device=None,
-        force_eval_mode=True,
+        force_eval=True,
         **kwargs
     ):
         """
@@ -54,7 +54,7 @@ class PytorchModelWrapper(ModelWrapper):
             layer named 'logits' is the logit layer.
         device : string, optional
             device on which to run model, by default None
-        force_eval_mode : bool, optional
+        force_eval : bool, optional
             If True, will call model.eval() to ensure determinism. Otherwise, keeps current model state, by default True
             
         """
@@ -72,8 +72,8 @@ class PytorchModelWrapper(ModelWrapper):
 
         super().__init__(model, **kwargs)
         # sets self._model, issues cross-backend messages
-        self.force_eval_mode = force_eval_mode
-        if self.force_eval_mode:
+        self.force_eval = force_eval
+        if self.force_eval:
             model.eval()
 
         if device is None:
@@ -349,7 +349,7 @@ class PytorchModelWrapper(ModelWrapper):
         with memory_suggestions(device=self.device):
             # Run the network.
             try:
-                if self.force_eval_mode:
+                if self.force_eval:
                     self._model.eval()  # needed for determinism sometimes
                 output = model_inputs.call_on(self._model)
 


### PR DESCRIPTION
Adds optional parameter `force_eval=True` to PytorchModelWrapper. Useful since `backward()` with LSTMs must be done in training mode (or with cuda disabled).