### PR TITLE
Fix PyTorch model arg mutation bug

### DIFF
--- a/trulens/nn/models/pytorch.py
+++ b/trulens/nn/models/pytorch.py
@@ -247,11 +247,14 @@ class PytorchModelWrapper(ModelWrapper):
         B = get_backend()
 
         # This method operates on backend tensors.
-        model_inputs = model_inputs.map(B.as_tensor)
         intervention = intervention.map(B.as_tensor)
 
+        # TODO: generalize the condition to include Cut objects that start at the beginning. Until then, clone the model args to avoid mutations (see MLNN-229)
         if isinstance(doi_cut, InputCut):
             model_inputs = intervention
+        else:
+            model_inputs = model_inputs.map(B.as_tensor)
+            model_inputs = model_inputs.map(B.clone)
 
         if attribution_cut is not None:
             # Specify that we want to preserve gradient information.
@@ -276,7 +279,7 @@ class PytorchModelWrapper(ModelWrapper):
 
         # Set up the intervention hookfn if we are starting from an intermediate
         # layer.
-
+        # TODO: generalize the condition to include Cut objects that start at the beginning. Until then, clone the model args to avoid mutations (see MLNN-229)
         if not isinstance(doi_cut, InputCut):
             # Interventions only allowed onto one layer (see FIXME below.)
 

--- a/trulens/utils/typing.py
+++ b/trulens/utils/typing.py
@@ -523,6 +523,12 @@ class TensorAKs(Tensors):  # "Tensor Args and Kwargs"
     def __len__(self):
         return len(self.args) + len(self.kwargs)
 
+    def __contains__(self, item):
+        for val in self.values():
+            if item is val:
+                return True
+        return False
+
     def lenses_values(self):
         """Get lenses focusing on each contained value."""
 


### PR DESCRIPTION
Avoid mutating original input arguments when calling fprop and doi_cut is at model input but is not an InputCut.

In the future, we could add a more sophisticated condition to check the doi_cut for whether it's at the input but I don't think we can get layer order from the model right now.