### PR TITLE
adding better handling of pytorch devices and test notebook

### DIFF
--- a/notebooks/cuda/devices_pytorch.ipynb
+++ b/notebooks/cuda/devices_pytorch.ipynb
@@ -1,0 +1,150 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook tests whether trulens plays well with pytorch when there are multiple CUDA devices available. It has to run on a computer with at least 2 CUDA devices."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "# Use this if running this notebook from within its place in the truera repository.\n",
+    "sys.path.insert(0, \"../..\")\n",
+    "\n",
+    "# Or otherwise install trulens.\n",
+    "# !{sys.executable} -m pip install trulens torch\n",
+    "\n",
+    "import torch\n",
+    "\n",
+    "assert torch.cuda.device_count() >= 2, f\"need at least 2 cuda devices to run this test, have {torch.cuda.device_count()}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Trivial(torch.nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "\n",
+    "        # make sure there is at least 1 parameter in this model\n",
+    "        self.softmax = torch.nn.Linear(in_features=1, out_features=1)\n",
+    "\n",
+    "torch.cuda.set_device(1)\n",
+    "device = torch.device(\"cuda\", 1)\n",
+    "model = Trivial().to(device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pre import\n",
+      "all good\n",
+      "post import\n",
+      "all good\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: lib level=1\n",
+      "INFO: root level=30\n",
+      "INFO: Detected pytorch backend for <class '__main__.Trivial'>.\n",
+      "INFO: Changing backend from None to Backend.PYTORCH.\n",
+      "INFO: If this seems incorrect, you can force the correct backend by passing the `backend` parameter directly into your get_model_wrapper call.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "post wrap\n",
+      "all good\n"
+     ]
+    }
+   ],
+   "source": [
+    "def check_device():\n",
+    "    \"\"\"\n",
+    "    Assert that the model parameters' device is the same as the one we set it to above.\n",
+    "    \"\"\"\n",
+    "    for p in model.parameters():\n",
+    "        assert p.device.type == device.type and p.device.index == device.index, f\"Expected model to be on device {device} but got some parameters on {p.device}.\"\n",
+    "    print(\"all good\")\n",
+    "\n",
+    "# Check model's device before importing and wrapping it using trulens.\n",
+    "print(\"pre import\")\n",
+    "check_device()\n",
+    "\n",
+    "from trulens.nn.models import get_model_wrapper\n",
+    "\n",
+    "# Check model's device after importing trulens.\n",
+    "print(\"post import\")\n",
+    "check_device()\n",
+    "wrapper = get_model_wrapper(model)\n",
+    "\n",
+    "# Finally check after wrapping.\n",
+    "print(\"post wrap\")\n",
+    "check_device()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "interpreter": {
+   "hash": "5c887fbf053ca26987bbc53439e0f6b5aed35740853e2f251f93c3825002a8ec"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.7.13 ('python37_pytorch_cuda')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/trulens/nn/backend/pytorch_backend/pytorch.py
+++ b/trulens/nn/backend/pytorch_backend/pytorch.py
@@ -3,6 +3,7 @@
 # pylint: disable=no-member
 # pylint: disable=not-callable
 
+from typing import Union
 import numpy as np
 import torch
 
@@ -32,8 +33,9 @@ def is_deterministic() -> bool:
 # device as in zeros_like or as_tensor called on numpy arrays.
 default_device = None
 
+DeviceLike = Union[str, torch.device]
 
-def set_default_device(device: str):
+def set_default_device(device: DeviceLike):
     """
     Set the default device so methods that do not take in a tensor can still
     produce a tensor on the right device.
@@ -45,18 +47,12 @@ def set_default_device(device: str):
     if device is None:
         return old_device
 
-    if isinstance(device, torch.device):
-        device = device.type
+    if isinstance(device, str):
+        device = torch.device(device)
 
-    if "cuda" in device:
-        default_device = torch.device(device)
-    elif device == "cpu":
-        default_device = torch.device(device)
-    else:
-        raise ValueError(f"Unhandled device type {device}")
+    default_device = device
 
-
-def get_default_device(device=None):
+def get_default_device(device: DeviceLike = None):
     if device is not None:
         return device
 
@@ -64,7 +60,7 @@ def get_default_device(device=None):
         return default_device
 
     if torch.cuda.is_available():
-        return torch.device("cuda:0")
+        return torch.device("cuda", torch.cuda.current_device())
 
     return torch.device('cpu')
 

--- a/trulens/nn/backend/pytorch_backend/pytorch.py
+++ b/trulens/nn/backend/pytorch_backend/pytorch.py
@@ -64,8 +64,8 @@ def get_default_device(device: DeviceLike = None):
 
     if torch.cuda.is_available():
         return torch.device("cuda", torch.cuda.current_device())
-
-    return torch.device('cpu')
+    else:
+        return torch.device('cpu')
 
 
 def memory_suggestions(*settings, device=None):

--- a/trulens/nn/backend/pytorch_backend/pytorch.py
+++ b/trulens/nn/backend/pytorch_backend/pytorch.py
@@ -4,6 +4,7 @@
 # pylint: disable=not-callable
 
 from typing import Union
+
 import numpy as np
 import torch
 
@@ -35,6 +36,7 @@ default_device = None
 
 DeviceLike = Union[str, torch.device]
 
+
 def set_default_device(device: DeviceLike):
     """
     Set the default device so methods that do not take in a tensor can still
@@ -51,6 +53,7 @@ def set_default_device(device: DeviceLike):
         device = torch.device(device)
 
     default_device = device
+
 
 def get_default_device(device: DeviceLike = None):
     if device is not None:

--- a/trulens/nn/models/pytorch.py
+++ b/trulens/nn/models/pytorch.py
@@ -86,14 +86,18 @@ class PytorchModelWrapper(ModelWrapper):
                     f"Model's parameters span more than one device ({devices})."
                 )
 
-            mdevice = list(devices)[0]
+            if len(devices) == 0:
+                # Model without any parameters. No need to do anything here.
+                pass
+            else:
+                mdevice = list(devices)[0]
 
-            if mdevice != device:
-                tru_logger.warning(
-                    f"Model is not on default device ({device}), moving it there. "
-                    f"If you intend to work on {mdevice}, set it as the default pytorch device or explicitly provide it as the device argument to get_model_wrapper."
-                )
-                model.to(device)
+                if mdevice != device:
+                    tru_logger.warning(
+                        f"Model is not on default device ({device}), moving it there. "
+                        f"If you intend to work on {mdevice}, set it as the default pytorch device or explicitly provide it as the device argument to get_model_wrapper."
+                    )
+                    model.to(device)
 
         else:
             model.to(device)

--- a/trulens/nn/models/pytorch.py
+++ b/trulens/nn/models/pytorch.py
@@ -79,9 +79,34 @@ class PytorchModelWrapper(ModelWrapper):
         if device is None:
             device = pytorch.get_default_device()
 
+            devices = set(p.device for p in model.parameters())
+
+            if len(devices) > 1:
+                tru_logger.warning(
+                    f"Model's parameters span more than one device ({devices})."
+                )
+
+            mdevice = list(devices)[0]
+
+            if mdevice != device:
+                tru_logger.warning(
+                    f"Model is not on default device ({device}), moving it there. "
+                    f"If you intend to work on {mdevice}, set it as the default pytorch device or explicitly provide it as the device argument to get_model_wrapper."
+                )
+                model.to(device)
+
+        else:
+            model.to(device)
+
+            def_device = pytorch.get_default_device()
+            if device != def_device:
+                tru_logger.warning(
+                    f"Model's device ({device}) differs from pytorch's default device ({def_device}). Changing default to model device."
+                )
+                pytorch.set_default_device(device)
+
         pytorch.set_default_device(device)
         self.device = device
-        model.to(self.device)
 
         self._logit_layer = logit_layer
 


### PR DESCRIPTION
get_model_wrapper modified to keep pytorch default device the same as the device of the wrapped model. Issues some warnings if they differ before making them the same.