### PR TITLE
Add a warning when an unrecognized anchor is encountered.

### DIFF
--- a/trulens/nn/models/keras.py
+++ b/trulens/nn/models/keras.py
@@ -377,6 +377,9 @@ class KerasModelWrapper(ModelWrapper):
         ]
 
         if cut.anchor not in ['in', 'out']:
+            tru_logger.warning(
+                f"Unrecognized cut.anchor {cut.anchor}. Defaulting to `out` anchor."
+            )
             outputs = [self._get_layer_output(layer) for layer in layers]
             outputs = [
                 out[cut.anchor][0] if cut.anchor in out else out

--- a/trulens/nn/models/pytorch.py
+++ b/trulens/nn/models/pytorch.py
@@ -307,6 +307,10 @@ class PytorchModelWrapper(ModelWrapper):
                     )
                 )
             else:
+                if doi_cut.anchor is not None and doi_cut.anchor != 'out':
+                    tru_logger.warning(
+                        f"Unrecognized doi_cut.anchor {doi_cut.anchor}. Defaulting to `out` anchor."
+                    )
                 in_handle = (
                     self._get_layer(doi_cut.name
                                    ).register_forward_hook(intervene_hookfn)

--- a/trulens/nn/models/tensorflow_v2.py
+++ b/trulens/nn/models/tensorflow_v2.py
@@ -203,6 +203,10 @@ class Tensorflow2ModelWrapper(KerasModelWrapper
                         if doi_cut.anchor == 'in':
                             layer.input_intervention = intervention_fn
                         else:
+                            if doi_cut.anchor is not None and doi_cut.anchor != 'out':
+                                tru_logger.warning(
+                                    f"Unrecognized doi_cut.anchor {doi_cut.anchor}. Defaulting to `out` anchor."
+                                )
                             layer.output_intervention = intervention_fn
                 else:
                     model_inputs = intervention


### PR DESCRIPTION
Add a warning when an unrecognized anchor is encountered. Otherwise, it will silently use the default but could be because of mispelling, or other issues.