### PR TITLE
AzureOpenAI

### DIFF
--- a/trulens_eval/trulens_eval/feedback.py
+++ b/trulens_eval/trulens_eval/feedback.py
@@ -15,7 +15,6 @@ import numpy as np
 import openai
 import pydantic
 
-
 from trulens_eval import feedback_prompts
 from trulens_eval.keys import *
 from trulens_eval.provider_apis import Endpoint
@@ -370,7 +369,9 @@ class Feedback(FeedbackDefinition):
 
             result_vals = np.array(result_vals)
             if len(result_vals) == 0:
-                logger.warning(f"Feedback function {self.name} with aggregation {self.agg} had no inputs.")
+                logger.warning(
+                    f"Feedback function {self.name} with aggregation {self.agg} had no inputs."
+                )
                 result = np.nan
             else:
                 result = self.agg(result_vals)
@@ -538,6 +539,9 @@ class OpenAI(Provider):
         return Provider.to_json(self, model_engine=self.model_engine)
     """
 
+    def _create_chat_completition(self, *args, **kwargs):
+        return openai.ChatCompletion.create(*args, **kwargs)
+
     def _moderation(self, text: str):
         return self.endpoint.run_me(
             lambda: openai.Moderation.create(input=text)
@@ -683,7 +687,7 @@ class OpenAI(Provider):
         """
         return _re_1_10_rating(
             self.endpoint.run_me(
-                lambda: openai.ChatCompletion.create(
+                lambda: self._create_chat_completition(
                     model=self.model_engine,
                     temperature=0.0,
                     messages=[
@@ -717,7 +721,7 @@ class OpenAI(Provider):
         """
         return _re_1_10_rating(
             self.endpoint.run_me(
-                lambda: openai.ChatCompletion.create(
+                lambda: self._create_chat_completition(
                     model=self.model_engine,
                     temperature=0.0,
                     messages=[
@@ -752,7 +756,7 @@ class OpenAI(Provider):
             being "in agreement".
         """
         oai_chat_response = OpenAI().endpoint_openai.run_me(
-            lambda: openai.ChatCompletion.create(
+            lambda: self._create_chat_completition(
                 model=self.model_engine,
                 temperature=0.0,
                 messages=[
@@ -787,7 +791,7 @@ class OpenAI(Provider):
 
         return _re_1_10_rating(
             self.endpoint.run_me(
-                lambda: openai.ChatCompletion.create(
+                lambda: self._create_chat_completition(
                     model=self.model_engine,
                     temperature=0.5,
                     messages=[
@@ -801,6 +805,42 @@ class OpenAI(Provider):
                     ]
                 )["choices"][0]["message"]["content"]
             )
+        )
+
+
+class AzureOpenAI(OpenAI):
+    deployment_id: str
+
+    def __init__(self, **kwargs):
+        """
+        Wrapper to use Azure OpenAI. Please export the following env variables
+
+        - OPENAI_API_BASE
+        - OPENAI_API_VERSION
+        - OPENAI_API_KEY
+
+        Parameters:
+
+        - model_engine (str, optional): The specific model version. Defaults to
+          "gpt-35-turbo".
+        - deployment_id (str): The specified deployment id
+        """
+
+        super().__init__(
+            **kwargs
+        )  # need to include pydantic.BaseModel.__init__
+
+        set_openai_key()
+        openai.api_type = "azure"
+        openai.api_base = os.getenv("OPENAI_API_BASE")
+        openai.api_version = os.getenv("OPENAI_API_VERSION")
+
+    def _create_chat_completition(self, *args, **kwargs):
+        """
+        We need to pass `engine`
+        """
+        return super()._create_chat_completition(
+            *args, deployment_id=self.deployment_id, **kwargs
         )
 
 


### PR DESCRIPTION
Hi there 👋 

I've added a new classed called `AzureOpenAI` to make it easier using the weird Azure OpenAI wrapper. So basically you can now

```python
from trulens_eval.feedback import AzureOpenAI

feedback = AzureOpenAI(
    model_engine="gpt-35-turbo", deployment_id=os.environ["OPENAI_ENGINE"]
)

print(feedback.qs_relevance("hey", "foo"))
```

I did it by first wrapping all the `openai.ChatCompletion.create` calls to a function named `_create_chat_completition`, then subclasses OpenAI and just re implemented that function to add an extra parameter