### PR TITLE
refine result pass/fail feedback categories in ui

### DIFF
--- a/trulens_eval/trulens_eval/Leaderboard.py
+++ b/trulens_eval/trulens_eval/Leaderboard.py
@@ -6,12 +6,12 @@ import streamlit as st
 from streamlit_extras.switch_page_button import switch_page
 
 from trulens_eval.db_migration import MIGRATION_UNKNOWN_STR
+from trulens_eval.ux.styles import CATEGORY
 
 st.runtime.legacy_caching.clear_cache()
 
 from trulens_eval import db
 from trulens_eval import Tru
-from trulens_eval.feedback import default_pass_fail_color_threshold
 from trulens_eval.ux import styles
 
 st.set_page_config(page_title="Leaderboard", layout="wide")
@@ -88,19 +88,13 @@ def streamlit_app():
                 pass
 
             else:
-                if mean >= default_pass_fail_color_threshold:
-                    feedback_cols[i].metric(
-                        label=col_name,
-                        value=f'{round(mean, 2)}',
-                        delta='✅ High'
-                    )
-                else:
-                    feedback_cols[i].metric(
-                        label=col_name,
-                        value=f'{round(mean, 2)}',
-                        delta='⚠️ Low ',
-                        delta_color="inverse"
-                    )
+                cat = CATEGORY.of_score(mean)
+                feedback_cols[i].metric(
+                    label=col_name,
+                    value=f'{round(mean, 2)}',
+                    delta=f'{cat.icon} {cat.adjective}',
+                    delta_color="normal" if mean >= CATEGORY.PASS.threshold else "inverse"
+                )
 
         with col99:
             if st.button('Select App', key=f"app-selector-{app}"):

--- a/trulens_eval/trulens_eval/feedback.py
+++ b/trulens_eval/trulens_eval/feedback.py
@@ -392,7 +392,6 @@ You can inspect the components making up your app via the `App` method
 """
 
 from datetime import datetime
-from enum import Enum
 from inspect import Signature
 from inspect import signature
 import itertools
@@ -430,7 +429,6 @@ from trulens_eval.util import UNICODE_CLOCK
 from trulens_eval.util import UNICODE_YIELD
 
 PROVIDER_CLASS_NAMES = ['OpenAI', 'Huggingface', 'Cohere']
-
 
 logger = logging.getLogger(__name__)
 

--- a/trulens_eval/trulens_eval/feedback.py
+++ b/trulens_eval/trulens_eval/feedback.py
@@ -392,6 +392,7 @@ You can inspect the components making up your app via the `App` method
 """
 
 from datetime import datetime
+from enum import Enum
 from inspect import Signature
 from inspect import signature
 import itertools
@@ -430,7 +431,6 @@ from trulens_eval.util import UNICODE_YIELD
 
 PROVIDER_CLASS_NAMES = ['OpenAI', 'Huggingface', 'Cohere']
 
-default_pass_fail_color_threshold = 0.5
 
 logger = logging.getLogger(__name__)
 

--- a/trulens_eval/trulens_eval/pages/Evaluations.py
+++ b/trulens_eval/trulens_eval/pages/Evaluations.py
@@ -10,7 +10,7 @@ from st_aggrid.shared import JsCode
 import streamlit as st
 from streamlit_javascript import st_javascript
 from ux.add_logo import add_logo
-from ux.styles import default_pass_fail_color_threshold
+from ux.styles import CATEGORY
 
 from trulens_eval import Tru
 from trulens_eval.app import ComponentView
@@ -26,7 +26,6 @@ from trulens_eval.util import JSONPath
 from trulens_eval.ux.components import draw_call
 from trulens_eval.ux.components import draw_llm_info
 from trulens_eval.ux.components import draw_prompt_info
-from trulens_eval.ux.components import draw_selector_button
 from trulens_eval.ux.components import render_selector_markdown
 from trulens_eval.ux.components import write_or_json
 from trulens_eval.ux.styles import cellstyle_jscode
@@ -209,12 +208,9 @@ else:
                 def display_feedback_call(call):
 
                     def highlight(s):
-                        return ['background-color: #4CAF50'] * len(
-                            s
-                        ) if s.result >= default_pass_fail_color_threshold else [
-                            'background-color: #FCE6E6'
-                        ] * len(s)
-
+                        cat = CATEGORY.of_score(s.result)
+                        return [f'background-color: {cat.color}'] * len(s)
+                        
                     if call is not None and len(call) > 0:
                         df = pd.DataFrame.from_records(
                             [call[i]["args"] for i in range(len(call))]

--- a/trulens_eval/trulens_eval/ux/styles.py
+++ b/trulens_eval/trulens_eval/ux/styles.py
@@ -37,9 +37,11 @@ class CATEGORY:
         icon="?"
     )
 
+    ALL = [PASS, WARNING, FAIL] # not including UNKNOWN intentionally
+
     @staticmethod
     def of_score(score: float) -> Category:
-        for cat in [CATEGORY.PASS, CATEGORY.WARNING, CATEGORY.FAIL]:
+        for cat in CATEGORY.ALL:
             if score >= cat.threshold:
                 return cat
 
@@ -51,6 +53,7 @@ class CATEGORY:
 root_js = f"""
     var default_pass_threshold = {CATEGORY.PASS.threshold};
     var default_warning_threshold = {CATEGORY.WARNING.threshold};
+    var default_fail_threshold = {CATEGORY.FAIL.threshold};
 """
 
 # Not presently used. Need to figure out how to include this in streamlit pages.
@@ -67,29 +70,21 @@ stmetricdelta_hidearrow = """
 cellstyle_jscode = f"""
     function(params) {{
         let v = parseFloat(params.value);
-        if (v >= {CATEGORY.PASS.threshold}) {{
+        """ + \
+    "\n".join(f"""
+        if (v >= {cat.threshold}) {{
             return {{
                 'color': 'black',
-                'backgroundColor': '{CATEGORY.PASS.color}'
-                
-            }};
-        }} else if (v >= {CATEGORY.WARNING.threshold}) {{
-            return {{
-                'color': 'black',
-                'backgroundColor': '{CATEGORY.WARNING.color}'
-            }};
-        }} else if (v >= {CATEGORY.FAIL.threshold}) {{
-            return {{
-                'color': 'black',
-                'backgroundColor': '{CATEGORY.FAIL.color}'
-            }};
-        }} else {{ // i.e. not a number
-            return {{
-                'color': 'black',
-                'backgroundColor': '{CATEGORY.UNKNOWN.color}'
+                'backgroundColor': '{cat.color}'
             }};
         }}
-    }};
+    """ for cat in CATEGORY.ALL) + f"""
+        // i.e. not a number
+        return {{
+            'color': 'black',
+            'backgroundColor': '{CATEGORY.UNKNOWN.color}'
+        }};
+    }}
     """
 
 hide_table_row_index = """

--- a/trulens_eval/trulens_eval/ux/styles.py
+++ b/trulens_eval/trulens_eval/ux/styles.py
@@ -1,5 +1,3 @@
-from enum import Enum
-
 import numpy as np
 
 from trulens_eval.util import SerialModel

--- a/trulens_eval/trulens_eval/ux/styles.py
+++ b/trulens_eval/trulens_eval/ux/styles.py
@@ -1,12 +1,62 @@
-from trulens_eval.feedback import default_pass_fail_color_threshold
+from enum import Enum
 
-# These would be useful to include in our pages but don't yet see a way to do this in streamlit.
+import numpy as np
+
+from trulens_eval.util import SerialModel
+
+
+class CATEGORY:
+    """
+    Feedback result categories for displaying purposes: pass, warning, fail, or
+    unknown.
+    """
+
+    class Category(SerialModel):
+        name: str
+        adjective: str
+        threshold: float
+        color: str
+        icon: str
+
+    PASS = Category(
+        name="pass", adjective="high", threshold=0.8, color="#aaffaa", icon="✅"
+    )
+    WARNING = Category(
+        name="warning",
+        adjective="medium",
+        threshold=0.6,
+        color="#ffffaa",
+        icon="⚠️"
+    )
+    FAIL = Category(
+        name="fail", adjective="low", threshold=0.0, color="#ffaaaa", icon="🛑"
+    )
+    UNKNOWN = Category(
+        name="unknown",
+        adjective="unknown",
+        threshold=np.nan,
+        color="#aaaaaa",
+        icon="?"
+    )
+
+    @staticmethod
+    def of_score(score: float) -> Category:
+        for cat in [CATEGORY.PASS, CATEGORY.WARNING, CATEGORY.FAIL]:
+            if score >= cat.threshold:
+                return cat
+
+        return CATEGORY.UNKNOWN
+
+
+# These would be useful to include in our pages but don't yet see a way to do
+# this in streamlit.
 root_js = f"""
-    default_pass_fail_color_threshold = {default_pass_fail_color_threshold};
+    var default_pass_threshold = {CATEGORY.PASS.threshold};
+    var default_warning_threshold = {CATEGORY.WARNING.threshold};
 """
 
+# Not presently used. Need to figure out how to include this in streamlit pages.
 root_html = f"""
-js:
 <script>
     {root_js}
 </script>
@@ -16,29 +66,32 @@ stmetricdelta_hidearrow = """
     <style> [data-testid="stMetricDelta"] svg { display: none; } </style>
     """
 
-cellstyle_jscode = """
-    function(params) {
-        if (parseFloat(params.value) < """ + str(
-    default_pass_fail_color_threshold
-) + """) {
-            return {
+cellstyle_jscode = f"""
+    function(params) {{
+        let v = parseFloat(params.value);
+        if (v >= {CATEGORY.PASS.threshold}) {{
+            return {{
                 'color': 'black',
-                'backgroundColor': '#FCE6E6'
-            }
-        } else if (parseFloat(params.value) >= """ + str(
-    default_pass_fail_color_threshold
-) + """) {
-            return {
+                'backgroundColor': '{CATEGORY.PASS.color}'
+                
+            }};
+        }} else if (v >= {CATEGORY.WARNING.threshold}) {{
+            return {{
                 'color': 'black',
-                'backgroundColor': '#4CAF50'
-            }
-        } else {
-            return {
+                'backgroundColor': '{CATEGORY.WARNING.color}'
+            }};
+        }} else if (v >= {CATEGORY.FAIL.threshold}) {{
+            return {{
                 'color': 'black',
-                'backgroundColor': 'white'
-            }
-        }
-    };
+                'backgroundColor': '{CATEGORY.FAIL.color}'
+            }};
+        }} else {{ // i.e. not a number
+            return {{
+                'color': 'black',
+                'backgroundColor': '{CATEGORY.UNKNOWN.color}'
+            }};
+        }}
+    }};
     """
 
 hide_table_row_index = """


### PR DESCRIPTION
Categories now include "warning" with medium scores and pass requires a higher threshold than before. Makes examples look more prescriptive. Moved all of this out of feedback.py and into ux/styles.py .


![Screenshot 2023-07-17 at 17 19 37](https://github.com/truera/trulens/assets/421701/e7bcb9cd-6a44-4bb6-90c2-455d5566de7c)
![Screenshot 2023-07-17 at 17 19 30](https://github.com/truera/trulens/assets/421701/05dc9d39-beef-4356-b02d-4010100618ae)

