### PR TITLE
Remove keys dependencies from dashboard

### DIFF
--- a/trulens_eval/trulens_eval/feedback.py
+++ b/trulens_eval/trulens_eval/feedback.py
@@ -1327,11 +1327,13 @@ class OpenAI(Provider):
 
 class GroundTruthAgreement(SerialModel, WithClassInfo):
     ground_truth: Union[List[str], FunctionOrMethod]
-    provider: OpenAI
+    provider: Provider
 
     ground_truth_imp: Optional[Callable] = pydantic.Field(exclude=True)
 
-    def __init__(self, ground_truth: Union[List[str], Callable, FunctionOrMethod], provider: OpenAI = OpenAI()):
+    def __init__(self, ground_truth: Union[List[str], Callable, FunctionOrMethod], provider: OpenAI = None):
+        if provider is None:
+            provider = OpenAI()
         if isinstance(ground_truth, List):
             ground_truth_imp = None
         elif isinstance(ground_truth, FunctionOrMethod):

--- a/trulens_eval/trulens_eval/pages/Progress.py
+++ b/trulens_eval/trulens_eval/pages/Progress.py
@@ -1,33 +1,10 @@
-from datetime import datetime
-import json
-from typing import Dict, List
-
-import pandas as pd
 from st_aggrid import AgGrid
-from st_aggrid.grid_options_builder import GridOptionsBuilder
-from st_aggrid.shared import GridUpdateMode
-from st_aggrid.shared import JsCode
 import streamlit as st
 from ux.add_logo import add_logo
 
-from trulens_eval import db
 from trulens_eval import Tru
-from trulens_eval.db import DB
-from trulens_eval.feedback import Feedback
-from trulens_eval.provider_apis import Endpoint
-from trulens_eval.provider_apis import HuggingfaceEndpoint
-from trulens_eval.provider_apis import OpenAIEndpoint
+from trulens_eval.provider_apis import DEFAULT_RPM
 from trulens_eval.schema import FeedbackResultStatus
-from trulens_eval.util import is_empty
-from trulens_eval.util import is_noserio
-from trulens_eval.util import TP
-
-from trulens_eval.keys import check_keys
-
-check_keys(
-    "OPENAI_API_KEY",
-    "HUGGINGFACE_API_KEY"
-)
 
 st.set_page_config(page_title="Feedback Progress", layout="wide")
 
@@ -40,10 +17,7 @@ add_logo()
 tru = Tru()
 lms = tru.db
 
-e_openai = OpenAIEndpoint()
-e_hugs = HuggingfaceEndpoint()
-
-endpoints = [e_openai, e_hugs]
+endpoints = ["OpenAI", "HuggingFace"]
 
 tab1, tab2, tab3 = st.tabs(["Progress", "Endpoints", "Feedback Functions"])
 
@@ -61,8 +35,8 @@ with tab1:
 
 with tab2:
     for e in endpoints:
-        st.header(e.name.upper())
-        st.metric("RPM", e.rpm)
+        st.header(e)
+        st.metric("RPM", DEFAULT_RPM)
 
 with tab3:
     feedbacks = lms.get_feedback_defs()

--- a/trulens_eval/trulens_eval/provider_apis.py
+++ b/trulens_eval/trulens_eval/provider_apis.py
@@ -32,7 +32,7 @@ pp = PrettyPrinter()
 T = TypeVar("T")
 
 INSTRUMENT = "__tru_instrument"
-
+DEFAULT_RPM = 60
 
 class EndpointCallback(SerialModel):
     """
@@ -119,7 +119,7 @@ class Endpoint(SerialModel, SingletonPerName):
     name: str
 
     # Requests per minute.
-    rpm: float = 60
+    rpm: float = DEFAULT_RPM
 
     # Retries (if performing requests using this class). TODO: wire this up to
     # the various endpoint systems' retries specification.


### PR DESCRIPTION
* Instantiating the default OpenAI in init param means it happens at import time
* The progress bar was instantiating providers but does not even use them and they do not represent the real providers that the feedback functions are using