### PR TITLE
get_records_and_feedback bug: Added argument in execute cmd

### DIFF
--- a/trulens_eval/trulens_eval/db.py
+++ b/trulens_eval/trulens_eval/db.py
@@ -583,7 +583,7 @@ class LocalSQLite(DB):
             app_id_list = ', '.join('?' * len(app_ids))
             query = query + f" WHERE r.app_id IN ({app_id_list})"
 
-        c.execute(query)
+        c.execute(query, app_ids)
         rows = c.fetchall()
         conn.close()
 
@@ -605,7 +605,7 @@ class LocalSQLite(DB):
             app_id_list = ', '.join('?' * len(app_ids))
             query = query + f" WHERE r.app_id IN ({app_id_list})"
 
-        c.execute(query)
+        c.execute(query, app_ids)
         rows = c.fetchall()
         conn.close()
 


### PR DESCRIPTION
### How to reproduce 

```
tru.get_records_and_feedback([app_id])
```

### Error 

```
Traceback (most recent call last):  File "/home/lab/lab392-rfpvirtualassistant/scripts/langchain/get_app.py", line 7, in <module>  
 json_output, fb_c = tru.get_records_and_feedback([app_id])  
File "/home/lab/anaconda/envs/lab392/lib/python3.10/site-packages/trulens_eval/tru.py", line 214, in get_records_and_feedback    
df, feedback_columns = self.db.get_records_and_feedback(app_ids)  
File "/home/lab/anaconda/envs/lab392/lib/python3.10/site-packages/trulens_eval/db.py", line 132, in wrapper    
returned_value = func(self, *args, **kwargs)  
File "/home/lab/anaconda/envs/lab392/lib/python3.10/site-packages/trulens_eval/db.py", line 587, in get_records_and_feedback    
c.execute(query)sqlite3.ProgrammingError: Incorrect number of bindings supplied. The current statement uses 1, and there are 0 supplied.
```

Now works with `tru.get_records_and_feedback([app_id])` and `tru.get_records_and_feedback(None)`

The argument was missing when executing the sqlite command