### PR TITLE
change warn to debug on endpoint tracking

### DIFF
--- a/trulens_eval/trulens_eval/provider_apis.py
+++ b/trulens_eval/trulens_eval/provider_apis.py
@@ -377,7 +377,7 @@ class Endpoint(SerialModel, SingletonPerName):
                 e = OpenAIEndpoint()
                 endpoints.append(e)
             except:
-                logger.warning(
+                logger.debug(
                     "OpenAI API keys are not set. "
                     "Will not track usage."
                 )
@@ -387,7 +387,7 @@ class Endpoint(SerialModel, SingletonPerName):
                 e = HuggingfaceEndpoint()
                 endpoints.append(e)
             except:
-                logger.warning(
+                logger.debug(
                     "Huggingface API keys are not set. "
                     "Will not track usage."
                 )


### PR DESCRIPTION
* Typically the call will already fail if it needs to the hit the endpoint anyways so this is not a very user friendly log. 
* Code lives in right place (as between every call the keys could have been added), so making it debug 