### PR TITLE
Allow `FeedbackCall` to have JSON args

### DIFF
--- a/trulens_eval/trulens_eval/schema.py
+++ b/trulens_eval/trulens_eval/schema.py
@@ -282,7 +282,7 @@ class FeedbackResultStatus(Enum):
 
 
 class FeedbackCall(SerialModel):
-    args: Dict[str, Optional[str]]
+    args: Dict[str, Optional[JSON]]
     ret: float
 
     # New in 0.6.0: Any additional data a feedback function returns to display


### PR DESCRIPTION
**Addressing this issue: https://github.com/truera/trulens/issues/343**

**Test logs: [test_log.txt](https://github.com/truera/trulens/files/12440768/test_log.txt)**

**Example usage:**
```python
from trulens_eval import Provider, Feedback, Select
from trulens_eval.tru_custom_app import TruCustomApp, instrument

class CustomApp:
    @instrument
    def _call(self, inputs: dict):
        return inputs

class CustomProvider(Provider):
    def my_feedback_func(self, vals: list) -> float:
        print(f"Running feedback on {vals}")
        return float(len(vals))

fb = Feedback(CustomProvider().my_feedback_func) \
    .on(vals=Select.RecordCalls._call.args.inputs.vals)

app = TruCustomApp(CustomApp(), app_id="custom_app", feedbacks=[fb])

_, _ = app.with_record(app.app._call, inputs={"vals": ["foo", "bar"]})
```

**What it looks like in the dashboard:**
![image](https://github.com/truera/trulens/assets/89975469/3f34e0e2-6dce-4ba4-9682-d743c9068932)

