### PR TITLE
Rename tru_query_engine and add docs to tru_wrapper usages

### DIFF
--- a/docs/trulens_eval/llama_index_instrumentation.ipynb
+++ b/docs/trulens_eval/llama_index_instrumentation.ipynb
@@ -59,9 +59,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tru_query_engine = TruLlama(query_engine)\n",
+    "tru_llama = TruLlama(query_engine)\n",
     "\n",
-    "llm_response = tru_query_engine.query(\"What did the author do growing up?\")"
+    "llm_response = tru_llama.query(\"What did the author do growing up?\")"
    ]
   },
   {
@@ -165,9 +165,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tru_query_engine = TruLlama(query_engine)\n",
+    "tru_llama = TruLlama(query_engine)\n",
     "\n",
-    "response = tru_query_engine.query(\"What did the author do growing up?\")\n",
+    "response = tru_llama.query(\"What did the author do growing up?\")\n",
     "\n",
     "for c in response.response_gen:\n",
     "    print(c)"

--- a/trulens_eval/examples/colab/quickstarts/llama_index_quickstart_colab.ipynb
+++ b/trulens_eval/examples/colab/quickstarts/llama_index_quickstart_colab.ipynb
@@ -178,7 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tru_query_engine = TruLlama(query_engine,\n",
+    "tru_llama = TruLlama(query_engine,\n",
     "    app_id='LlamaIndex_App1',\n",
     "    feedbacks=[f_lang_match, f_qa_relevance, f_qs_relevance])"
    ]
@@ -190,11 +190,11 @@
    "outputs": [],
    "source": [
     "# Instrumented query engine can operate like the original:\n",
-    "llm_response = tru_query_engine.query(\"What did the author do growing up?\")\n",
+    "llm_response = tru_llama.query(\"What did the author do growing up?\")\n",
     "print(llm_response)\n",
     "\n",
     "# or as context manager\n",
-    "with tru_query_engine as recording:\n",
+    "with tru_llama as recording:\n",
     "    query_engine.query(\"What did the author do growing up?\")"
    ]
   },

--- a/trulens_eval/examples/frameworks/langchain/langchain_agents.ipynb
+++ b/trulens_eval/examples/frameworks/langchain/langchain_agents.ipynb
@@ -165,7 +165,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tru_agent = TruChain(agent, app_id = \"Search_Agent\", feedbacks = [f_no_answer])"
+    "tru_chain = TruChain(agent, app_id = \"Search_Agent\", feedbacks = [f_no_answer])"
    ]
   },
   {
@@ -183,7 +183,7 @@
     "    \"I'm interested in buying a new smartphone from the producer with the highest stock price. Which company produces the smartphone I should by and what is their current stock price?\"\n",
     "]\n",
     "\n",
-    "with tru_agent as recording:\n",
+    "with tru_chain as recording:\n",
     "    for prompt in prompts:\n",
     "        agent(prompt)"
    ]
@@ -323,7 +323,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tru_agent = TruChain(agent, app_id = \"Search_Agent_v2\", feedbacks = [f_no_answer])"
+    "tru_chain = TruChain(agent, app_id = \"Search_Agent_v2\", feedbacks = [f_no_answer])"
    ]
   },
   {
@@ -341,7 +341,7 @@
    "outputs": [],
    "source": [
     "# wrapped agent can act as context manager\n",
-    "with tru_agent as recording:\n",
+    "with tru_chain as recording:\n",
     "    for prompt in prompts:\n",
     "        agent(prompt)"
    ]

--- a/trulens_eval/examples/frameworks/langchain/langchain_math_agent.ipynb
+++ b/trulens_eval/examples/frameworks/langchain/langchain_math_agent.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "agent = initialize_agent(tools, llm, agent=AgentType.OPENAI_FUNCTIONS, verbose=True)\n",
     "\n",
-    "tru_agent = TruChain(agent)"
+    "tru_chain = TruChain(agent)"
    ]
   },
   {
@@ -107,7 +107,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with tru_agent as recording:\n",
+    "with tru_chain as recording:\n",
     "    agent(inputs={\"input\": \"how much is Euler's number divided by PI\"})"
    ]
   },

--- a/trulens_eval/examples/frameworks/llama_index/llama_index_agents.ipynb
+++ b/trulens_eval/examples/frameworks/llama_index/llama_index_agents.ipynb
@@ -309,7 +309,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tru_agent = TruLlama(agent,\n",
+    "tru_llama = TruLlama(agent,\n",
     "    app_id='YelpAgent',\n",
     "    tags = \"agent prototype\",\n",
     "    feedbacks = [f_qa_relevance, f_groundtruth, f_context_relevance, f_groundedness, f_query_translation, f_ratings_usage])"
@@ -368,7 +368,7 @@
     "for prompt in prompt_set:\n",
     "    with tru_llm_standalone as recording:\n",
     "        llm_standalone(prompt)\n",
-    "    with tru_agent as recording:\n",
+    "    with tru_llama as recording:\n",
     "        agent.query(prompt)"
    ]
   }

--- a/trulens_eval/examples/frameworks/llama_index/llama_index_async.ipynb
+++ b/trulens_eval/examples/frameworks/llama_index/llama_index_async.ipynb
@@ -124,7 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tru_query_engine = TruLlama(\n",
+    "tru_llama = TruLlama(\n",
     "    query_engine, feedbacks=[f_qa_relevance, f_qs_relevance]\n",
     ")"
    ]
@@ -143,7 +143,7 @@
    "outputs": [],
    "source": [
     "# Instrumented query engine can operate like the original:\n",
-    "llm_response_async, rec_async = await tru_query_engine.aquery_with_record(\"What did the author do growing up?\")\n",
+    "llm_response_async, rec_async = await tru_llama.aquery_with_record(\"What did the author do growing up?\")\n",
     "\n",
     "print(llm_response_async)"
    ]

--- a/trulens_eval/examples/frameworks/llama_index/llama_index_groundtruth.ipynb
+++ b/trulens_eval/examples/frameworks/llama_index/llama_index_groundtruth.ipynb
@@ -154,7 +154,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tru_query_engine = TruLlama(query_engine,\n",
+    "tru_llama = TruLlama(query_engine,\n",
     "    app_id='LlamaIndex_App1',\n",
     "    feedbacks=[f_groundtruth],\n",
     ")"
@@ -176,7 +176,7 @@
    "source": [
     "#Run and evaluate on groundtruth questions\n",
     "for pair in golden_set:\n",
-    "    with tru_query_engine as recording:\n",
+    "    with tru_llama as recording:\n",
     "        llm_response = query_engine.query(pair['query'])\n",
     "        print(llm_response)"
    ]

--- a/trulens_eval/examples/frameworks/llama_index/llama_index_queryplanning.ipynb
+++ b/trulens_eval/examples/frameworks/llama_index/llama_index_queryplanning.ipynb
@@ -222,10 +222,10 @@
     "            else:\n",
     "                pass         \n",
     "\n",
-    "            tru_query_engine = TruLlama(app_id = f'{query_engine_type}_{embedding}', app = query_engine, feedbacks = [model_agreement])\n",
+    "            tru_llama = TruLlama(app_id = f'{query_engine_type}_{embedding}', app = query_engine, feedbacks = [model_agreement])\n",
     "\n",
-    "            # tru_query_engine as context manager\n",
-    "            with tru_query_engine as recording:\n",
+    "            # tru_llama as context manager\n",
+    "            with tru_llama as recording:\n",
     "                 for prompt in prompts:\n",
     "                    query_engine.query(prompt)\n"
    ]

--- a/trulens_eval/examples/frameworks/llama_index/llama_index_quickstart.ipynb
+++ b/trulens_eval/examples/frameworks/llama_index/llama_index_quickstart.ipynb
@@ -165,7 +165,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tru_query_engine = TruLlama(query_engine,\n",
+    "tru_llama = TruLlama(query_engine,\n",
     "    app_id='LlamaIndex_App1',\n",
     "    feedbacks=[f_lang_match, f_qa_relevance, f_qs_relevance])"
    ]
@@ -177,11 +177,11 @@
    "outputs": [],
    "source": [
     "# Instrumented query engine can operate like the original:\n",
-    "llm_response = tru_query_engine.query(\"What did the author do growing up?\")\n",
+    "llm_response = tru_llama.query(\"What did the author do growing up?\")\n",
     "print(llm_response)\n",
     "\n",
     "# or as context manager\n",
-    "with tru_query_engine as recording:\n",
+    "with tru_llama as recording:\n",
     "    query_engine.query(\"What did the author do growing up?\")"
    ]
   },

--- a/trulens_eval/examples/llama_index_quickstart.py
+++ b/trulens_eval/examples/llama_index_quickstart.py
@@ -75,18 +75,18 @@ f_qs_relevance = Feedback(openai.qs_relevance).on_input().on(
 
 # ## Instrument chain for logging with TruLens
 
-tru_query_engine = TruLlama(
+tru_llama = TruLlama(
     query_engine,
     app_id='LlamaIndex_App1',
     feedbacks=[f_lang_match, f_qa_relevance, f_qs_relevance]
 )
 
 # Instrumented query engine can operate like the original:
-llm_response = tru_query_engine.query("What did the author do growing up?")
+llm_response = tru_llama.query("What did the author do growing up?")
 print(llm_response)
 
 # or as context manager
-with tru_query_engine as recording:
+with tru_llama as recording:
     query_engine.query("What did the author do growing up?")
 
 # ## Explore in a Dashboard

--- a/trulens_eval/examples/models/azure_openai_llama_index.ipynb
+++ b/trulens_eval/examples/models/azure_openai_llama_index.ipynb
@@ -204,7 +204,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tru_query_engine = TruLlama(query_engine,\n",
+    "tru_llama = TruLlama(query_engine,\n",
     "    app_id='LlamaIndex_App1',\n",
     "    feedbacks=[f_groundedness, f_qa_relevance, f_qs_relevance])"
    ]
@@ -216,7 +216,7 @@
    "outputs": [],
    "source": [
     "query = \"What is most interesting about this essay?\"\n",
-    "with tru_query_engine as recording:\n",
+    "with tru_llama as recording:\n",
     "    answer = query_engine.query(query)\n",
     "    print(answer.get_formatted_sources())\n",
     "    print(\"query was:\", query)\n",

--- a/trulens_eval/examples/vector-dbs/milvus/milvus_evals_build_better_rags.ipynb
+++ b/trulens_eval/examples/vector-dbs/milvus/milvus_evals_build_better_rags.ipynb
@@ -268,7 +268,7 @@
     "            service_context=service_context,\n",
     "            storage_context=storage_context)\n",
     "    query_engine = index.as_query_engine(similarity_top_k = top_k)\n",
-    "    tru_query_engine = TruLlama(query_engine,\n",
+    "    tru_llama = TruLlama(query_engine,\n",
     "                    feedbacks=[f_groundedness, f_qa_relevance, f_qs_relevance],\n",
     "                    metadata={\n",
     "                        'index_param':index_param,\n",
@@ -277,10 +277,10 @@
     "                        'chunk_size':chunk_size\n",
     "                        })\n",
     "    @retry(stop=stop_after_attempt(10), wait=wait_exponential(multiplier=1, min=4, max=10))\n",
-    "    def call_tru_query_engine(prompt):\n",
-    "        return tru_query_engine.query(prompt)\n",
+    "    def call_tru_llama(prompt):\n",
+    "        return tru_llama.query(prompt)\n",
     "    for prompt in test_prompts:\n",
-    "        call_tru_query_engine(prompt)"
+    "        call_tru_llama(prompt)"
    ]
   },
   {

--- a/trulens_eval/examples/vector-dbs/milvus/milvus_simple.ipynb
+++ b/trulens_eval/examples/vector-dbs/milvus/milvus_simple.ipynb
@@ -208,7 +208,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tru_query_engine = TruLlama(query_engine,\n",
+    "tru_llama = TruLlama(query_engine,\n",
     "    app_id='LlamaIndex_App1',\n",
     "    feedbacks=[f_groundedness, f_qa_relevance, f_qs_relevance])"
    ]
@@ -220,7 +220,7 @@
    "outputs": [],
    "source": [
     "# Instrumented query engine can operate as a context manager\n",
-    "with tru_query_engine as recording:\n",
+    "with tru_llama as recording:\n",
     "    llm_response = query_engine.query(\"What did the author do growing up?\")\n",
     "    print(llm_response)"
    ]

--- a/trulens_eval/examples/vector-dbs/pinecone/pinecone_simple.ipynb
+++ b/trulens_eval/examples/vector-dbs/pinecone/pinecone_simple.ipynb
@@ -255,7 +255,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tru_query_engine = TruLlama(query_engine,\n",
+    "tru_llama = TruLlama(query_engine,\n",
     "    app_id='LlamaIndex_App1',\n",
     "    feedbacks=[f_groundedness, f_qa_relevance, f_qs_relevance])"
    ]
@@ -267,7 +267,7 @@
    "outputs": [],
    "source": [
     "# Instrumented query engine can operate as a context manager:\n",
-    "with tru_query_engine as recording:\n",
+    "with tru_llama as recording:\n",
     "    llm_response = query_engine.query(\"What did the author do growing up?\")\n",
     "    print(llm_response)"
    ]

--- a/trulens_eval/tests/unit/test_tru_llama.py
+++ b/trulens_eval/tests/unit/test_tru_llama.py
@@ -46,14 +46,14 @@ class TestLlamaIndex(JSONTestCase):
 
         query_engine = self.index.as_query_engine()
 
-        tru_query_engine = TruLlama(query_engine)
-        llm_response_async, record_async = await tru_query_engine.aquery_with_record(
+        tru_llama = TruLlama(query_engine)
+        llm_response_async, record_async = await tru_llama.aquery_with_record(
             "What did the author do growing up?"
         )
 
         query_engine = self.index.as_query_engine()
-        tru_query_engine = TruLlama(query_engine)
-        llm_response_sync, record_sync = tru_query_engine.query_with_record(
+        tru_llama = TruLlama(query_engine)
+        llm_response_sync, record_sync = tru_llama.query_with_record(
             "What did the author do growing up?"
         )
 
@@ -85,14 +85,14 @@ class TestLlamaIndex(JSONTestCase):
         # regardless of streaming option.
 
         query_engine = self.index.as_query_engine()
-        tru_query_engine = TruLlama(query_engine)
-        llm_response, record = tru_query_engine.query_with_record(
+        tru_llama = TruLlama(query_engine)
+        llm_response, record = tru_llama.query_with_record(
             "What did the author do growing up?"
         )
 
         query_engine = self.index.as_query_engine(streaming=True)
-        tru_query_engine = TruLlama(query_engine)
-        llm_response_stream, record_stream = tru_query_engine.query_with_record(
+        tru_llama = TruLlama(query_engine)
+        llm_response_stream, record_stream = tru_llama.query_with_record(
             "What did the author do growing up?"
         )
 

--- a/trulens_eval/trulens_eval/app.py
+++ b/trulens_eval/trulens_eval/app.py
@@ -770,6 +770,12 @@ class App(AppDefinition, SerialModel, WithInstrumentCallbacks, Hashable):
         """
         Call the given async `func` with the given `*args` and `**kwargs`,
         producing its results as well as a record of the execution.
+
+        **Usage:**
+        ```
+        tru_app = ... # one of TruChain/TruLLama/TruBasicApp/TruCustomApp
+        tru_app.awith_record("Who can help me with my request?")
+        ```
         """
 
         self._check_instrumented(func)
@@ -807,6 +813,12 @@ class App(AppDefinition, SerialModel, WithInstrumentCallbacks, Hashable):
         """
         Call the given `func` with the given `*args` and `**kwargs`, producing
         its results as well as a record of the execution.
+
+        **Usage:**
+        ```
+        tru_app = ... # one of TruChain/TruLLama/TruBasicApp/TruCustomApp
+        tru_app.with_record("Who can help me with my request?")
+        ```
         """
 
         self._check_instrumented(func)

--- a/trulens_eval/trulens_eval/feedback/provider/hugs.py
+++ b/trulens_eval/trulens_eval/feedback/provider/hugs.py
@@ -123,7 +123,6 @@ class Huggingface(Provider):
 
             float: A value between 0 and 1. 0 being "different languages" and 1 being "same languages".
         """
-
         def get_scores(text):
             payload = {"inputs": text}
             hf_response = self.endpoint.post(

--- a/trulens_eval/trulens_eval/tru_basic_app.py
+++ b/trulens_eval/trulens_eval/tru_basic_app.py
@@ -65,7 +65,12 @@ class TruBasicApp(App):
         basic_app = TruBasicApp(custom_application, 
             app_id="Custom Application v1",
             feedbacks=[f_lang_match, f_qa_relevance, f_qs_relevance])
+        
+        # Use any of the below
         basic_app("Give me a response")
+        basic_app.call_with_record("Give me a response")
+        with basic_app as recording:
+            custom_application("Give me a response")
         ```
         See [Feedback Functions](https://www.trulens.org/trulens_eval/api/feedback/) for instantiating feedback functions.
 
@@ -128,6 +133,12 @@ class TruBasicApp(App):
         """
         Run the callable with the given arguments. Note that the wrapped
         callable is expected to take in a single string.
+
+        **Usage:**
+        ```
+        basic_app = TruBasicApp(my_app,...)
+        basic_app.call_with_record("Who can help me with my request?")
+        ```
 
         Returns:
             dict: record metadata

--- a/trulens_eval/trulens_eval/tru_chain.py
+++ b/trulens_eval/trulens_eval/tru_chain.py
@@ -138,7 +138,13 @@ class TruChain(App):
             app_id='Chain1_ChatApplication',
             feedbacks=[f_lang_match, f_qa_relevance, f_qs_relevance])
         )
+
+        # Use any of the below
         truchain("What is langchain?")
+        truchain.call_with_record("What is langchain?")
+        with truchain as recording:
+            chain("What is langchain?")
+        
         ```
         See [Feedback Functions](https://www.trulens.org/trulens_eval/api/feedback/) for instantiating feedback functions.
 
@@ -261,8 +267,18 @@ class TruChain(App):
     # NOTE: Input signature compatible with langchain.chains.base.Chain.__call__
     # TODEP
     def call_with_record(self, *args, **kwargs) -> Tuple[Any, Record]:
-        """
-        Run the chain call method and also return a record metadata object.
+        """Returns the response and trulens record of the wrapped chain. 
+        All instrumented methods and feedback functions will run with the application run.
+
+        **Usage:**
+        ```
+        truchain = TruChain(my_chain,...)
+        truchain.call_with_record("Who can help me with my request?")
+        ```
+
+        Returns:
+            Record: The trulens-eval record with populated instrumented information.
+            Response: The response to the query
         """
 
         self._with_dep_message(
@@ -277,6 +293,13 @@ class TruChain(App):
         """
         Wrapped call to self.app._call with instrumentation. If you need to
         get the record, use `call_with_record` instead. 
+
+        **Usage:**
+        ```
+        truchain = TruChain(my_chain,...)
+        truchain("Who can help me with my request?")
+        ```
+
         """
 
         self._with_dep_message(
@@ -288,6 +311,17 @@ class TruChain(App):
     # TODEP
     # Chain requirement
     def _call(self, *args, **kwargs) -> Any:
+        """
+        Returns the application response. All instrumented methods and feedback functions will run with the application run.
+        If you need to get the record, use `call_with_record` instead. 
+
+        **Usage:**
+        ```
+        truchain = TruChain(my_chain,...)
+        truchain._call("Who can help me with my request?")
+        ```
+
+        """
         self._with_dep_message(
             method="_call", is_async=False, with_record=False
         )
@@ -299,6 +333,17 @@ class TruChain(App):
     # TODEP
     # Optional Chain requirement
     async def _acall(self, *args, **kwargs) -> Any:
+        """
+        Runs an async call of the application. All instrumented methods and feedback functions will run with the application run.
+        If you need to get the record, use `call_with_record` instead. 
+
+        **Usage:**
+        ```
+        truchain = TruChain(my_chain,...)
+        truchain._acall("Who can help me with my request?")
+        ```
+
+        """
         self._with_dep_message(
             method="_acall", is_async=True, with_record=False
         )

--- a/trulens_eval/trulens_eval/tru_custom_app.py
+++ b/trulens_eval/trulens_eval/tru_custom_app.py
@@ -70,13 +70,13 @@ import TruCustomApp
 
 ca = CustomApp()
 
-# Normal app **Usage:**
+# Normal app Usage:
 response = ca.respond_to_query("What is the capital of Indonesia?")
 
 # Wrapping app with `TruCustomApp`: 
 ta = TruCustomApp(ca)
 
-# Wrapped **Usage:** must use the general `with_record` (or `awith_record`) method:
+# Wrapped Usage: must use the general `with_record` (or `awith_record`) method:
 response, record = ta.with_record(
     ca.respond_to_query, input="What is the capital of Indonesia?"
 )
@@ -254,10 +254,10 @@ class TruCustomApp(App):
         
         question = "What is the capital of Indonesia?"
 
-        # Normal **Usage:**
+        # Normal Usage:
         response_normal = ca.respond_to_query(question)
 
-        # Instrumented **Usage:**
+        # Instrumented Usage:
         response_wrapped, record = custom_app.with_record(
             ca.respond_to_query, input=question, record_metadata="meta1"
         )

--- a/trulens_eval/trulens_eval/tru_llama.py
+++ b/trulens_eval/trulens_eval/tru_llama.py
@@ -153,10 +153,16 @@ class TruLlama(App):
         ```
         from trulens_eval import TruLlama
         # f_lang_match, f_qa_relevance, f_qs_relevance are feedback functions
-        tru_query_engine = TruLlama(query_engine,
+        tru_llama = TruLlama(query_engine,
             app_id='LlamaIndex_App1',
             feedbacks=[f_lang_match, f_qa_relevance, f_qs_relevance])
-        tru_query_engine("What is llama index?")
+    
+        # Use any of the below
+        tru_llama("What is llama index?")
+        tru_llama.query_with_record("What is llama index?")
+        with tru_llama as recording:
+            query_engine("What is llama index?")
+
         ```
         See [Feedback Functions](https://www.trulens.org/trulens_eval/api/feedback/) for instantiating feedback functions.
 
@@ -245,6 +251,18 @@ class TruLlama(App):
     # TODEP
     # llama_index.chat_engine.types.BaseChatEngine
     def chat(self, *args, **kwargs) -> AgentChatResponse:
+        """ Returns the response of the wrapped chat_engine of type `llama_index.chat_engine.types.BaseChatEngine`. 
+        All instrumented methods and feedback functions will run with the application run.
+
+        **Usage:**
+        ```
+        tru_llama = TruLlama(my_chat_app,...)
+        tru_llama.chat("Who can help me with my request?")
+        ```
+
+        Returns:
+            AgentChatResponse: The chat agent response
+        """
         assert isinstance(
             self.app, llama_index.chat_engine.types.BaseChatEngine
         )
@@ -257,6 +275,18 @@ class TruLlama(App):
     # TODEP
     # llama_index.chat_engine.types.BaseChatEngine
     async def achat(self, *args, **kwargs) -> AgentChatResponse:
+        """Runs an async response of the wrapped chat_engine of type `llama_index.chat_engine.types.BaseChatEngine`. 
+        All instrumented methods and feedback functions will run with the application run.
+
+        **Usage:**
+        ```
+        tru_llama = TruLlama(my_chat_app,...)
+        tru_llama.achat("Who can help me with my request?")
+        ```
+
+        Returns:
+            AgentChatResponse: The chat agent response
+        """
         assert isinstance(
             self.app, llama_index.chat_engine.types.BaseChatEngine
         )
@@ -269,6 +299,18 @@ class TruLlama(App):
     # TODEP
     # llama_index.chat_engine.types.BaseChatEngine
     def stream_chat(self, *args, **kwargs) -> StreamingAgentChatResponse:
+        """Runs a streaming response of the wrapped chat_engine of type `llama_index.chat_engine.types.BaseChatEngine`. 
+        All instrumented methods and feedback functions will run with the application run.
+
+        **Usage:**
+        ```
+        tru_llama = TruLlama(my_chat_app,...)
+        tru_llama.stream_chat("Who can help me with my request?")
+        ```
+
+        Returns:
+            StreamingAgentChatResponse: The chat agent response
+        """
         assert isinstance(
             self.app, llama_index.chat_engine.types.BaseChatEngine
         )
@@ -283,6 +325,18 @@ class TruLlama(App):
     # TODEP
     # llama_index.chat_engine.types.BaseChatEngine
     async def astream_chat(self, *args, **kwargs) -> StreamingAgentChatResponse:
+        """Runs an async streaming response of the wrapped chat_engine of type `llama_index.chat_engine.types.BaseChatEngine`. 
+        All instrumented methods and feedback functions will run with the application run.
+
+        **Usage:**
+        ```
+        tru_llama = TruLlama(my_chat_app,...)
+        tru_llama.astream_chat("Who can help me with my request?")
+        ```
+
+        Returns:
+            StreamingAgentChatResponse: _description_
+        """
         assert isinstance(
             self.app, llama_index.chat_engine.types.BaseChatEngine
         )
@@ -297,6 +351,18 @@ class TruLlama(App):
     # TODEP
     # llama_index.indices.query.base.BaseQueryEngine
     def query(self, *args, **kwargs) -> RESPONSE_TYPE:
+        """Returns the response of the wrapped query_engine of type `llama_index.indices.query.base.BaseQueryEngine`. 
+        All instrumented methods and feedback functions will run with the application run.
+
+        **Usage:**
+        ```
+        tru_llama = TruLlama(my_query_engine_app,...)
+        tru_llama.query("Who can help me with my request?")
+        ```
+
+        Returns:
+            QueryResponse: The response to the query
+        """
         assert isinstance(
             self.app, llama_index.indices.query.base.BaseQueryEngine
         )
@@ -311,6 +377,18 @@ class TruLlama(App):
     # TODEP
     # llama_index.indices.query.base.BaseQueryEngine
     async def aquery(self, *args, **kwargs) -> RESPONSE_TYPE:
+        """Runs an async response of the wrapped query_engine of type `llama_index.indices.query.base.BaseQueryEngine`. 
+        All instrumented methods and feedback functions will run with the application run.
+
+        **Usage:**
+        ```
+        tru_llama = TruLlama(my_query_engine_app,...)
+        tru_llama.aquery("Who can help me with my request?")
+        ```
+
+        Returns:
+            QueryResponse: The response to the query
+        """
         assert isinstance(
             self.app, llama_index.indices.query.base.BaseQueryEngine
         )
@@ -326,6 +404,19 @@ class TruLlama(App):
     # Mirrors llama_index.indices.query.base.BaseQueryEngine.query .
     def query_with_record(self, *args,
                           **kwargs) -> Tuple[RESPONSE_TYPE, Record]:
+        """Returns the response and trulens record of the wrapped query_engine of type `llama_index.indices.query.base.BaseQueryEngine`. 
+        All instrumented methods and feedback functions will run with the application run.
+
+        **Usage:**
+        ```
+        tru_llama = TruLlama(my_query_engine_app,...)
+        tru_llama.query_with_record("Who can help me with my request?")
+        ```
+
+        Returns:
+            Record: The trulens-eval record with populated instrumented information.
+            QueryResponse: The response to the query
+        """
         assert isinstance(
             self.app, llama_index.indices.query.base.BaseQueryEngine
         )
@@ -338,6 +429,19 @@ class TruLlama(App):
     # Mirrors llama_index.indices.query.base.BaseQueryEngine.aquery .
     async def aquery_with_record(self, *args,
                                  **kwargs) -> Tuple[RESPONSE_TYPE, Record]:
+        """Runs an async response and trulens record of the wrapped query_engine of type `llama_index.indices.query.base.BaseQueryEngine`. 
+        All instrumented methods and feedback functions will run with the application run.
+
+        **Usage:**
+        ```
+        tru_llama = TruLlama(my_query_engine_app,...)
+        tru_llama.aquery_with_record("Who can help me with my request?")
+        ```
+
+        Returns:
+            Record: The trulens-eval record with populated instrumented information.
+            QueryResponse: The response to the query
+        """
         assert isinstance(
             self.app, llama_index.indices.query.base.BaseQueryEngine
         )
@@ -350,6 +454,19 @@ class TruLlama(App):
     # Compatible with llama_index.chat_engine.types.BaseChatEngine.chat .
     def chat_with_record(self, *args,
                          **kwargs) -> Tuple[AgentChatResponse, Record]:
+        """Returns the response and trulens record of the wrapped chat_engine of type `llama_index.chat_engine.types.BaseChatEngine`. 
+        All instrumented methods and feedback functions will run with the application run.
+
+        **Usage:**
+        ```
+        tru_llama = TruLlama(my_chat_app,...)
+        tru_llama.chat_with_record("Who can help me with my request?")
+        ```
+
+        Returns:
+            Record: The trulens-eval record with populated instrumented information.
+            AgentChatResponse: The chat agent response
+        """
         assert isinstance(
             self.app, llama_index.chat_engine.types.BaseChatEngine
         )
@@ -362,6 +479,19 @@ class TruLlama(App):
     # Compatible with llama_index.chat_engine.types.BaseChatEngine.achat .
     async def achat_with_record(self, *args,
                                 **kwargs) -> Tuple[AgentChatResponse, Record]:
+        """Runs an async response and trulens record of the wrapped chat_engine of type `llama_index.chat_engine.types.BaseChatEngine`. 
+        All instrumented methods and feedback functions will run with the application run.
+
+        **Usage:**
+        ```
+        tru_llama = TruLlama(my_chat_app,...)
+        tru_llama.achat_with_record("Who can help me with my request?")
+        ```
+
+        Returns:
+            Record: The trulens-eval record with populated instrumented information.
+            AgentChatResponse: The chat agent response
+        """
         assert isinstance(
             self.app, llama_index.chat_engine.types.BaseChatEngine
         )
@@ -375,6 +505,19 @@ class TruLlama(App):
     def stream_chat_with_record(
         self, *args, **kwargs
     ) -> Tuple[StreamingAgentChatResponse, Record]:
+        """Returns the streaming response and trulens record of the wrapped chat_engine of type `llama_index.chat_engine.types.BaseChatEngine`. 
+        All instrumented methods and feedback functions will run with the application run.
+
+        **Usage:**
+        ```
+        tru_llama = TruLlama(my_chat_app,...)
+        tru_llama.stream_chat_with_record("Who can help me with my request?")
+        ```
+
+        Returns:
+            Record: The trulens-eval record with populated instrumented information.
+            StreamingAgentChatResponse: The chat agent response
+        """
         assert isinstance(
             self.app, llama_index.chat_engine.types.BaseChatEngine
         )
@@ -390,6 +533,19 @@ class TruLlama(App):
     async def astream_chat_with_record(
         self, *args, **kwargs
     ) -> Tuple[StreamingAgentChatResponse, Record]:
+        """Runs an async streaming response and trulens record of the wrapped chat_engine of type `llama_index.chat_engine.types.BaseChatEngine`. 
+        All instrumented methods and feedback functions will run with the application run.
+
+        **Usage:**
+        ```
+        tru_llama = TruLlama(my_chat_app,...)
+        tru_llama.astream_chat_with_record("Who can help me with my request?")
+        ```
+
+        Returns:
+            Record: The trulens-eval record with populated instrumented information.
+            StreamingAgentChatResponse: The chat agent response
+        """
         assert isinstance(
             self.app, llama_index.chat_engine.types.BaseChatEngine
         )

--- a/trulens_eval/trulens_eval/tru_llama.py
+++ b/trulens_eval/trulens_eval/tru_llama.py
@@ -335,7 +335,7 @@ class TruLlama(App):
         ```
 
         Returns:
-            StreamingAgentChatResponse: _description_
+            StreamingAgentChatResponse: The chat agent response 
         """
         assert isinstance(
             self.app, llama_index.chat_engine.types.BaseChatEngine
@@ -357,7 +357,7 @@ class TruLlama(App):
         **Usage:**
         ```
         tru_llama = TruLlama(my_query_engine_app,...)
-        tru_llama.query("Who can help me with my request?")
+        tru_llama.query("What are all the dog breeds?")
         ```
 
         Returns:
@@ -410,7 +410,7 @@ class TruLlama(App):
         **Usage:**
         ```
         tru_llama = TruLlama(my_query_engine_app,...)
-        tru_llama.query_with_record("Who can help me with my request?")
+        tru_llama.query_with_record("What are all the dog breeds?")
         ```
 
         Returns:
@@ -435,7 +435,7 @@ class TruLlama(App):
         **Usage:**
         ```
         tru_llama = TruLlama(my_query_engine_app,...)
-        tru_llama.aquery_with_record("Who can help me with my request?")
+        tru_llama.aquery_with_record("What are all the dog breeds?")
         ```
 
         Returns:


### PR DESCRIPTION
* Now that wrappers have both call and record options, the wrapper should be more generically named.
* The recorder and calling wrapper cannot be partitioned into two modes as the name, feedback functions, and metadata still needs to be specified and is better in one place.
* Added documentation and code example updates to better show possible usages