### PR TITLE
[MLNN-1077] Groundedness score extraction bug

### DIFF
--- a/trulens_eval/trulens_eval/utils/generated.py
+++ b/trulens_eval/trulens_eval/utils/generated.py
@@ -7,14 +7,17 @@ import re
 
 logger = logging.getLogger(__name__)
 
-pat_0_10 = re.compile(r"\s*([0-9][0-9]*)\s*")
+# for extracting the 0-10 rating, we are assuming the score will
+# always be the last part of the generated text from LLM - hence we are matching for the last
+# group of digits in the string
+pat_0_10 = re.compile(r"\s*([0-9]+)\s*$")
 
 
 def re_0_10_rating(str_val):
     matches = pat_0_10.fullmatch(str_val)
     if not matches:
         # Try soft match
-        matches = re.search('[0-9][0-9]*', str_val)
+        matches = re.search('([0-9]+)(?=\D*$)', str_val)
         if not matches:
             logger.warning(f"0-10 rating regex failed to match on: '{str_val}'")
             return -10  # so this will be reported as -1 after division by 10


### PR DESCRIPTION
Issue:  our score extraction in the partial match cases is failing on any LLM-generated output with group of digits **appearing before** the final `"Score: 10"` text.

Before the fix:
<img width="971" alt="image" src="https://github.com/truera/trulens/assets/19476654/8b6833d5-97b1-4826-8f1d-922b83e8964d">


After the fix:
![image](https://github.com/truera/trulens/assets/19476654/40fced8c-ba37-4004-997a-a24b7dbda380)
