### PR TITLE
Temporarily pin openai until we migrate

### DIFF
--- a/trulens_eval/requirements.txt
+++ b/trulens_eval/requirements.txt
@@ -12,7 +12,7 @@ pyllama
 tokenizers
 protobuf
 accelerate
-openai
+openai==0.28.1 # temporary pin for openai until migration to 1.1.1
 pinecone-client
 tiktoken
 slack_bolt

--- a/trulens_eval/setup.py
+++ b/trulens_eval/setup.py
@@ -46,7 +46,7 @@ setup(
         f'llama_index>={llama_version}',
         'merkle-json>=1.0.0',
         'millify>=0.1.1',
-        'openai>=0.27.6',
+        'openai==0.28.1',
         'pinecone-client>=2.2.1',
         'pydantic >=1.10.7, <2',  # TODO(piotrm): need some migration for pydantic 2
         'humanize>=4.6.0',


### PR DESCRIPTION
Tests are failing against openai==1.1.1. Pin to prior version to unblock dev until we migrate.