### PR TITLE
move model comparison to use cases (expected location)

### DIFF
--- a/trulens_eval/examples/expositional/use_cases/model_comparison.ipynb
+++ b/trulens_eval/examples/expositional/use_cases/model_comparison.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "In this example you will learn how to compare different models with TruLens.\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/truera/trulens/blob/main/trulens_eval/examples/expositional/models/model_comparison.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/truera/trulens/blob/main/trulens_eval/examples/expositional/use_cases/model_comparison.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
![Screen Shot 2023-11-30 at 4 29 57 PM](https://github.com/truera/trulens/assets/60949774/4a5670a7-1ad4-46f9-9b84-d2f8cf993160)

Move model comparison to use cases folder so that it correctly loads from docs page