### PR TITLE
updated langchain retrieval agent example notebook link to proper URL on google colab

### DIFF
--- a/trulens_eval/examples/expositional/frameworks/langchain/langchain_retrieval_agent.ipynb
+++ b/trulens_eval/examples/expositional/frameworks/langchain/langchain_retrieval_agent.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "Given we have more than one distinct tasks defined in the tools for our agent, one being summarization and another one, which generates multiple choice questions and corresponding answers, being more similar to traditional Natural Language Understanding (NLU), we are also leveraging deferred evaluation.  By creating different options for context evaluation, we can use deferred evaluations to try both and use the one that matches the structure of the serialized record. This is especially true when not all of the feedback functions defined are applicable to the selected tool(s) by the agent. In the below notebook, you can see we also run the evaluations at a later time.  \n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/truera/trulens/blob/main/trulens_eval/examples/quickstart/langchain_retrieval_agent.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/truera/trulens/blob/main/trulens_eval/examples/expositional/frameworks/langchain/langchain_retrieval_agent.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
Fixed location of google colab url in langchain retrieval agent located [here](https://github.com/truera/trulens/blob/main/trulens_eval/examples/expositional/frameworks/langchain/langchain_retrieval_agent.ipynb)