### PR TITLE
TruLens quickstart notebook: add data to the embedding database

### DIFF
--- a/trulens_eval/examples/quickstart/quickstart.ipynb
+++ b/trulens_eval/examples/quickstart/quickstart.ipynb
@@ -110,6 +110,26 @@
   },
   {
    "cell_type": "markdown",
+   "source": [
+    "Add the university_info to the embedding database."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "vector_store.add(\"uni_info\", documents=university_info)"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Build RAG from scratch\n",


### PR DESCRIPTION
Previously in the notebook the `university_info` variable was declared and the embeddings of it were calculated in a separate cell, however it was not added to the embedding database. It seems to me like this was a mistake, however it might have been on purpose to show that TruLens recognizes faulty output.

It might be interesting to have both examples in the notebook to show how TruLens responds, for now it seems weird to create a document and calculate embeddings without using them.