### PR TITLE
Fix > character in prompt

### DIFF
--- a/trulens_eval/trulens_eval/feedback/prompts.py
+++ b/trulens_eval/trulens_eval/feedback/prompts.py
@@ -18,7 +18,7 @@ For every sentence in the statement, please answer with this template:
 TEMPLATE: 
 Statement Sentence: <Sentence>, 
 Supporting Evidence: <Choose the exact unchanged sentences in the source that can answer the statement, if nothing matches, say NOTHING FOUND>
-Score: <Output a number between 0-10 where 0 is no information overlap and 10 is all information is overlapping.
+Score: <Output a number between 0-10 where 0 is no information overlap and 10 is all information is overlapping>
 """
 
 # Keep this in line with the LLM output template as above


### PR DESCRIPTION
This PR changes the `.` at the end of  `LLM_GROUNDEDNESS_FULL_SYSTEM` to a `>`, this is more in line with other template prompts such as `COT_REASONS_TEMPLATE`.

Please let me know if the full stop was there on purpose!