### PR TITLE
Update langchain prompt based evals

### DIFF
--- a/trulens_eval/trulens_eval/feedback/prompts.py
+++ b/trulens_eval/trulens_eval/feedback/prompts.py
@@ -5,6 +5,16 @@
 
 from trulens_eval.feedback.v2 import feedback as v2
 
+COT_REASONS_TEMPLATE = \
+"""
+Please answer with this template:
+
+TEMPLATE: 
+Criteria: <Provide the criteria for this evaluation>
+Supporting Evidence: <Provide your reasons for scoring based on the listed criteria step by step. Tie it back to the evaluation being completed.>
+Score: <The score 0-10 based on the given criteria>
+"""
+
 LLM_GROUNDEDNESS = v2.Groundedness.prompt.template
 
 LLM_GROUNDEDNESS_SYSTEM_NO_COT = """You are a INFORMATION OVERLAP classifier providing the overlap of information between a SOURCE and STATEMENT.
@@ -75,16 +85,18 @@ The right answer is:
 Answer only with an integer from 1 to 10 based on how close the responses are to the right answer.
 """
 
+REMOVE_Y_N = " If so, respond Y. If not, respond N."
+
 LANGCHAIN_CONCISENESS_PROMPT = v2.Conciseness.prompt.template
 LANGCHAIN_CORRECTNESS_PROMPT = v2.Correctness.prompt.template
 LANGCHAIN_COHERENCE_PROMPT = v2.Coherence.prompt.template
-LANGCHAIN_HARMFULNESS_PROMPT = v2.Harmfulness.prompt.template
-LANGCHAIN_MALICIOUSNESS_PROMPT = v2.Maliciousness.prompt.template
-LANGCHAIN_HELPFULNESS_PROMPT = v2.Helpfulness.prompt.template
-LANGCHAIN_CONTROVERSIALITY_PROMPT = v2.Controversiality.prompt.template
-LANGCHAIN_MISOGYNY_PROMPT = v2.Misogyny.prompt.template
-LANGCHAIN_CRIMINALITY_PROMPT = v2.Criminality.prompt.template
-LANGCHAIN_INSENSITIVITY_PROMPT = v2.Insensitivity.prompt.template
+LANGCHAIN_HARMFULNESS_PROMPT = v2.Harmfulness.prompt.template.replace(REMOVE_Y_N, "")
+LANGCHAIN_MALICIOUSNESS_PROMPT = v2.Maliciousness.prompt.template.replace(REMOVE_Y_N, "")
+LANGCHAIN_HELPFULNESS_PROMPT = v2.Helpfulness.prompt.template.replace(REMOVE_Y_N, "")
+LANGCHAIN_CONTROVERSIALITY_PROMPT = v2.Controversiality.prompt.template.replace(REMOVE_Y_N, "")
+LANGCHAIN_MISOGYNY_PROMPT = v2.Misogyny.prompt.template.replace(REMOVE_Y_N, "")
+LANGCHAIN_CRIMINALITY_PROMPT = v2.Criminality.prompt.template.replace(REMOVE_Y_N, "")
+LANGCHAIN_INSENSITIVITY_PROMPT = v2.Insensitivity.prompt.template.replace(REMOVE_Y_N, "")
 
 LANGCHAIN_PROMPT_TEMPLATE = """
 CRITERIA:
@@ -95,6 +107,8 @@ SUBMISSION:
 
 {submission}
 """
+
+LANGCHAIN_PROMPT_TEMPLATE_WITH_COT_REASONS = LANGCHAIN_PROMPT_TEMPLATE + COT_REASONS_TEMPLATE
 
 STEREOTYPES_PROMPT = v2.Stereotypes.prompt.template
 
@@ -130,14 +144,4 @@ Score: <Give a score from 0 to 10 on if the SUMMARY addresses every single one o
 /START SOURCE/ 
 {source}
 /END SOURCE/ 
-"""
-
-COT_REASONS_TEMPLATE = \
-"""
-Please answer with this template:
-
-TEMPLATE: 
-Criteria: <Provide the criteria for this evaluation>
-Supporting Evidence: <Provide your reasons for scoring based on the listed criteria step by step. Tie it back to the evaluation being completed.>
-Score: <The score 0-10 based on the given criteria>
 """

--- a/trulens_eval/trulens_eval/feedback/prompts.py
+++ b/trulens_eval/trulens_eval/feedback/prompts.py
@@ -86,6 +86,16 @@ LANGCHAIN_MISOGYNY_PROMPT = v2.Misogyny.prompt.template
 LANGCHAIN_CRIMINALITY_PROMPT = v2.Criminality.prompt.template
 LANGCHAIN_INSENSITIVITY_PROMPT = v2.Insensitivity.prompt.template
 
+LANGCHAIN_PROMPT_TEMPLATE = """
+CRITERIA:
+
+{criteria}
+
+SUBMISSION:
+
+{submission}
+"""
+
 STEREOTYPES_PROMPT = v2.Stereotypes.prompt.template
 
 SUMMARIZATION_PROMPT = """

--- a/trulens_eval/trulens_eval/feedback/provider/base.py
+++ b/trulens_eval/trulens_eval/feedback/provider/base.py
@@ -427,7 +427,6 @@ class LLMProvider(Provider, ABC):
         )
         return re_0_10_rating(agreement_txt) / 10.0
 
-    # TODO: figure out where text is used.
     def _langchain_evaluate(self, text: str, system_prompt: str) -> float:
         """
         Uses chat completion model. A general function that completes a template
@@ -445,7 +444,10 @@ class LLMProvider(Provider, ABC):
 
         return re_0_10_rating(
             self.endpoint.
-            run_me(lambda: self._create_chat_completion(prompt=system_prompt))
+            run_me(lambda: self._create_chat_completion(
+                prompts.LANGCHAIN_PROMPT_TEMPLATE.format(
+                    criteria=system_prompt,
+                    text=text)))
         ) / 10.0
 
     def conciseness(self, text: str) -> float:


### PR DESCRIPTION
Issue: https://github.com/truera/trulens/issues/592

Langchain prompt-based evals now take into account the text and use standard COT template when cot reasoning is called.
![Screen Shot 2023-12-04 at 6 29 00 PM](https://github.com/truera/trulens/assets/60949774/a9b3eb61-e420-4d2d-bb4f-a56fadc155d0)
![Screen Shot 2023-12-04 at 6 26 25 PM](https://github.com/truera/trulens/assets/60949774/1e3a9db0-f7ab-4e87-9748-db4765179ffc)