### PR TITLE
Fix: AzureOpenAI

### DIFF
--- a/trulens_eval/trulens_eval/feedback/provider/endpoint/__init__.py
+++ b/trulens_eval/trulens_eval/feedback/provider/endpoint/__init__.py
@@ -3,9 +3,14 @@ from trulens_eval.feedback.provider.endpoint.base import Endpoint
 from trulens_eval.feedback.provider.endpoint.bedrock import BedrockEndpoint
 from trulens_eval.feedback.provider.endpoint.hugs import HuggingfaceEndpoint
 from trulens_eval.feedback.provider.endpoint.litellm import LiteLLMEndpoint
-from trulens_eval.feedback.provider.endpoint.openai import OpenAIEndpoint
+from trulens_eval.feedback.provider.endpoint.openai import OpenAIEndpoint, OpenAIClient
 
 __all__ = [
-    'Endpoint', 'DummyEndpoint', 'HuggingfaceEndpoint', 'OpenAIEndpoint',
-    'LiteLLMEndpoint', 'BedrockEndpoint'
+    "Endpoint",
+    "DummyEndpoint",
+    "HuggingfaceEndpoint",
+    "OpenAIEndpoint",
+    "LiteLLMEndpoint",
+    "BedrockEndpoint",
+    "OpenAIClient",
 ]


### PR DESCRIPTION
The module currently doesn't work with AzureOpenAI. With the new `openai` version (>1), there is no requirement for providing `deployment_id`.
This also fixes an issue by providing the `deployment_name` to the `openai.AzureOpenAI`-object.
Provide credentials using environment variables or `kwargs`, i.e.:

```
AZURE_OPENAI_API_KEY
OPENAI_API_VERSION
AZURE_OPENAI_ENDPOINT
```

Solution feels a bit hacky, but doing it in a proper way would probably require a refactoring