### PR TITLE
better messages for optional imports

### DIFF
--- a/trulens_eval/trulens_eval/feedback/groundtruth.py
+++ b/trulens_eval/trulens_eval/feedback/groundtruth.py
@@ -14,10 +14,10 @@ from trulens_eval.utils.pyschema import FunctionOrMethod
 from trulens_eval.utils.pyschema import WithClassInfo
 from trulens_eval.utils.serial import SerialModel
 
-with OptionalImports(message=REQUIREMENT_BERT_SCORE):
+with OptionalImports(messages=REQUIREMENT_BERT_SCORE):
     from bert_score import BERTScorer
 
-with OptionalImports(message=REQUIREMENT_EVALUATE):
+with OptionalImports(messages=REQUIREMENT_EVALUATE):
     import evaluate
 
 logger = logging.getLogger(__name__)

--- a/trulens_eval/trulens_eval/feedback/provider/endpoint/bedrock.py
+++ b/trulens_eval/trulens_eval/feedback/provider/endpoint/bedrock.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 pp = pprint.PrettyPrinter()
 
-with OptionalImports(message=REQUIREMENT_BEDROCK):
+with OptionalImports(messages=REQUIREMENT_BEDROCK):
     import boto3
     from botocore.client import ClientCreator
 

--- a/trulens_eval/trulens_eval/feedback/provider/endpoint/openai.py
+++ b/trulens_eval/trulens_eval/feedback/provider/endpoint/openai.py
@@ -30,7 +30,7 @@ from langchain.schema import Generation
 from langchain.schema import LLMResult
 import pydantic
 
-from trulens_eval.feedback.provider.endpoint.base import Endpoint
+from trulens_eval.feedback.provider.endpoint.base import DEFAULT_RPM, Endpoint
 from trulens_eval.feedback.provider.endpoint.base import EndpointCallback
 from trulens_eval.utils.imports import OptionalImports
 from trulens_eval.utils.imports import REQUIREMENT_OPENAI
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 pp = pprint.PrettyPrinter()
 
-with OptionalImports(message=REQUIREMENT_OPENAI):
+with OptionalImports(messages=REQUIREMENT_OPENAI):
     import openai as oai
 
 
@@ -285,6 +285,7 @@ class OpenAIEndpoint(Endpoint, WithClassInfo):
 
     def __init__(
         self,
+        rpm: float = DEFAULT_RPM,
         client: Optional[Union[oai.OpenAI, oai.AzureOpenAI,
                                OpenAIClient]] = None,
         **kwargs
@@ -299,6 +300,7 @@ class OpenAIEndpoint(Endpoint, WithClassInfo):
 
         self_kwargs = dict(
             name="openai",  # for SingletonPerName
+            rpm=rpm, # for Endpoint
             callback_class=OpenAICallback,
             obj=self,  # for WithClassInfo:
             **kwargs

--- a/trulens_eval/trulens_eval/tru_chain.py
+++ b/trulens_eval/trulens_eval/tru_chain.py
@@ -25,8 +25,10 @@ logger = logging.getLogger(__name__)
 
 pp = PrettyPrinter()
 
-with OptionalImports(message=REQUIREMENT_LANGCHAIN):
+with OptionalImports(messages=REQUIREMENT_LANGCHAIN):
     # langchain.agents.agent.AgentExecutor, # is langchain.chains.base.Chain
+
+    # import langchain
 
     from langchain.agents.agent import BaseMultiActionAgent
     from langchain.agents.agent import BaseSingleActionAgent

--- a/trulens_eval/trulens_eval/tru_llama.py
+++ b/trulens_eval/trulens_eval/tru_llama.py
@@ -25,8 +25,8 @@ logger = logging.getLogger(__name__)
 
 pp = PrettyPrinter()
 
-with OptionalImports(message=REQUIREMENT_LLAMA):
-    import llama_index
+with OptionalImports(messages=REQUIREMENT_LLAMA):
+    # import llama_index
 
     from llama_index.indices.query.base import BaseQueryEngine
     from llama_index.chat_engine.types import BaseChatEngine

--- a/trulens_eval/trulens_eval/tru_llama.py
+++ b/trulens_eval/trulens_eval/tru_llama.py
@@ -28,7 +28,7 @@ pp = PrettyPrinter()
 with OptionalImports(messages=REQUIREMENT_LLAMA):
     # import llama_index
 
-    from llama_index.indices.query.base import BaseQueryEngine
+    from llama_index.indice.query.base import BaseQueryEngine
     from llama_index.chat_engine.types import BaseChatEngine
     from llama_index.chat_engine.types import AgentChatResponse, StreamingAgentChatResponse
     from llama_index.response.schema import Response, StreamingResponse, RESPONSE_TYPE
@@ -44,7 +44,6 @@ with OptionalImports(messages=REQUIREMENT_LLAMA):
     from llama_index.llms.base import BaseLLM  # subtype of BaseComponent
 
     # misc
-    from llama_index.indices.query.base import BaseQueryEngine
     from llama_index.indices.base_retriever import BaseRetriever
     from llama_index.indices.base import BaseIndex
     from llama_index.chat_engine.types import BaseChatEngine

--- a/trulens_eval/trulens_eval/utils/imports.py
+++ b/trulens_eval/trulens_eval/utils/imports.py
@@ -3,13 +3,16 @@ Utilities for importing python modules and optional importing.
 """
 
 import builtins
+from dataclasses import dataclass
 import inspect
 import logging
 from pathlib import Path
 from pprint import PrettyPrinter
-from typing import Dict, Sequence, Union
+from typing import Dict, Optional, Sequence, Type, Union
 
 import pkg_resources
+
+from trulens_eval import __name__ as trulens_name
 
 logger = logging.getLogger(__name__)
 pp = PrettyPrinter()
@@ -35,34 +38,79 @@ optional_packages = requirements_of_file(
 
 all_packages = {**required_packages, **optional_packages}
 
+def pin_spec(r: pkg_resources.Requirement) -> pkg_resources.Requirement:
+    """
+    Pin the requirement to the version assuming it is lower bounded by a
+    version.
+    """
+    
+    spec = str(r)
+    if ">=" not in spec:
+        raise ValueError(f"Requirement {spec} is not lower-bounded.")
 
-def format_missing_imports(
+    spec = spec.replace(">=", "==")
+    return pkg_resources.Requirement.parse(spec)
+
+@dataclass
+class ImportErrorMessages():
+    module_not_found: str
+    import_error: str
+
+
+def format_import_errors(
     packages: Union[str, Sequence[str]],
-    purpose: str,
+    purpose: Optional[str] = None,
     throw: Union[bool, Exception] = False
-) -> str:
+) -> ImportErrorMessages:
     """
-    Format a message indicating the given `packages` are required for `purpose`.
-    Throws an `ImportError` with the formatted message if `throw` flag is set.
-    If `throw` is already an exception, throws that instead after printing the
-    message.
+    Format two messages for missing optional package or bad import from an
+    optional package.. Throws an `ImportError` with the formatted message if
+    `throw` flag is set. If `throw` is already an exception, throws that instead
+    after printing the message.
     """
+
+    if purpose is None:
+        purpose = f"using {packages}"
 
     if isinstance(packages, str):
         packages = [packages]
 
     requirements = []
+    requirements_pinned = []
+
     for pkg in packages:
         if pkg in all_packages:
             requirements.append(str(all_packages[pkg]))
+            requirements_pinned.append(str(pin_spec(all_packages[pkg])))
         else:
             print(f"WARNING: package {pkg} not present in requirements.")
             requirements.append(pkg)
 
-    msg = (
-        f"{','.join(packages)} {'packages are' if len(packages) > 1 else 'package is'} required for {purpose}. "
-        f"You should be able to install {'them' if len(packages) > 1 else 'it'} with pip:\n"
-        f"  pip install '{' '.join(requirements)}'"
+    packs = ','.join(packages)
+    pack_s = "package" if len(packages) == 1 else "packages"
+    is_are = "is" if len(packages) == 1 else "are"
+    it_them = "it" if len(packages) == 1 else "them"
+    this_these = "this" if len(packages) == 1 else "these"
+
+    msg = (f"""
+{','.join(packages)} {pack_s} {is_are} required for {purpose}.
+You should be able to install {it_them} with pip:
+
+    pip install '{' '.join(requirements)}
+""")
+
+    msg_pinned = (
+f"""
+You have {packs} installed but we could not import the required
+components. There may be a version incompatibility. Please try installing {this_these}
+exact {pack_s} with pip: 
+
+  pip install '{' '.join(requirements_pinned)}'
+
+Alternatively, if you do not need {packs}, uninstall {it_them}:
+
+  pip uninstall '{' '.join(packages)}'
+"""
     )
 
     if isinstance(throw, Exception):
@@ -73,34 +121,36 @@ def format_missing_imports(
         if throw:
             raise ImportError(msg)
 
-    return msg
+    return ImportErrorMessages(
+        module_not_found=msg,
+        import_error=msg_pinned
+    )
 
-
-REQUIREMENT_LLAMA = format_missing_imports(
+REQUIREMENT_LLAMA = format_import_errors(
     'llama-index', purpose="instrumenting llama_index apps"
 )
 
-REQUIREMENT_LANGCHAIN = format_missing_imports(
+REQUIREMENT_LANGCHAIN = format_import_errors(
     'langchain', purpose="instrumenting langchain apps"
 )
 
-REQUIREMENT_SKLEARN = format_missing_imports(
+REQUIREMENT_SKLEARN = format_import_errors(
     "scikit-learn", purpose="using embedding vector distances"
 )
 
-REQUIREMENT_BEDROCK = format_missing_imports(
+REQUIREMENT_BEDROCK = format_import_errors(
     ['boto3', 'botocore'], purpose="using Bedrock models"
 )
 
-REQUIREMENT_OPENAI = format_missing_imports(
+REQUIREMENT_OPENAI = format_import_errors(
     'openai', purpose="using OpenAI models"
 )
 
-REQUIREMENT_BERT_SCORE = format_missing_imports(
+REQUIREMENT_BERT_SCORE = format_import_errors(
     "bert-score", purpose="measuring BERT Score"
 )
 
-REQUIREMENT_EVALUATE = format_missing_imports(
+REQUIREMENT_EVALUATE = format_import_errors(
     "evaluate", purpose="using certain metrics"
 )
 
@@ -111,12 +161,18 @@ class Dummy(object):
     error if accessed in any way.
     """
 
-    def __init__(self, message: str, importer=None):
+    def __init__(
+        self,
+        message: str,
+        exception_class: Type[Exception] = ModuleNotFoundError,
+        importer=None
+    ):
         self.message = message
         self.importer = importer
+        self.exception_class = exception_class
 
     def __call__(self, *args, **kwargs):
-        raise ModuleNotFoundError(self.message)
+        raise self.exception_class(self.message)
 
     def __getattr__(self, name):
         # If in OptionalImport context, create a new dummy for the requested
@@ -125,7 +181,7 @@ class Dummy(object):
         if self.importer is not None and self.importer.importing:
             return Dummy(message=self.message, importer=self.importer)
 
-        raise ModuleNotFoundError(self.message)
+        raise self.exception_class(self.message)
 
 
 class OptionalImports(object):
@@ -133,11 +189,13 @@ class OptionalImports(object):
     Helper context manager for doing multiple imports from an optional module:
 
     ```python
-
-        with OptionalImports(message='Please install llama_index first'):
+        messages = ImportErrorMessages(
+            module_not_found="install llama_index first",
+            import_error="install llama_index==0.1.0"
+        )
+        with OptionalImports(messages=messages):
             import llama_index
             from llama_index import query_engine
-
     ```
 
     The above python block will not raise any errors but once anything else
@@ -145,24 +203,62 @@ class OptionalImports(object):
     specified message (unless llama_index is installed of course).
     """
 
-    def __init__(self, message: str = None):
-        self.message = message
+    def __init__(self, messages: ImportErrorMessages):
+        self.messages = messages
         self.importing = False
         self.imp = builtins.__import__
 
-    def __import__(self, *args, **kwargs):
+    def __import__(self, name, globals=None, locals=None, fromlist=(), level=0):
         try:
-            return self.imp(*args, **kwargs)
+            mod = self.imp(name, globals, locals, fromlist, level)
+
+            # NOTE(piotrm): commented block attempts to check module contents
+            # for required attributes so we can offer a message without raising
+            # an exception later. It is commented out for now it is catching
+            # some things we don't watch to catch. Need to check how attributes
+            # are normally looked up in a module to fix this. Specifically, the
+            # code that raises these messages: "ImportError: cannot import name
+            # ..."
+            """
+            if isinstance(fromlist, Iterable):
+                for i in fromlist:
+                    if i == "*":
+                        continue
+                    # Check the contents so there is opportunity to catch import errors here
+                    try:
+                        getattr(mod, i)
+                    except AttributeError as e:
+                        raise ImportError(e)
+            """
+
+            return mod
 
         except ModuleNotFoundError as e:
             # Check if the import error was from an import in trulens_eval as
             # otherwise we don't want to intercept the error as some modules
             # rely on import failures for various things.
             module_name = inspect.currentframe().f_back.f_globals["__name__"]
-            if not module_name.startswith("trulens_eval"):
+            if not module_name.startswith(trulens_name):
                 raise e
-            logger.debug(f"Could not import {args[0]}.")
-            return Dummy(message=self.message, importer=self)
+            logger.debug(f"Module not found {name}.")
+            return Dummy(message=self.messages.module_not_found, importer=self)
+        
+        # NOTE(piotrm): This below seems to never be caught. It might be that a
+        # different import method is being used once a module is found.
+        """
+        except ImportError as e:
+            module_name = inspect.currentframe().f_back.f_globals["__name__"]
+            if not module_name.startswith(trulens_name):
+                raise e
+            logger.debug(f"Could not import {name} ({fromlist}). There might be a version incompatibility.")
+            logger.warning(self.messages.import_error + "\n" + str(e))
+
+            return Dummy(
+                message=self.messages.import_error,
+                exception_class=ImportError,
+                importer=self
+            )
+        """
 
     def __enter__(self):
         builtins.__import__ = self.__import__
@@ -176,6 +272,16 @@ class OptionalImports(object):
         if exc_value is None:
             return None
 
-        print(self.message)
+        # Print the appropriate message.
+
+        if isinstance(exc_value, ModuleNotFoundError):
+            print(exc_value)
+            print(self.messages.module_not_found)
+        elif isinstance(exc_value, ImportError):
+            print(exc_value)
+            print(self.messages.import_error)
+        else:
+            print(exc_value)
+
         # Will re-raise exception unless True is returned.
         return None

--- a/trulens_eval/trulens_eval/utils/langchain.py
+++ b/trulens_eval/trulens_eval/utils/langchain.py
@@ -20,7 +20,7 @@ from trulens_eval.utils.serial import JSON
 from trulens_eval.utils.serial import model_dump
 from trulens_eval.utils.threading import ThreadPoolExecutor
 
-with OptionalImports(message=REQUIREMENT_LANGCHAIN):
+with OptionalImports(messages=REQUIREMENT_LANGCHAIN):
     import langchain
     from langchain.schema import Document
     from langchain.vectorstores.base import VectorStoreRetriever

--- a/trulens_eval/trulens_eval/utils/llama.py
+++ b/trulens_eval/trulens_eval/utils/llama.py
@@ -18,7 +18,7 @@ from trulens_eval.utils.imports import REQUIREMENT_LLAMA
 from trulens_eval.utils.pyschema import Class
 from trulens_eval.utils.threading import ThreadPoolExecutor
 
-with OptionalImports(message=REQUIREMENT_LLAMA):
+with OptionalImports(messages=REQUIREMENT_LLAMA):
     from llama_index.indices.query.schema import QueryBundle
     from llama_index.indices.vector_store.retrievers import \
         VectorIndexRetriever

--- a/trulens_eval/trulens_eval/ux/components.py
+++ b/trulens_eval/trulens_eval/ux/components.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional
 
 import pandas as pd
 import streamlit as st
-from streamlit_javascript import st_javascript
 
 from trulens_eval.app import ComponentView
 from trulens_eval.keys import REDACTED_VALUE


### PR DESCRIPTION
Added a different message for when an optional import package does exist but something inside it cannot be imported. For example:

```
You have llama-index installed but we could not import the required
components. There may be a version incompatibility. Please try installing this
exact package with pip: 

  pip install 'llama-index==v0.9.14.post3'

Alternatively, if you do not need llama-index, uninstall it:

  pip uninstall 'llama-index'
```

For now, this is raised regardless of whether the user needs the optional import or not due to some technicalities. If the package itself is not found, the behaviour is still to ignore this unless the user tries to make use of a trulens feature that requires that package, in that case this gets printed, for example:

```
llama-index package is required for instrumenting llama_index apps.
You should be able to install it with pip:

    pip install 'llama-index>=v0.9.14.post3
```