### PR TITLE
Expand langchain instrumentation for RAGs

### DIFF
--- a/trulens_eval/examples/quickstart/langchain_quickstart.ipynb
+++ b/trulens_eval/examples/quickstart/langchain_quickstart.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ! pip install trulens_eval==0.19.1 openai==1.3.7"
+    "# ! pip install trulens_eval==0.19.1 openai==1.3.7 langchain chromadb langchainhub bs4"
    ]
   },
   {
@@ -38,8 +38,7 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "os.environ[\"OPENAI_API_KEY\"] = \"...\"\n",
-    "os.environ[\"HUGGINGFACE_API_KEY\"] = \"...\""
+    "os.environ[\"OPENAI_API_KEY\"] = \"...\""
    ]
   },
   {
@@ -62,14 +61,18 @@
     "from trulens_eval import TruChain, Feedback, Huggingface, Tru\n",
     "from trulens_eval.schema import FeedbackResult\n",
     "tru = Tru()\n",
+    "tru.reset_database()\n",
     "\n",
-    "# Imports from langchain to build app. You may need to install langchain first\n",
-    "# with the following:\n",
-    "# ! pip install langchain>=0.0.170\n",
-    "from langchain.chains import LLMChain\n",
-    "from langchain.llms import OpenAI\n",
-    "from langchain.prompts import ChatPromptTemplate, PromptTemplate\n",
-    "from langchain.prompts import HumanMessagePromptTemplate"
+    "# Imports from langchain to build app\n",
+    "import bs4\n",
+    "from langchain import hub\n",
+    "from langchain.chat_models import ChatOpenAI\n",
+    "from langchain.document_loaders import WebBaseLoader\n",
+    "from langchain.embeddings import OpenAIEmbeddings\n",
+    "from langchain.schema import StrOutputParser\n",
+    "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
+    "from langchain.vectorstores import Chroma\n",
+    "from langchain_core.runnables import RunnablePassthrough"
    ]
   },
   {
@@ -77,9 +80,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Create Simple LLM Application\n",
-    "\n",
-    "This example uses a LangChain framework and OpenAI LLM"
+    "### Load documents"
    ]
   },
   {
@@ -88,19 +89,63 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "full_prompt = HumanMessagePromptTemplate(\n",
-    "    prompt=PromptTemplate(\n",
-    "        template=\n",
-    "        \"Provide a helpful response with relevant background information for the following: {prompt}\",\n",
-    "        input_variables=[\"prompt\"],\n",
-    "    )\n",
+    "loader = WebBaseLoader(\n",
+    "    web_paths=(\"https://lilianweng.github.io/posts/2023-06-23-agent/\",),\n",
+    "    bs_kwargs=dict(\n",
+    "        parse_only=bs4.SoupStrainer(\n",
+    "            class_=(\"post-content\", \"post-title\", \"post-header\")\n",
+    "        )\n",
+    "    ),\n",
     ")\n",
+    "docs = loader.load()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create Vector Store"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)\n",
+    "splits = text_splitter.split_documents(docs)\n",
     "\n",
-    "chat_prompt_template = ChatPromptTemplate.from_messages([full_prompt])\n",
+    "vectorstore = Chroma.from_documents(documents=splits, embedding=OpenAIEmbeddings())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create RAG"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "retriever = vectorstore.as_retriever()\n",
     "\n",
-    "llm = OpenAI(temperature=0.9, max_tokens=128)\n",
+    "prompt = hub.pull(\"rlm/rag-prompt\")\n",
+    "llm = ChatOpenAI(model_name=\"gpt-3.5-turbo\", temperature=0)\n",
     "\n",
-    "chain = LLMChain(llm=llm, prompt=chat_prompt_template, verbose=True)"
+    "def format_docs(docs):\n",
+    "    return \"\\n\\n\".join(doc.page_content for doc in docs)\n",
+    "\n",
+    "rag_chain = (\n",
+    "    {\"context\": retriever | format_docs, \"question\": RunnablePassthrough()}\n",
+    "    | prompt\n",
+    "    | llm\n",
+    "    | StrOutputParser()\n",
+    ")"
    ]
   },
   {
@@ -117,18 +162,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prompt_input = '¿que hora es?'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "llm_response = chain(prompt_input)\n",
-    "\n",
-    "display(llm_response)"
+    "rag_chain.invoke(\"What is Task Decomposition?\")"
    ]
   },
   {
@@ -145,13 +179,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Initialize Huggingface-based feedback function collection class:\n",
-    "hugs = Huggingface()\n",
+    "from trulens_eval.feedback.provider import OpenAI\n",
+    "from trulens_eval import Select\n",
+    "import numpy as np\n",
+    "# Initialize provider class\n",
+    "openai = OpenAI()\n",
+    "from trulens_eval.feedback import Groundedness\n",
+    "grounded = Groundedness(groundedness_provider=OpenAI())\n",
+    "# Define a groundedness feedback function\n",
+    "f_groundedness = (\n",
+    "    Feedback(grounded.groundedness_measure_with_cot_reasons)\n",
+    "    .on(Select.RecordCalls.first.invoke.rets.context)\n",
+    "    .on_output()\n",
+    "    .aggregate(grounded.grounded_statements_aggregator)\n",
+    ")\n",
     "\n",
-    "# Define a language match feedback function using HuggingFace.\n",
-    "f_lang_match = Feedback(hugs.language_match).on_input_output()\n",
-    "# By default this will check language match on the main app input and main app\n",
-    "# output."
+    "# Question/answer relevance between overall question and answer.\n",
+    "f_qa_relevance = Feedback(openai.relevance).on_input_output()\n",
+    "# Question/statement relevance between question and each context chunk.\n",
+    "f_context_relevance = (\n",
+    "    Feedback(openai.qs_relevance)\n",
+    "    .on(Select.RecordCalls.first.invoke.args.input)\n",
+    "    .on(Select.RecordCalls.first.invoke.rets.context)\n",
+    "    .aggregate(np.mean)\n",
+    ")"
    ]
   },
   {
@@ -168,9 +219,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tru_recorder = TruChain(chain,\n",
+    "tru_recorder = TruChain(rag_chain,\n",
     "    app_id='Chain1_ChatApplication',\n",
-    "    feedbacks=[f_lang_match])"
+    "    feedbacks=[f_qa_relevance, f_context_relevance, f_groundedness])"
    ]
   },
   {
@@ -180,9 +231,18 @@
    "outputs": [],
    "source": [
     "with tru_recorder as recording:\n",
-    "    llm_response = chain(prompt_input)\n",
+    "    llm_response = rag_chain.invoke(\"What is Task Decomposition?\")\n",
     "\n",
     "display(llm_response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tru.run_dashboard()"
    ]
   },
   {

--- a/trulens_eval/trulens_eval/tru_chain.py
+++ b/trulens_eval/trulens_eval/tru_chain.py
@@ -28,9 +28,6 @@ pp = PrettyPrinter()
 with OptionalImports(messages=REQUIREMENT_LANGCHAIN):
     # langchain.agents.agent.AgentExecutor, # is langchain.chains.base.Chain
     # import langchain
-    from langchain_core.vectorstores import VectorStoreRetriever
-    from langchain_core.vectorstores import VectorStore
-    from langchain_core.retrievers import BaseRetriever
     
     from langchain_core.runnables.base import RunnableSerializable
 
@@ -58,9 +55,6 @@ class LangChainInstrument(Instrument):
 
         # Thunk because langchain is optional. TODO: Not anymore.
         CLASSES = lambda: {
-            VectorStoreRetriever,
-            VectorStore,
-            BaseRetriever,
             RunnableSerializable,
             Serializable,
             Document,
@@ -83,32 +77,10 @@ class LangChainInstrument(Instrument):
 
         # Instrument only methods with these names and of these classes.
         METHODS = {
-            "as_retriever":
-                lambda o: isinstance(o, VectorStore),
-            "search":
-                lambda o: isinstance(o, VectorStore),
-            "asearch":
-                lambda o: isinstance(o, VectorStore),
-            "similarity_search":
-                lambda o: isinstance(o, VectorStore),
-            "asimilarity_search":
-                lambda o: isinstance(o, VectorStore),
-            "similarity_search_by_vector":
-                lambda o: isinstance(o, VectorStore),
-            "asimilarity_search_by_vector":
-                lambda o: isinstance(o, VectorStore),
-            "max_marginal_relevance_search":
-                lambda o: isinstance(o, VectorStore),
-            "amax_marginal_relevance_search":
-                lambda o: isinstance(o, VectorStore),
-            "max_marginal_relevance_search_by_vector":
-                lambda o: isinstance(o, VectorStore),
-            "amax_marginal_relevance_search_by_vector":
-                lambda o: isinstance(o, VectorStore),
             "invoke":
-                lambda o: isinstance(o, (RunnableSerializable, BaseRetriever)),
+                lambda o: isinstance(o, RunnableSerializable),
             "ainvoke":
-                lambda o: isinstance(o, (RunnableSerializable, BaseRetriever)),
+                lambda o: isinstance(o, RunnableSerializable),
             "save_context":
                 lambda o: isinstance(o, BaseMemory),
             "clear":
@@ -122,9 +94,9 @@ class LangChainInstrument(Instrument):
             "acall":
                 lambda o: isinstance(o, Chain),
             "_get_relevant_documents":
-                lambda o: isinstance(o, (RunnableSerializable, BaseRetriever, VectorStoreRetriever)),
+                lambda o: isinstance(o, (RunnableSerializable)),
             "_aget_relevant_documents":
-                lambda o: isinstance(o, (RunnableSerializable, BaseRetriever, VectorStoreRetriever)),
+                lambda o: isinstance(o, (RunnableSerializable)),
             # "format_prompt": lambda o: isinstance(o, langchain.prompts.base.BasePromptTemplate),
             # "format": lambda o: isinstance(o, langchain.prompts.base.BasePromptTemplate),
             # the prompt calls might be too small to be interesting

--- a/trulens_eval/trulens_eval/tru_chain.py
+++ b/trulens_eval/trulens_eval/tru_chain.py
@@ -28,6 +28,9 @@ pp = PrettyPrinter()
 with OptionalImports(messages=REQUIREMENT_LANGCHAIN):
     # langchain.agents.agent.AgentExecutor, # is langchain.chains.base.Chain
     # import langchain
+    from langchain_core.vectorstores import VectorStoreRetriever
+    from langchain_core.vectorstores import VectorStore
+    from langchain_core.retrievers import BaseRetriever
     
     from langchain_core.runnables.base import RunnableSerializable
 
@@ -51,10 +54,13 @@ with OptionalImports(messages=REQUIREMENT_LANGCHAIN):
 class LangChainInstrument(Instrument):
 
     class Default:
-        MODULES = {"langchain."}
+        MODULES = {"langchain"}
 
         # Thunk because langchain is optional. TODO: Not anymore.
         CLASSES = lambda: {
+            VectorStoreRetriever,
+            VectorStore,
+            BaseRetriever,
             RunnableSerializable,
             Serializable,
             Document,
@@ -77,10 +83,32 @@ class LangChainInstrument(Instrument):
 
         # Instrument only methods with these names and of these classes.
         METHODS = {
+            "as_retriever":
+                lambda o: isinstance(o, VectorStore),
+            "search":
+                lambda o: isinstance(o, VectorStore),
+            "asearch":
+                lambda o: isinstance(o, VectorStore),
+            "similarity_search":
+                lambda o: isinstance(o, VectorStore),
+            "asimilarity_search":
+                lambda o: isinstance(o, VectorStore),
+            "similarity_search_by_vector":
+                lambda o: isinstance(o, VectorStore),
+            "asimilarity_search_by_vector":
+                lambda o: isinstance(o, VectorStore),
+            "max_marginal_relevance_search":
+                lambda o: isinstance(o, VectorStore),
+            "amax_marginal_relevance_search":
+                lambda o: isinstance(o, VectorStore),
+            "max_marginal_relevance_search_by_vector":
+                lambda o: isinstance(o, VectorStore),
+            "amax_marginal_relevance_search_by_vector":
+                lambda o: isinstance(o, VectorStore),
             "invoke":
-                lambda o: isinstance(o, RunnableSerializable),
+                lambda o: isinstance(o, (RunnableSerializable, BaseRetriever)),
             "ainvoke":
-                lambda o: isinstance(o, RunnableSerializable),
+                lambda o: isinstance(o, (RunnableSerializable, BaseRetriever)),
             "save_context":
                 lambda o: isinstance(o, BaseMemory),
             "clear":
@@ -94,7 +122,9 @@ class LangChainInstrument(Instrument):
             "acall":
                 lambda o: isinstance(o, Chain),
             "_get_relevant_documents":
-                lambda o: True,  # VectorStoreRetriever, langchain >= 0.230
+                lambda o: isinstance(o, (RunnableSerializable, BaseRetriever, VectorStoreRetriever)),
+            "_aget_relevant_documents":
+                lambda o: isinstance(o, (RunnableSerializable, BaseRetriever, VectorStoreRetriever)),
             # "format_prompt": lambda o: isinstance(o, langchain.prompts.base.BasePromptTemplate),
             # "format": lambda o: isinstance(o, langchain.prompts.base.BasePromptTemplate),
             # the prompt calls might be too small to be interesting


### PR DESCRIPTION
Before:
![Screen Shot 2023-12-18 at 1 07 17 PM](https://github.com/truera/trulens/assets/60949774/bbf697ec-8fa5-45fc-ba7e-7693da3bfb62)

After:
![Screen Shot 2023-12-18 at 1 30 33 PM](https://github.com/truera/trulens/assets/60949774/eadac358-72a4-4eee-80d3-c03e19a7ff34)

Also declutters main input and shows example of RAG eval.
![Screen Shot 2023-12-18 at 1 53 14 PM](https://github.com/truera/trulens/assets/60949774/d47b2d9a-fa2d-40b5-bfaa-fef769bbcddb)