### PR TITLE
add aliases for selectors for main method args and main method return

### DIFF
--- a/trulens_eval/examples/experimental/dev_notebook.ipynb
+++ b/trulens_eval/examples/experimental/dev_notebook.ipynb
@@ -382,7 +382,10 @@
    "source": [
     "rec = recording.get().layout_calls_as_app() # important\n",
     "from trulens_eval.utils.serial import Lens\n",
-    "next(Lens().app.query[0].args.str_or_query_bundle.get(rec))"
+    "from trulens_eval.schema import Select\n",
+    "all_args = next(Lens().app.query[0].args.str_or_query_bundle.get(rec))\n",
+    "\n",
+    "Select.render_for_dashboard(Select.RecordRets)"
    ]
   },
   {

--- a/trulens_eval/trulens_eval/schema.py
+++ b/trulens_eval/trulens_eval/schema.py
@@ -255,6 +255,7 @@ class Select:
     """
 
     # Typing for type hints.
+    # TODEP
     Query = Lens
 
     # Instance for constructing queries for record json like `Record.app.llm`.
@@ -269,6 +270,11 @@ class Select:
     RecordOutput: Query = Record.main_output  # type: ignore
 
     RecordCalls: Query = Record.app  # type: ignore
+
+    # The whole set of inputs/arguments to the first called / last method call.
+    RecordArgs: Query = Record.calls[-1].args
+    # The whole output of the first called / last returned method call.
+    RecordRets: Query = Record.calls[-1].rets
 
     @staticmethod
     def for_record(query: Select.Query) -> Query:
@@ -297,9 +303,18 @@ class Select:
         elif query.path[0:2] == Select.RecordOutput.path:
             ret = "Select.RecordOutput"
             rest = query.path[2:]
+
         elif query.path[0:2] == Select.RecordCalls.path:
             ret = "Select.RecordCalls"
             rest = query.path[2:]
+
+        elif query.path[0:4] == Select.RecordArgs.path:
+            ret = "Select.RecordArgs"
+            rest = query.path[4:]
+        elif query.path[0:4] == Select.RecordRets.path:
+            ret = "Select.RecordRets"
+            rest = query.path[4:]
+
         elif query.path[0] == Select.Record.path[0]:
             ret = "Select.Record"
             rest = query.path[1:]

--- a/trulens_eval/trulens_eval/schema.py
+++ b/trulens_eval/trulens_eval/schema.py
@@ -269,12 +269,16 @@ class Select:
     RecordInput: Query = Record.main_input  # type: ignore
     RecordOutput: Query = Record.main_output  # type: ignore
 
+    # The calls made by the wrapped app. Layed out by path into components. 
     RecordCalls: Query = Record.app  # type: ignore
 
+    # The first called method (last to return).
+    RecordCall: Query = Record.calls[-1]
+
     # The whole set of inputs/arguments to the first called / last method call.
-    RecordArgs: Query = Record.calls[-1].args
+    RecordArgs: Query = RecordCall.args
     # The whole output of the first called / last returned method call.
-    RecordRets: Query = Record.calls[-1].rets
+    RecordRets: Query = RecordCall.rets
 
     @staticmethod
     def for_record(query: Select.Query) -> Query:
@@ -304,16 +308,20 @@ class Select:
             ret = "Select.RecordOutput"
             rest = query.path[2:]
 
-        elif query.path[0:2] == Select.RecordCalls.path:
-            ret = "Select.RecordCalls"
-            rest = query.path[2:]
-
         elif query.path[0:4] == Select.RecordArgs.path:
             ret = "Select.RecordArgs"
             rest = query.path[4:]
         elif query.path[0:4] == Select.RecordRets.path:
             ret = "Select.RecordRets"
             rest = query.path[4:]
+
+        elif query.path[0:2] == Select.RecordCalls.path:
+            ret = "Select.RecordCalls"
+            rest = query.path[2:]
+
+         elif query.path[0:3] == Select.RecordCall.path:
+            ret = "Select.RecordCall"
+            rest = query.path[3:]
 
         elif query.path[0] == Select.Record.path[0]:
             ret = "Select.Record"

--- a/trulens_eval/trulens_eval/schema.py
+++ b/trulens_eval/trulens_eval/schema.py
@@ -319,7 +319,7 @@ class Select:
             ret = "Select.RecordCalls"
             rest = query.path[2:]
 
-         elif query.path[0:3] == Select.RecordCall.path:
+        elif query.path[0:3] == Select.RecordCall.path:
             ret = "Select.RecordCall"
             rest = query.path[3:]
 


### PR DESCRIPTION
Added selector aliases:
- `Select.RecordCall` equivalent to `Lens().__record__.calls[-1]`, 
- `Select.RecordArgs` equivalent to `Lens().__record__.calls[-1].args`, and 
- `Select.RecordRets` equivalent to `Lens().__record__.calls[-1].rets` .

In all of the above `calls[-1]` refers to the first called and therefore last to return instrumented method.

Simplifies https://github.com/truera/trulens/issues/689 .