### PR TITLE
More secure way of storing API key by using getpass standard library

### DIFF
--- a/trulens_eval/examples/quickstart/quickstart.ipynb
+++ b/trulens_eval/examples/quickstart/quickstart.ipynb
@@ -29,7 +29,9 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "os.environ[\"OPENAI_API_KEY\"] = \"...\""
+    "import getpass\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = getpass.getpass(prompt=\"OpenAI API key: \")"
    ]
   },
   {


### PR DESCRIPTION
In the case someone makes a copy of the tutorial, they don't have to hard code the api key