### PR TITLE
Add code to show IP address of the collab instance so dashboard can be viewed

### DIFF
--- a/trulens_eval/examples/quickstart/quickstart.ipynb
+++ b/trulens_eval/examples/quickstart/quickstart.ipynb
@@ -290,6 +290,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import requests\n",
+    "\n",
+    "IP = requests.get(\"https://ipecho.net/plain\")\n",
+    "print(IP.text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Paste the IP printed above into the website given in this cell's output\n",
     "tru.run_dashboard()"
    ]
   }


### PR DESCRIPTION
Without this, when you run the very last cell, the output says to input the IP but you do not know where the IP is from:

![image](https://github.com/truera/trulens/assets/67878058/82e90cf9-b25a-4c06-9b31-8fa40226a905)

My change prints it like this:

![image](https://github.com/truera/trulens/assets/67878058/69fb9e8d-a280-4f91-8370-259a24d66e24)
