### PR TITLE
allow debug timeout to be adjusted

### DIFF
--- a/trulens_eval/trulens_eval/utils/threading.py
+++ b/trulens_eval/trulens_eval/utils/threading.py
@@ -8,7 +8,7 @@ from concurrent.futures import TimeoutError
 from inspect import stack
 import logging
 import threading
-from typing import Callable, TypeVar
+from typing import Callable, Optional, TypeVar
 
 from trulens_eval.utils.python import _future_target_wrapper
 from trulens_eval.utils.python import code_line
@@ -72,9 +72,11 @@ class TP(SingletonPerName['TP']):  # "thread processing"
         self,
         func: Callable[..., T],
         *args,
-        timeout: float = DEBUG_TIMEOUT,
+        timeout: Optional[float] = None,
         **kwargs
     ) -> T:
+        if timeout is None:
+            timeout = TP.DEBUG_TIMEOUT
 
         fut: 'Future[T]' = self.thread_pool.submit(func, *args, **kwargs)
 
@@ -100,9 +102,11 @@ class TP(SingletonPerName['TP']):  # "thread processing"
         self,
         func: Callable[..., T],
         *args,
-        timeout: float = DEBUG_TIMEOUT,
+        timeout: Optional[float] = None,
         **kwargs
     ) -> 'Future[T]':
+        if timeout is None:
+            timeout = TP.DEBUG_TIMEOUT
 
         # TODO(piotrm): need deadlock fixes here. If submit or _submit was called
         # earlier in the stack, do not use a threadpool to evaluate this task
@@ -116,9 +120,11 @@ class TP(SingletonPerName['TP']):  # "thread processing"
         self,
         func: Callable[..., T],
         *args,
-        timeout: float = DEBUG_TIMEOUT,
+        timeout: Optional[float] = None,
         **kwargs
     ) -> 'Future[T]':
+        if timeout is None:
+            timeout = TP.DEBUG_TIMEOUT
 
         # Submit a concurrent tasks to run `func` with the given `args` and
         # `kwargs` but stop with error if it ever takes too long. This is only

--- a/trulens_eval/trulens_eval/utils/threading.py
+++ b/trulens_eval/trulens_eval/utils/threading.py
@@ -43,7 +43,7 @@ class TP(SingletonPerName['TP']):  # "thread processing"
     MAX_THREADS: int = 128
 
     # How long to wait for any task before restarting it.
-    DEBUG_TIMEOUT: float = 600.0  # [seconds], None to disable
+    DEBUG_TIMEOUT: Optional[float] = 600.0  # [seconds], None to disable
 
     def __init__(self):
         if safe_hasattr(self, "thread_pool"):

--- a/trulens_eval/trulens_eval/utils/threading.py
+++ b/trulens_eval/trulens_eval/utils/threading.py
@@ -40,10 +40,10 @@ class TP(SingletonPerName['TP']):  # "thread processing"
     # Store here stacks of calls to various thread starting methods so that we
     # can retrieve the trace of calls that caused a thread to start.
 
-    MAX_THREADS = 128
+    MAX_THREADS: int = 128
 
     # How long to wait for any task before restarting it.
-    DEBUG_TIMEOUT = 600.0  # 5 minutes
+    DEBUG_TIMEOUT: float = 600.0  # [seconds], None to disable
 
     def __init__(self):
         if safe_hasattr(self, "thread_pool"):


### PR DESCRIPTION
Some trulens calls have a 10 minute timeout by default. This can now be adjusted or disabled.

```python
from trulens_eval.utils.threading import TP
TP.DEBUG_TIMEOUT = None # None to disable
```