### PR TITLE
Fix subscripted generics typechecking for Python<3.10

### DIFF
--- a/trulens_eval/trulens_eval/feedback/provider/hugs.py
+++ b/trulens_eval/trulens_eval/feedback/provider/hugs.py
@@ -65,11 +65,6 @@ def _tci(func):  # "typecheck inputs"
                     raise TypeError(
                         f"{pident} must be of type `{annotation_name}` but was `{type(v).__name__}` instead."
                     )
-                
-                if not isinstance(v, annot.annotation):
-                    raise TypeError(
-                        f"{pident} must be of type `{annot.annotation.__name__}` but was `{type(v).__name__}` instead."
-                    )
                 if annot.annotation is str:
                     if len(v) == 0:
                         raise ValueError(f"{pident} must be non-empty.")

--- a/trulens_eval/trulens_eval/feedback/provider/hugs.py
+++ b/trulens_eval/trulens_eval/feedback/provider/hugs.py
@@ -2,7 +2,7 @@ from concurrent.futures import Future
 from concurrent.futures import wait
 import logging
 from multiprocessing.pool import AsyncResult
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, Union, get_args, get_origin
 
 import numpy as np
 
@@ -49,6 +49,23 @@ def _tci(func):  # "typecheck inputs"
             if annot is not None:
                 pident = f"Input `{param}` to `{func.__name__}`"
                 v = bindings.arguments[param]
+    
+                typ_origin = get_origin(annot.annotation)
+                if typ_origin == Union:
+                    annotation = get_args(annot.annotation)
+                    annotation_name = "(" + ", ".join(a.__name__ for a in annotation) + ")"
+                elif typ_origin:
+                    annotation = typ_origin
+                    annotation_name = annotation.__name__
+                else:
+                    annotation = annot.annotation
+                    annotation_name = annot.annotation.__name__
+
+                if not isinstance(v, annotation):
+                    raise TypeError(
+                        f"{pident} must be of type `{annotation_name}` but was `{type(v).__name__}` instead."
+                    )
+                
                 if not isinstance(v, annot.annotation):
                     raise TypeError(
                         f"{pident} must be of type `{annot.annotation.__name__}` but was `{type(v).__name__}` instead."


### PR DESCRIPTION
So class and instance checks against generic types like typing.Union[str, int] isn't allowed in Python<3.10
This fix extracts the origin class to compare against