### PR TITLE
removes summarize_provider from groundedness variable

### DIFF
--- a/trulens_eval/examples/expositional/models/azure_openai.ipynb
+++ b/trulens_eval/examples/expositional/models/azure_openai.ipynb
@@ -189,7 +189,7 @@
     ").aggregate(np.mean)\n",
     "\n",
     "# groundedness of output on the context\n",
-    "groundedness = feedback.Groundedness(summarize_provider=azopenai, groundedness_provider=azopenai)\n",
+    "groundedness = feedback.Groundedness(groundedness_provider=azopenai)\n",
     "f_groundedness = Feedback(groundedness.groundedness_measure, name = \"Groundedness\").on(TruLlama.select_source_nodes().node.text).on_output()"
    ]
   },


### PR DESCRIPTION
Addressing issue [#747](https://github.com/truera/trulens/issues/747) 
reduces errors for future users of this notebook by eliminating the `summarize_provider` from the `groundedness` var definition: `groundedness = feedback.Groundedness(groundedness_provider=azopenai)`