### PR TITLE
Evaluations Page Nits

### DIFF
--- a/trulens_eval/trulens_eval/pages/Evaluations.py
+++ b/trulens_eval/trulens_eval/pages/Evaluations.py
@@ -106,7 +106,6 @@ def render_component(query, component, header=True):
         with st.expander("Unhandled Component Details:"):
             st.json(jsonify_for_ui(component.json))
 
-
 # Renders record level metrics (e.g. total tokens, cost, latency) compared to the average when appropriate
 def render_record_metrics(app_df: pd.DataFrame, selected_rows: pd.DataFrame):
     app_specific_df = app_df[app_df["app_id"] == selected_rows["app_id"][0]]
@@ -135,7 +134,6 @@ def render_record_metrics(app_df: pd.DataFrame, selected_rows: pd.DataFrame):
         delta=delta_latency,
         delta_color="inverse",
     )
-
 
 if df_results.empty:
     st.write("No records yet...")
@@ -308,15 +306,18 @@ else:
 
             with metadata_tab:
                 metadata_dict = json.loads(record_json)["meta"]
-                metadata_cols = list(metadata_dict.keys())
+                if not metadata_dict:
+                    st.write("No record metadata available.")
+                else:
+                    metadata_cols = list(metadata_dict.keys())
     
-                metadata_cols = st.columns(len(metadata_cols))
+                    metadata_cols = st.columns(len(metadata_cols))
 
-                for i, (key, value) in enumerate(metadata_dict.items()):
-                    metadata_cols[i].metric(
-                        label=key,
-                        value=value,
-                    )
+                    for i, (key, value) in enumerate(metadata_dict.items()):
+                        metadata_cols[i].metric(
+                            label=key,
+                            value=value,
+                        )
 
             with feedback_tab:
                 if len(feedback_cols) == 0:

--- a/trulens_eval/trulens_eval/pages/Evaluations.py
+++ b/trulens_eval/trulens_eval/pages/Evaluations.py
@@ -198,14 +198,12 @@ else:
 
         gb.configure_column("feedback_id", header_name="Feedback ID", hide=True)
         gb.configure_column("input", header_name="User Input")
-        gb.configure_column(
-            "output",
-            header_name="Response",
-        )
+        gb.configure_column("output", header_name="Response")
+        
         gb.configure_column("total_tokens", header_name="Total Tokens (#)")
         gb.configure_column("total_cost", header_name="Total Cost (USD)")
         gb.configure_column("latency", header_name="Latency (Seconds)")
-        gb.configure_column("tags", header_name="Tags")
+        gb.configure_column("tags", header_name="Application Tag")
         gb.configure_column("ts", header_name="Time Stamp", sort="desc")
 
         non_feedback_cols = [
@@ -279,6 +277,7 @@ else:
             prompt = selected_rows["input"][0]
             response = selected_rows["output"][0]
             details = selected_rows["app_json"][0]
+            record_json = selected_rows["record_json"][0]
 
             app_json = json.loads(
                 details
@@ -307,12 +306,16 @@ else:
             feedback_tab, metadata_tab = st.tabs(["Feedback", "Metadata"])
 
             with metadata_tab:
-                metadata = app_json.get("metadata")
-                if metadata:
-                    with st.expander("Metadata"):
-                        st.markdown(draw_metadata(metadata))
-                else:
-                    st.write("No metadata found")
+                metadata_dict = json.loads(record_json)["meta"]
+                metadata_cols = list(metadata_dict.keys())
+    
+                metadata_cols = st.columns(len(metadata_cols))
+
+                for i, (key, value) in enumerate(metadata_dict.items()):
+                    metadata_cols[i].metric(
+                        label=key,
+                        value=value,
+                    )
 
             with feedback_tab:
                 if len(feedback_cols) == 0:

--- a/trulens_eval/trulens_eval/pages/Evaluations.py
+++ b/trulens_eval/trulens_eval/pages/Evaluations.py
@@ -134,6 +134,14 @@ def render_record_metrics(app_df: pd.DataFrame, selected_rows: pd.DataFrame):
         delta_color="inverse",
     )
 
+        # Define a function to extract record metadata from each row
+def extract_metadata(row):
+    try:
+        record_json = json.loads(row['record_json'])
+        return str(record_json["meta"])
+    except json.JSONDecodeError:
+        return None
+
 if df_results.empty:
     st.write("No records yet...")
 
@@ -182,9 +190,8 @@ else:
         evaluations_df['input'] = decoded_input
         evaluations_df['output'] = decoded_output
 
-        # Extract record metadata from record_json and add it as a new column
-        record_metadata = str(json.loads(evaluations_df['record_json'][0])["meta"])
-        evaluations_df['record_metadata'] = record_metadata
+        # Apply the function to each row and create a new column 'record_metadata'
+        evaluations_df['record_metadata'] = evaluations_df.apply(extract_metadata, axis=1)
 
         gb = GridOptionsBuilder.from_dataframe(evaluations_df)
 

--- a/trulens_eval/trulens_eval/pages/Evaluations.py
+++ b/trulens_eval/trulens_eval/pages/Evaluations.py
@@ -69,7 +69,6 @@ feedback_directions = {
 }
 default_direction = "HIGHER_IS_BETTER"
 
-
 def render_component(query, component, header=True):
     # Draw the accessor/path within the wrapped app of the component.
     if header:
@@ -183,6 +182,10 @@ else:
         evaluations_df['input'] = decoded_input
         evaluations_df['output'] = decoded_output
 
+        # Extract record metadata from record_json and add it as a new column
+        record_metadata = str(json.loads(evaluations_df['record_json'][0])["meta"])
+        evaluations_df['record_metadata'] = record_metadata
+
         gb = GridOptionsBuilder.from_dataframe(evaluations_df)
 
         gb.configure_column("type", header_name="App Type")
@@ -197,7 +200,8 @@ else:
         gb.configure_column("feedback_id", header_name="Feedback ID", hide=True)
         gb.configure_column("input", header_name="User Input")
         gb.configure_column("output", header_name="Response")
-        
+        gb.configure_column("record_metadata", header_name="Record Metadata")
+
         gb.configure_column("total_tokens", header_name="Total Tokens (#)")
         gb.configure_column("total_cost", header_name="Total Cost (USD)")
         gb.configure_column("latency", header_name="Latency (Seconds)")
@@ -213,8 +217,8 @@ else:
             "record_json",
             "latency",
             "tags",
+            "record_metadata",
             "record_id",
-            "app_id",
             "cost_json",
             "app_json",
             "input",
@@ -277,6 +281,7 @@ else:
             response = selected_rows["output"][0]
             details = selected_rows["app_json"][0]
             record_json = selected_rows["record_json"][0]
+            record_metadata = selected_rows["record_metadata"][0]
 
             app_json = json.loads(
                 details
@@ -305,9 +310,9 @@ else:
             feedback_tab, metadata_tab = st.tabs(["Feedback", "Metadata"])
 
             with metadata_tab:
-                metadata_dict = json.loads(record_json)["meta"]
-                if not metadata_dict:
-                    st.write("No record metadata available.")
+                metadata_dict = json.loads(record_json).get("meta", None)
+                if metadata_dict is None:
+                    st.write("No record metadata available")
                 else:
                     metadata_cols = list(metadata_dict.keys())
     

--- a/trulens_eval/trulens_eval/pages/Evaluations.py
+++ b/trulens_eval/trulens_eval/pages/Evaluations.py
@@ -134,13 +134,19 @@ def render_record_metrics(app_df: pd.DataFrame, selected_rows: pd.DataFrame):
         delta_color="inverse",
     )
 
-        # Define a function to extract record metadata from each row
+# Define a function to extract record metadata from each row
 def extract_metadata(row):
-    try:
-        record_json = json.loads(row['record_json'])
-        return str(record_json["meta"])
-    except json.JSONDecodeError:
-        return None
+    """
+    Extract metadata from the record_json and return the metadata as a string.
+
+    Args:
+        row: The row containing the record_json.
+
+    Returns:
+        str: The metadata extracted from the record_json.
+    """
+    record_data = json.loads(row['record_json'])
+    return str(record_data["meta"])
 
 if df_results.empty:
     st.write("No records yet...")

--- a/trulens_eval/trulens_eval/pages/Evaluations.py
+++ b/trulens_eval/trulens_eval/pages/Evaluations.py
@@ -214,6 +214,7 @@ else:
             "total_cost",
             "record_json",
             "latency",
+            "tags",
             "record_id",
             "app_id",
             "cost_json",


### PR DESCRIPTION
Add record metadata to display in evaluations table and on metadata tab.

```python
with tru_rag as recording:
    recording.record_metadata=dict(test_category_1="university", test_category_2="washington")
    rag.query("When was the University of Washington founded?")
```

![Screenshot 2024-01-12 at 6 04 33 PM](https://github.com/truera/trulens/assets/60949774/d5ef9c9c-6f16-4d3d-82a2-32ad8ccc8e6c)

![Screenshot 2024-01-12 at 5 14 57 PM](https://github.com/truera/trulens/assets/60949774/2867b387-9578-4a3b-b9bd-15b26c356436)

Fix name display for application level tags

```python
from trulens_eval import TruCustomApp
tru_rag = TruCustomApp(rag,
    app_id = 'RAG v1',
    tags = "test tag"
```

![Screenshot 2024-01-12 at 5 30 41 PM](https://github.com/truera/trulens/assets/60949774/1c4bc2ef-935b-450d-935d-62cb06194ab3)