### PR TITLE
fix ellipsis issue

### DIFF
--- a/trulens_eval/trulens_eval/requirements.txt
+++ b/trulens_eval/trulens_eval/requirements.txt
@@ -4,6 +4,7 @@ munch              >= 3.0.0
 dill               >= 0.3.7
 tqdm               >= 4.66.1    # groundedness.py
 requests           >= 2.31.0
+nest-asyncio       >= 1.5.8
 
 # Secrets/env management
 python-dotenv      >= 1.0.0


### PR DESCRIPTION
Python 3.8 doesn't like ellipsis ("...") in some places where a type is expected. This PR puts a type variable in those places.