### PR TITLE
non-threaded pacer

### DIFF
--- a/.azure_pipelines/ci-eval-pr.yaml
+++ b/.azure_pipelines/ci-eval-pr.yaml
@@ -31,15 +31,6 @@ jobs:
           python-version: 3.10
           tests-folder: tests/unit/static
 
-    # This doesn't seem to be neccessary, the env is setup without it perhaps by
-    # Azure pipeline config?
-    #env:
-    #  OPENAI_API_KEY: $(OPENAI_API_KEY)
-    #  HUGGINGFACE_API_KEY: $(HUGGINGFACE_API_KEY)
-    #  PINECONE_API_KEY: $(PINECONE_API_KEY)
-    #  PINECONE_ENV: $(PINECONE_ENV)
-    #  HUGGINGFACEHUB_API_TOKEN: $(HUGGINGFACEHUB_API_TOKEN)
-
     steps:
       - checkout: self
         clean: true
@@ -135,7 +126,14 @@ jobs:
           python -m pytest  --test-run-title="Optional $(python-version) unit tests" $(tests-folder)
         env:
           # enables optional tests, see tests/unit/test.py
-          TEST_OPTIONAL: true 
+          TEST_OPTIONAL: true
+  
+          # tests make use of various APIs:
+          OPENAI_API_KEY: $(OPENAI_API_KEY)
+          HUGGINGFACE_API_KEY: $(HUGGINGFACE_API_KEY)
+          PINECONE_API_KEY: $(PINECONE_API_KEY)
+          PINECONE_ENV: $(PINECONE_ENV)
+          HUGGINGFACEHUB_API_TOKEN: $(HUGGINGFACEHUB_API_TOKEN)
 
         displayName: Unit tests with optional packages
 

--- a/.azure_pipelines/ci-eval-pr.yaml
+++ b/.azure_pipelines/ci-eval-pr.yaml
@@ -96,6 +96,7 @@ jobs:
 
           cd ./trulens_eval
           python -m pytest --test-run-title="Required $(python-version) unit tests" $(tests-folder)
+
         displayName: Unit tests with required packages
 
       - bash: |

--- a/trulens_eval/examples/experimental/dev_notebook.ipynb
+++ b/trulens_eval/examples/experimental/dev_notebook.ipynb
@@ -47,56 +47,18 @@
     "root.addHandler(handler)\n",
     "\"\"\"\n",
     "\n",
-    "#from trulens_eval.keys import check_keys\n",
+    "from trulens_eval.keys import check_keys\n",
     "\n",
-    "#check_keys(\n",
-    "#    \"OPENAI_API_KEY\",\n",
-    "#    \"HUGGINGFACE_API_KEY\"\n",
-    "#)\n",
+    "check_keys(\n",
+    "    \"OPENAI_API_KEY\",\n",
+    "    \"HUGGINGFACE_API_KEY\"\n",
+    ")\n",
     "\n",
-    "#from trulens_eval import Tru\n",
-    "#tru = Tru()\n",
+    "from trulens_eval import Tru\n",
+    "tru = Tru()\n",
     "# tru.reset_database()\n",
     "\n",
-    "# tru.run_dashboard(_dev=base, force=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from trulens_eval.utils.pace import Pace"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "p = Pace(rpm=60.0, seconds_per_period=60.0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import time"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "while True:\n",
-    "    # time.sleep(0.5)\n",
-    "    print(\"elapsed:\", p.mark())"
+    "tru.run_dashboard(_dev=base, force=True)"
    ]
   },
   {

--- a/trulens_eval/examples/experimental/dev_notebook.ipynb
+++ b/trulens_eval/examples/experimental/dev_notebook.ipynb
@@ -47,18 +47,56 @@
     "root.addHandler(handler)\n",
     "\"\"\"\n",
     "\n",
-    "from trulens_eval.keys import check_keys\n",
+    "#from trulens_eval.keys import check_keys\n",
     "\n",
-    "check_keys(\n",
-    "    \"OPENAI_API_KEY\",\n",
-    "    \"HUGGINGFACE_API_KEY\"\n",
-    ")\n",
+    "#check_keys(\n",
+    "#    \"OPENAI_API_KEY\",\n",
+    "#    \"HUGGINGFACE_API_KEY\"\n",
+    "#)\n",
     "\n",
-    "from trulens_eval import Tru\n",
-    "tru = Tru()\n",
+    "#from trulens_eval import Tru\n",
+    "#tru = Tru()\n",
     "# tru.reset_database()\n",
     "\n",
-    "tru.run_dashboard(_dev=base, force=True)"
+    "# tru.run_dashboard(_dev=base, force=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens_eval.utils.pace import Pace"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = Pace(rpm=60.0, seconds_per_period=60.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "while True:\n",
+    "    # time.sleep(0.5)\n",
+    "    print(\"elapsed:\", p.mark())"
    ]
   },
   {

--- a/trulens_eval/trulens_eval/appui.py
+++ b/trulens_eval/trulens_eval/appui.py
@@ -12,12 +12,14 @@ from trulens_eval.utils.json import jsonify_for_ui
 from trulens_eval.utils.serial import Lens
 
 with OptionalImports(messages=REQUIREMENT_NOTEBOOK):
+    import ipywidgets # here just for the assertion below
+    
     from ipywidgets import widgets
     import traitlets
     from traitlets import HasTraits
     from traitlets import Unicode
 
-OptionalImports(messages=REQUIREMENT_NOTEBOOK).assert_installed(widgets)
+OptionalImports(messages=REQUIREMENT_NOTEBOOK).assert_installed(ipywidgets)
 
 pp = PrettyPrinter()
 

--- a/trulens_eval/trulens_eval/feedback/provider/base.py
+++ b/trulens_eval/trulens_eval/feedback/provider/base.py
@@ -60,14 +60,15 @@ class LLMProvider(Provider):
         pass
 
     def _find_relevant_string(self, full_source: str, hypothesis: str) -> str:
-        return self.endpoint.run_me(
-            lambda: self._create_chat_completion(
-                prompt=str.format(
-                    prompts.SYSTEM_FIND_SUPPORTING,
-                    prompt=full_source,
-                ) + "\n" + str.
-                format(prompts.USER_FIND_SUPPORTING, response=hypothesis)
-            )
+        assert self.endpoint is not None, "Endpoint is not set."
+
+        return self.endpoint.run_in_pace(
+            self._create_chat_completion,
+            prompt=str.format(
+                prompts.SYSTEM_FIND_SUPPORTING,
+                prompt=full_source,
+            ) + "\n" + str.
+            format(prompts.USER_FIND_SUPPORTING, response=hypothesis)
         )
 
     def _summarized_groundedness(self, premise: str, hypothesis: str) -> float:
@@ -102,14 +103,15 @@ class LLMProvider(Provider):
         Returns:
             str: An LLM response using a scorecard template
         """
-        return self.endpoint.run_me(
-            lambda: self._create_chat_completion(
-                prompt=str.format(prompts.LLM_GROUNDEDNESS_FULL_SYSTEM,) + str.
-                format(
-                    prompts.LLM_GROUNDEDNESS_FULL_PROMPT,
-                    premise=premise,
-                    hypothesis=hypothesis
-                )
+        assert self.endpoint is not None, "Endpoint is not set."
+
+        return self.endpoint.run_in_pace(    
+            self._create_chat_completion,
+            prompt=str.format(prompts.LLM_GROUNDEDNESS_FULL_SYSTEM,) + str.
+            format(
+                prompts.LLM_GROUNDEDNESS_FULL_PROMPT,
+                premise=premise,
+                hypothesis=hypothesis
             )
         )
 
@@ -130,12 +132,14 @@ class LLMProvider(Provider):
         Returns:
             The score (float): 0-1 scale.
         """
+        assert self.endpoint is not None, "Endpoint is not set."
+
         llm_messages = [{"role": "system", "content": system_prompt}]
         if user_prompt is not None:
             llm_messages.append({"role": "user", "content": user_prompt})
 
-        response = self.endpoint.run_me(
-            lambda: self._create_chat_completion(messages=llm_messages)
+        response = self.endpoint.run_in_pace(
+            self._create_chat_completion, messages=llm_messages
         )
 
         return re_0_10_rating(response) / normalize
@@ -156,12 +160,14 @@ class LLMProvider(Provider):
         Returns:
             The score (float): 0-1 scale and reason metadata (dict) if available.
         """
+        assert self.endpoint is not None, "Endpoint is not set."
+
         llm_messages = [{"role": "system", "content": system_prompt}]
         if user_prompt is not None:
             llm_messages.append({"role": "user", "content": user_prompt})
 
-        response = self.endpoint.run_me(
-            lambda: self._create_chat_completion(messages=llm_messages)
+        response = self.endpoint.run_in_pace(
+            self._create_chat_completion, messages=llm_messages
         )
         if "Supporting Evidence" in response:
             score = -1
@@ -970,12 +976,13 @@ class LLMProvider(Provider):
             str
         """
 
-        return self.endpoint.run_me(
-            lambda: self._create_chat_completion(
-                prompt=
-                (prompts.AGREEMENT_SYSTEM_PROMPT %
-                 (prompt, check_response)) + response
-            )
+        assert self.endpoint is not None, "Endpoint is not set."
+
+        return self.endpoint.run_in_pace(
+            self._create_chat_completion,
+            prompt=
+            (prompts.AGREEMENT_SYSTEM_PROMPT %
+                (prompt, check_response)) + response
         )
 
     def comprehensiveness_with_cot_reasons(self, source: str,

--- a/trulens_eval/trulens_eval/feedback/provider/base.py
+++ b/trulens_eval/trulens_eval/feedback/provider/base.py
@@ -63,7 +63,7 @@ class LLMProvider(Provider):
         assert self.endpoint is not None, "Endpoint is not set."
 
         return self.endpoint.run_in_pace(
-            self._create_chat_completion,
+            func=self._create_chat_completion,
             prompt=str.format(
                 prompts.SYSTEM_FIND_SUPPORTING,
                 prompt=full_source,
@@ -106,7 +106,7 @@ class LLMProvider(Provider):
         assert self.endpoint is not None, "Endpoint is not set."
 
         return self.endpoint.run_in_pace(    
-            self._create_chat_completion,
+            func=self._create_chat_completion,
             prompt=str.format(prompts.LLM_GROUNDEDNESS_FULL_SYSTEM,) + str.
             format(
                 prompts.LLM_GROUNDEDNESS_FULL_PROMPT,
@@ -139,7 +139,7 @@ class LLMProvider(Provider):
             llm_messages.append({"role": "user", "content": user_prompt})
 
         response = self.endpoint.run_in_pace(
-            self._create_chat_completion, messages=llm_messages
+            func=self._create_chat_completion, messages=llm_messages
         )
 
         return re_0_10_rating(response) / normalize
@@ -167,7 +167,7 @@ class LLMProvider(Provider):
             llm_messages.append({"role": "user", "content": user_prompt})
 
         response = self.endpoint.run_in_pace(
-            self._create_chat_completion, messages=llm_messages
+            func=self._create_chat_completion, messages=llm_messages
         )
         if "Supporting Evidence" in response:
             score = -1
@@ -979,7 +979,7 @@ class LLMProvider(Provider):
         assert self.endpoint is not None, "Endpoint is not set."
 
         return self.endpoint.run_in_pace(
-            self._create_chat_completion,
+            func=self._create_chat_completion,
             prompt=
             (prompts.AGREEMENT_SYSTEM_PROMPT %
                 (prompt, check_response)) + response

--- a/trulens_eval/trulens_eval/feedback/provider/bedrock.py
+++ b/trulens_eval/trulens_eval/feedback/provider/bedrock.py
@@ -113,7 +113,7 @@ class Bedrock(LLMProvider):
         """
         
         response = self.endpoint.run_in_pace(
-            self._create_chat_completion,
+            func=self._create_chat_completion,
             prompt=
             (system_prompt + user_prompt if user_prompt else system_prompt)
         )
@@ -139,7 +139,7 @@ class Bedrock(LLMProvider):
             The score and reason metadata if available.
         """
         response = self.endpoint.run_in_pace(
-            self._create_chat_completion,
+            func=self._create_chat_completion,
             prompt=
             (system_prompt + user_prompt if user_prompt else system_prompt)
         )

--- a/trulens_eval/trulens_eval/feedback/provider/bedrock.py
+++ b/trulens_eval/trulens_eval/feedback/provider/bedrock.py
@@ -111,11 +111,11 @@ class Bedrock(LLMProvider):
         Returns:
             The score and reason metadata if available.
         """
-        response = self.endpoint.run_me(
-            lambda: self._create_chat_completion(
-                prompt=
-                (system_prompt + user_prompt if user_prompt else system_prompt)
-            )
+        
+        response = self.endpoint.run_in_pace(
+            self._create_chat_completion,
+            prompt=
+            (system_prompt + user_prompt if user_prompt else system_prompt)
         )
 
         return re_0_10_rating(response) / normalize
@@ -138,11 +138,10 @@ class Bedrock(LLMProvider):
         Returns:
             The score and reason metadata if available.
         """
-        response = self.endpoint.run_me(
-            lambda: self._create_chat_completion(
-                prompt=
-                (system_prompt + user_prompt if user_prompt else system_prompt)
-            )
+        response = self.endpoint.run_in_pace(
+            self._create_chat_completion,
+            prompt=
+            (system_prompt + user_prompt if user_prompt else system_prompt)
         )
         if "Supporting Evidence" in response:
             score = 0.0

--- a/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py
+++ b/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py
@@ -682,7 +682,7 @@ class DummyEndpoint(Endpoint):
     loading_prob: float
     # How much time to indicate as needed to load the model in the above response.
     loading_time: Callable[[], float] = \
-        pydantic.Field(exclude=True, default_factory=lambda: lambda: random.uniform(0.73, 3.7))
+        Field(exclude=True, default_factory=lambda: lambda: random.uniform(0.73, 3.7))
 
     # How often to produce an error response.
     error_prob: float

--- a/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py
+++ b/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py
@@ -274,25 +274,8 @@ class Endpoint(WithClassInfo, SerialModel, SingletonPerName):
         Retries request multiple times if self.retries > 0.
         """
 
-        retries = self.retries + 1
-        retry_delay = 2.0
-
-        while retries > 0:
-            try:
-                self.pace_me()
-                ret = thunk()
-                return ret
-            except Exception as e:
-                retries -= 1
-                logger.error(
-                    f"{self.name} request failed {type(e)}={e}. Retries remaining={retries}."
-                )
-                if retries > 0:
-                    sleep(retry_delay)
-                    retry_delay *= 2
-
-        raise RuntimeError(
-            f"API {self.name} request failed {self.retries+1} time(s)."
+        raise NotImplementedError(
+            "This method is deprecated. Use `run_in_pace` instead."
         )
 
     def _instrument_module(self, mod: ModuleType, method_name: str) -> None:

--- a/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py
+++ b/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py
@@ -17,10 +17,10 @@ from pydantic import Field
 import requests
 
 from trulens_eval.schema import Cost
-from trulens_eval.trulens_eval.utils.pace import Pace
 from trulens_eval.utils.asynchro import desync
 from trulens_eval.utils.asynchro import sync
 from trulens_eval.utils.asynchro import ThunkMaybeAwaitable
+from trulens_eval.utils.pace import Pace
 from trulens_eval.utils.pyschema import safe_getattr
 from trulens_eval.utils.pyschema import WithClassInfo
 from trulens_eval.utils.python import get_first_local_in_call_stack

--- a/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py
+++ b/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py
@@ -249,6 +249,8 @@ class Endpoint(WithClassInfo, SerialModel, SingletonPerName):
         retries = self.retries + 1
         retry_delay = 2.0
 
+        errors = []
+
         while retries > 0:
             try:
                 self.pace_me()
@@ -260,12 +262,13 @@ class Endpoint(WithClassInfo, SerialModel, SingletonPerName):
                 logger.error(
                     f"{self.name} request failed {type(e)}={e}. Retries remaining={retries}."
                 )
+                errors.append(e)
                 if retries > 0:
                     sleep(retry_delay)
                     retry_delay *= 2
 
         raise RuntimeError(
-            f"API {self.name} request failed {self.retries+1} time(s)."
+            f"Endpoint {self.name} request failed {self.retries+1} time(s): \n\t" + ("\n\t".join(map(str, errors)))
         )
     
     def run_me(self, thunk: Thunk[T]) -> T:

--- a/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py
+++ b/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py
@@ -270,8 +270,10 @@ class Endpoint(WithClassInfo, SerialModel, SingletonPerName):
     
     def run_me(self, thunk: Thunk[T]) -> T:
         """
-        Run the given thunk, returning itse output, on pace with the api.
+        DEPRECTED: Run the given thunk, returning itse output, on pace with the api.
         Retries request multiple times if self.retries > 0.
+
+        DEPRECATED: Use `run_in_pace` instead.
         """
 
         raise NotImplementedError(

--- a/trulens_eval/trulens_eval/feedback/provider/openai.py
+++ b/trulens_eval/trulens_eval/feedback/provider/openai.py
@@ -95,8 +95,8 @@ class OpenAI(LLMProvider):
 
     def _moderation(self, text: str):
         # See https://platform.openai.com/docs/guides/moderation/overview .
-        moderation_response = self.endpoint.run_me(
-            lambda: self.endpoint.client.moderations.create(input=text)
+        moderation_response = self.endpoint.run_in_pace(
+            self.endpoint.client.moderations.create, input=text
         )
         return moderation_response.results[0]
 

--- a/trulens_eval/trulens_eval/feedback/provider/openai.py
+++ b/trulens_eval/trulens_eval/feedback/provider/openai.py
@@ -96,7 +96,7 @@ class OpenAI(LLMProvider):
     def _moderation(self, text: str):
         # See https://platform.openai.com/docs/guides/moderation/overview .
         moderation_response = self.endpoint.run_in_pace(
-            self.endpoint.client.moderations.create, input=text
+            func=self.endpoint.client.moderations.create, input=text
         )
         return moderation_response.results[0]
 

--- a/trulens_eval/trulens_eval/utils/pace.py
+++ b/trulens_eval/trulens_eval/utils/pace.py
@@ -1,0 +1,125 @@
+from _thread import LockType
+from collections import deque
+from datetime import datetime
+from datetime import timedelta
+import logging
+from threading import Lock
+import time
+from typing import ClassVar, Deque, Optional
+
+from pydantic import BaseModel
+from pydantic import Field
+
+logger = logging.getLogger(__name__)
+
+class Pace(BaseModel):
+    """
+    Keep a given pace. Calls to `Pace.mark` may block until the pace of its
+    returns is kept to a constraint: the number of returns in the given period
+    of time cannot exceed `marks_per_second * seconds_per_period`. This means
+    the average number of returns in that period is bounded above exactly by
+    `marks_per_second`. some period of time. 
+    """
+
+    # The pace in number of mark returns per second.
+    marks_per_second: float = 1.0
+    
+    # Evaluate pace as overage over this period. Assumes that prior to
+    # construction of this Pace instance, the period did not have any marks
+    # called. The longer this period is, the bigger burst of marks will be
+    # allowed initially and after long periods of no marks.
+    seconds_per_period: float = 60.0
+
+    # The above period as a timedelta.
+    seconds_per_period_timedelta: timedelta = Field(
+        default_factory=lambda: timedelta(seconds=60.0)
+    )
+
+    # Keep track of returns that happened in the last `period` seconds. Store
+    # the datetime at which they expire (they become longer than `period` seconds
+    # old).
+    mark_expirations: Deque[datetime] = Field(default_factory=deque)
+
+    # The maximum number of marks to keep track in the above deque. It will be
+    # set to (seconds_per_period * returns_per_second) so that the average
+    # returns per second over period is no more than exactly returns_per_second.
+    max_marks: int
+    
+    # Time of the last mark return.
+    last_mark: datetime = Field(default_factory=datetime.now)
+
+    # Thread Lock to ensure mark content runs only one at a time.
+    lock: LockType = Field(default_factory=Lock)
+
+    model_config: ClassVar[dict] = dict(
+        arbitrary_types_allowed=True
+    )
+
+    def __init__(
+        self,
+        seconds_per_period: float,
+        *args,
+        marks_per_second: Optional[float] = None,
+        rpm: Optional[float] = None,
+        **kwargs
+    ):
+        
+        if marks_per_second is None:
+            assert rpm is not None, "Either `marks_per_second` or `rpm` must be given."
+            marks_per_second = rpm / 60.0
+        else:
+            assert rpm is None, "Only one of `marks_per_second` or `rpm` can be given."
+
+        max_marks = int(seconds_per_period * marks_per_second)
+        if max_marks == 0:
+            raise ValueError(
+                "Period is too short for the give rate. "
+                "Increase `seconds_per_period` or `returns_per_second` (or both)."
+            )
+
+        super().__init__(
+            *args,
+            seconds_per_period=seconds_per_period,
+            seconds_per_period_timedelta = timedelta(seconds=seconds_per_period),
+            marks_per_second=marks_per_second,
+            max_marks=max_marks,
+            **kwargs
+        )
+
+    
+    def mark(self) -> float:
+        """
+        Return in appropriate pace. Blocks until return can happen in the
+        appropriate pace. Returns time in seconds since last mark returned.
+        """
+
+        with self.lock:
+    
+            while len(self.mark_expirations) >= self.max_marks:
+                delay = (self.mark_expirations[0] - datetime.now()).total_seconds()
+
+                if delay >= self.seconds_per_period * 0.5:
+                    logger.warning(f"""
+Pace has a long delay of {delay} seconds. There might have been a burst of
+requests which may become a problem for the receiver of whatever is being paced.
+Consider reducing the `seconds_per_period` (currently {self.seconds_per_period} [seconds]) over which to
+maintain pace to reduce burstiness. " Alternatively reduce `marks_per_second`
+(currently {self.marks_per_second} [1/second]) to reduce the number of marks
+per second in that period. 
+"""
+                    )
+
+                if delay > 0.0:
+                    time.sleep(delay)
+
+                self.marks.popleft()
+    
+            prior_last_mark = self.last_mark
+            now = datetime.now()
+            self.last_mark = now
+
+            # Add to marks the point at which the mark can be removed (after
+            # `period` seconds).
+            self.mark_expirations.append(now + self.seconds_per_period_timedelta)
+
+            return (now - prior_last_mark).total_seconds()

--- a/trulens_eval/trulens_eval/utils/pace.py
+++ b/trulens_eval/trulens_eval/utils/pace.py
@@ -112,7 +112,7 @@ per second in that period.
                 if delay > 0.0:
                     time.sleep(delay)
 
-                self.marks.popleft()
+                self.mark_expirations.popleft()
     
             prior_last_mark = self.last_mark
             now = datetime.now()


### PR DESCRIPTION
The endpoint pacing mechanism used threads meaning one was allocated for each endpoint which induced a bunch of overhead. Replaced the threaded mechanism that does not use a separate thread.

Also replaced `run_me` that operated on thunks with `run_in_pace` that operates functions and its args. This means we don't have to wrap everything with lambdas and reduces the number of frames in the call stack.