### PR TITLE
Ensure agreement prompt outputs integer score only

### DIFF
--- a/trulens_eval/trulens_eval/feedback/prompts.py
+++ b/trulens_eval/trulens_eval/feedback/prompts.py
@@ -79,7 +79,7 @@ The expected answer is:
 
 Answer only with an integer from 1 to 10 based on how semantically similar the responses are to the expected answer. 
 where 0 is no semantic similarity at all and 10 is perfect agreement between the responses and the expected answer.
-Never elaborate.
+On a NEW LINE, give the integer score and nothing more.
 """
 
 REMOVE_Y_N = " If so, respond Y. If not, respond N."


### PR DESCRIPTION
Addressing issue: https://github.com/truera/trulens/issues/862

TODO: add test