### PR TITLE
check packages on init

### DIFF
--- a/trulens_eval/trulens_eval/__init__.py
+++ b/trulens_eval/trulens_eval/__init__.py
@@ -90,6 +90,12 @@ TO PLACE
 
 __version__ = "0.23.0"
 
+# This check is intentionally done ahead of the other imports as we want to
+# print out a nice warning/error before an import error happens further down
+# this sequence.
+from trulens_eval.utils.imports import check_imports
+check_imports()
+
 from trulens_eval.feedback import Feedback
 from trulens_eval.feedback import Langchain
 from trulens_eval.feedback.provider import Provider

--- a/trulens_eval/trulens_eval/tru.py
+++ b/trulens_eval/trulens_eval/tru.py
@@ -14,8 +14,8 @@ import sys
 import threading
 from threading import Thread
 from time import sleep
-from typing import (Any, Callable, Dict, Iterable, List, Optional,
-                    Sequence, Tuple, Union)
+from typing import (Any, Callable, Dict, Iterable, List, Optional, Sequence,
+                    Tuple, Union)
 import warnings
 
 import humanize
@@ -29,6 +29,7 @@ from trulens_eval import db
 from trulens_eval import schema
 from trulens_eval.database import sqlalchemy_db
 from trulens_eval.feedback import feedback
+from trulens_eval.utils import imports
 from trulens_eval.utils import notebook_utils
 from trulens_eval.utils import python
 from trulens_eval.utils import serial
@@ -144,22 +145,22 @@ class Tru(python.SingletonPerName):
         self,
         database_url: Optional[str] = None,
         database_file: Optional[str] = None,
-        database_redact_keys: bool = False
+        database_redact_keys: bool = False,
     ):
 
         if python.safe_hasattr(self, "db"):
             if database_url is not None or database_file is not None:
                 logger.warning(
-                    f"Tru was already initialized. "
-                    f"Cannot change database_url={database_url} "
-                    f"or database_file={database_file} ."
+                    "Tru was already initialized. "
+                    "Cannot change database_url=%s "
+                    "or database_file=%s .", database_url, database_file
                 )
 
             # Already initialized by SingletonByName mechanism.
             return
 
-        assert None in (database_url, database_file), \
-            "Please specify at most one of `database_url` and `database_file`"
+        if None not in (database_url, database_file):
+            raise ValueError("Please specify at most one of `database_url` and `database_file`")
 
         if database_file:
             warnings.warn(
@@ -191,6 +192,7 @@ class Tru(python.SingletonPerName):
                 "See the `database_redact_keys` option of Tru` to prevent this."
             )
 
+    
     def Chain(
         self,
         chain: langchain.chains.base.Chain,

--- a/trulens_eval/trulens_eval/utils/imports.py
+++ b/trulens_eval/trulens_eval/utils/imports.py
@@ -105,17 +105,26 @@ dependencies get installed and hopefully corrected:
         except DistributionNotFound as e:
             if is_optional:
                 logger.debug("""
-    Optional %s is not installed. Optional functionality will not be
-    available.
-    """, req.project_name
+Optional package %s is not installed. Related optional functionality will not be
+available.
+""", req.project_name
         )
 
             else:
                 raise ModuleNotFoundError(f"""
-Required package {req.project_name} is not installed. Please install it with:
-```bash
-pip install '{req}'
-```
+Required package {req.project_name} is not installed. Please install it with pip:
+
+    ```bash
+    pip install '{req}'
+    ```
+
+If your distribution is in a bad place beyond this package, you may need to
+reinstall trulens_eval so that all of the dependencies get installed:
+    
+    ```bash
+    pip uninstall -y trulens_eval
+    pip install trulens_eval
+    ```
 """) from e
 
 

--- a/trulens_eval/trulens_eval/utils/imports.py
+++ b/trulens_eval/trulens_eval/utils/imports.py
@@ -13,6 +13,10 @@ from pprint import PrettyPrinter
 from typing import Any, Dict, Optional, Sequence, Type, Union
 
 import pkg_resources
+from pkg_resources import DistributionNotFound
+from pkg_resources import get_distribution
+from pkg_resources import VersionConflict
+
 
 from trulens_eval import __name__ as trulens_name
 
@@ -39,6 +43,80 @@ optional_packages = requirements_of_file(
 )
 
 all_packages = {**required_packages, **optional_packages}
+
+
+def check_imports(ignore_version_mismatch: bool = False):
+    """Check required and optional package versions.
+
+    Args:
+        ignore_version_mismatch: If set, will not raise an error if a
+            version mismatch is found in a required package. Regardless of
+            this setting, mismatch in an optional package is a warning.
+    """
+
+    for n, req in all_packages.items():
+        is_optional = n in optional_packages
+
+        try:
+            get_distribution(req)
+
+        except VersionConflict as e:
+            
+            message = f"Package {req.project_name} is installed but has a version conflict:\n\t{e}\n"
+
+            if is_optional:
+                message += f"""
+This package is optional for trulens_eval so this may not be a problem but if
+you need to use the related optional features and find there are errors, you
+will need to resolve the conflict:
+
+    ```bash
+    pip install '{req}'
+    ```
+"""
+
+            else:
+                message += f"""
+This package is required for trulens_eval. Please resolve the conflict by
+installing a compatible version with:
+
+    ```bash
+    pip install '{req}'
+    ```
+"""
+                
+            message += """
+If you are running trulens_eval in a notebook, you may need to restart the
+kernel after resolving the conflict. If your distribution is in a bad place
+beyond this package, you may need to reinstall trulens_eval so that all of the
+dependencies get installed and hopefully corrected:
+    
+    ```bash
+    pip uninstall -y trulens_eval
+    pip install trulens_eval
+    ```
+"""
+
+            if (not is_optional) and (not ignore_version_mismatch):
+                raise VersionConflict(message) from e
+            else:
+                logger.warning(message)
+
+        except DistributionNotFound as e:
+            if is_optional:
+                logger.debug("""
+    Optional %s is not installed. Optional functionality will not be
+    available.
+    """, req.project_name
+        )
+
+            else:
+                raise ModuleNotFoundError(f"""
+Required package {req.project_name} is not installed. Please install it with:
+```bash
+pip install '{req}'
+```
+""") from e
 
 
 def pin_spec(r: pkg_resources.Requirement) -> pkg_resources.Requirement:
@@ -86,7 +164,7 @@ def format_import_errors(
             requirements.append(str(all_packages[pkg]))
             requirements_pinned.append(str(pin_spec(all_packages[pkg])))
         else:
-            print(f"WARNING: package {pkg} not present in requirements.")
+            logger.warning("Package %s not present in requirements.", pkg)
             requirements.append(pkg)
 
     packs = ','.join(packages)
@@ -100,7 +178,9 @@ def format_import_errors(
 {','.join(packages)} {pack_s} {is_are} required for {purpose}.
 You should be able to install {it_them} with pip:
 
+    ```bash
     pip install {' '.join(map(lambda a: f'"{a}"', requirements))}
+    ```
 """
     )
 
@@ -110,11 +190,15 @@ You have {packs} installed but we could not import the required
 components. There may be a version incompatibility. Please try installing {this_these}
 exact {pack_s} with pip: 
 
-  pip install {' '.join(map(lambda a: f'"{a}"', requirements_pinned))}
+    ```bash
+    pip install {' '.join(map(lambda a: f'"{a}"', requirements_pinned))}
+    ```
 
 Alternatively, if you do not need {packs}, uninstall {it_them}:
 
-  pip uninstall '{' '.join(packages)}'
+    ```bash
+    pip uninstall '{' '.join(packages)}'
+    ```
 """
     )
 


### PR DESCRIPTION
Added checking for installed packages to main `__init__` so we can catch problems before hard-to-debug errors arise.

If a user does not have a required package installed, an error is raised:

```
ModuleNotFoundError: 
Required package langchain is not installed. Please install it with pip:

    ```bash
    pip install 'langchain>=0.0.354'
    ```

If your distribution is in a bad place beyond this package, you may need to
reinstall trulens_eval so that all of the dependencies get installed:
    
    ```bash
    pip uninstall -y trulens_eval
    pip install trulens_eval
    ```
```

If a user has a required package installed but it is of a wrong version, this error is raised:

```
VersionConflict: Package langchain is installed but has a version conflict:
	(langchain 0.0.353 (/opt/homebrew/Caskroom/miniconda/base/envs/py311_trulens/lib/python3.11/site-packages), Requirement.parse('langchain>=0.0.354'))

This package is required for trulens_eval. Please resolve the conflict by
installing a compatible version with:

    ```bash
    pip install 'langchain>=0.0.354'
    ```

If you are running trulens_eval in a notebook, you may need to restart the
kernel after resolving the conflict. If your distribution is in a bad place
beyond this package, you may need to reinstall trulens_eval so that all of the
dependencies get installed and hopefully corrected:
    
    ```bash
    pip uninstall -y trulens_eval
    pip install trulens_eval
    ```
```

If a user has an optional package with a version conflict, a warning is printed:
```
Package llama-index is installed but has a version conflict:
	(llama-index 0.10.9 (/opt/homebrew/Caskroom/miniconda/base/envs/py311_trulens/lib/python3.11/site-packages), Requirement.parse('llama-index<0.10.0,>=0.9.26'))

This package is optional for trulens_eval so this may not be a problem but if
you need to use the related optional features and find there are errors, you
will need to resolve the conflict:

    ```bash
    pip install 'llama-index<0.10.0,>=0.9.26'
    ```

If you are running trulens_eval in a notebook, you may need to restart the
kernel after resolving the conflict. If your distribution is in a bad place
beyond this package, you may need to reinstall trulens_eval so that all of the
dependencies get installed and hopefully corrected:
    
    ```bash
    pip uninstall -y trulens_eval
    pip install trulens_eval
    ```
```

If a user does not have an optional package, only debug-level message is printed (not visible by default):

```
Optional package llama-index is not installed. Related optional functionality will not be
available.
```