### PR TITLE
Better selection of main input/output

### DIFF
--- a/trulens_eval/trulens_eval/app.py
+++ b/trulens_eval/trulens_eval/app.py
@@ -666,8 +666,24 @@ class App(AppDefinition, WithInstrumentCallbacks, Hashable):
         raise NotImplementedError()
 
     def _extract_content(self, value):
+        """
+        Extracts the 'content' from various data types commonly used by libraries
+        like OpenAI, Canopy, LiteLLM, etc. This method navigates nested data
+        structures (pydantic models, dictionaries, lists) to retrieve the
+        'content' field. If 'content' is not directly available, it attempts to
+        extract from known structures like 'choices' in a ChatResponse. This
+        standardizes extracting relevant text or data from complex API responses
+        or internal data representations.
+        
+        Args:
+            value: The input data to extract content from. Can be a pydantic
+                   model, dictionary, list, or basic data type.
+        
+        Returns:
+            The extracted content, which may be a single value, a list of values,
+            or a nested structure with content extracted from all levels.
+        """
         if isinstance(value, pydantic.BaseModel):
-            # Check for 'content' attribute directly
             content = getattr(value, 'content', None)
             if content is not None:
                 return content

--- a/trulens_eval/trulens_eval/app.py
+++ b/trulens_eval/trulens_eval/app.py
@@ -761,11 +761,11 @@ class App(AppDefinition, WithInstrumentCallbacks, Hashable):
             return str(focus)
 
         logger.warning(
-            "Could not determine main input string call to %s with args %s.",
-            callable_name(func), all_args
+            "Could not determine main input/output of %s.",
+            str(all_args)
         )
 
-        return ""
+        return "Could not determine main input from " + str(all_args)
 
     def main_output(
         self, func: Callable, sig: Signature, bindings: BoundArguments, ret: Any
@@ -792,13 +792,11 @@ class App(AppDefinition, WithInstrumentCallbacks, Hashable):
             if len(content) > 0:
                 return str(content[0])
             else:
-                return ""
+                return "Could not determine main output from " + str(content)
 
         else:
-            logger.warning(
-                f"Unsure what the main output string is for the call to {callable_name(func)} with return type {type(content)}."
-            )
-            return str(content) if content is not None else ""
+            logger.warning("Could not determine main output from %s.", content)
+            return str(content) if content is not None else "Could not determine main output from " + str(content)
 
     # WithInstrumentCallbacks requirement
     def on_method_instrumented(self, obj: object, func: Callable, path: Lens):

--- a/trulens_eval/trulens_eval/app.py
+++ b/trulens_eval/trulens_eval/app.py
@@ -734,7 +734,7 @@ class App(AppDefinition, WithInstrumentCallbacks, Hashable):
             focus = self._extract_content(focus)
 
             if not isinstance(focus, Sequence):
-                print(f"focus {focus} is not a sequence")
+                logger.warning(f"focus {focus} is not a sequence")
                 break
 
         if isinstance(focus, JSON_BASES):
@@ -754,7 +754,7 @@ class App(AppDefinition, WithInstrumentCallbacks, Hashable):
             focus = self._extract_content(focus)
 
             if not isinstance(focus, Sequence):
-                print(f"focus {focus} is not a sequence")
+                logger.warning(f"focus {focus} is not a sequence")
                 break
 
         if isinstance(focus, JSON_BASES):


### PR DESCRIPTION
This change better extracts the content from main_input and main_output to both display in the TruLens UI and use for helper methods such as `.on_input()` and `.on_output()`. Particularly, this change looks for content following the OpenAI pattern, e.g.

Inputs such as:

```
'{
     "model": "gpt-3.5-turbo",
     "messages": [{"role": "user", "content": "Say this is a test!"}],
     "temperature": 0.7
   }'
```

And outputs such as:

```
{
    "id": "chatcmpl-abc123",
    "object": "chat.completion",
    "created": 1677858242,
    "model": "gpt-3.5-turbo-0613",
    "usage": {
        "prompt_tokens": 13,
        "completion_tokens": 7,
        "total_tokens": 20
    },
    "choices": [
        {
            "message": {
                "role": "assistant",
                "content": "\n\nThis is a test!"
            },
            "logprobs": null,
            "finish_reason": "stop",
            "index": 0
        }
    ]
}
```

Notice in both cases, the text we actually care about is located as the value for the key, `content`. This pattern is widely used and adopted by frameworks such as Pinecone's `Canopy` and middleware such as `LiteLLM`.

See an example of this change below:

**Example 1: Pinecone Canopy**

Before:
This warning in notebook:
```
Unsure what the main input string is for the call to chat with args [[UserMessage(role=<Role.USER: 'user'>, content='How can you get started with Pinecone and TruLens?')]].
Unsure what the main output string is for the call to chat with return type <class 'canopy.models.api_models.ChatResponse'>.
```
And
![Screenshot 2024-02-26 at 5 13 55 PM](https://github.com/truera/trulens/assets/60949774/12abd52c-6190-4600-9675-74e292a3e012)


After:
![Screenshot 2024-02-26 at 5 12 05 PM](https://github.com/truera/trulens/assets/60949774/c8fb70f7-ec43-4a96-b996-8256b45055ce)

**Example 2: OpenAI**

Before:
![Screenshot 2024-02-27 at 2 47 18 PM](https://github.com/truera/trulens/assets/60949774/182a530b-9c41-4109-be0f-934c82f3421f)

After:

![Screenshot 2024-02-27 at 2 49 28 PM](https://github.com/truera/trulens/assets/60949774/7790a143-d2bb-4595-8576-32455b9b8b57)

