### PR TITLE
Fix TruChain instrumentation issue introduced in 0.24.1

### DIFF
--- a/trulens_eval/trulens_eval/tru_chain.py
+++ b/trulens_eval/trulens_eval/tru_chain.py
@@ -90,7 +90,7 @@ class LangChainInstrument(Instrument):
                 ("save_context", "clear"):
                     BaseMemory,
                 (
-                    "run", "arun", "_call", "__call__", "_acall", "acall", "invoke", "ainvoke"
+                    "run", "arun", "_call", "__call__", "_acall", "acall"
                 ):
                     Chain,
                 (


### PR DESCRIPTION
In 0.24.1, `invoke` and `ainvoke` were added as instrumented methods for `BaseMemory`. This change seems to override the instrumentation of those methods for `RunnableSerializable`

Before:
<img width="1268" alt="Screenshot 2024-03-08 at 7 51 35 AM" src="https://github.com/truera/trulens/assets/60949774/574d1452-b005-4324-91c7-2e4e9e780b63">
<img width="1292" alt="Screenshot 2024-03-08 at 7 51 30 AM" src="https://github.com/truera/trulens/assets/60949774/bcd8e93b-3049-41cc-8f58-aea57dc83e32">

After:
<img width="1284" alt="Screenshot 2024-03-08 at 7 44 19 AM" src="https://github.com/truera/trulens/assets/60949774/50171ea2-70b0-4692-a781-f7eb6216b078">
<img width="1268" alt="Screenshot 2024-03-08 at 7 51 43 AM" src="https://github.com/truera/trulens/assets/60949774/a7931341-5934-4be0-928e-b7becab3dfd9">
