### PR TITLE
Adds Azure Quickstart for LangChain

### DIFF
--- a/trulens_eval/examples/expositional/models/azure_openai_langchain.ipynb
+++ b/trulens_eval/examples/expositional/models/azure_openai_langchain.ipynb
@@ -29,7 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#! pip install trulens-eval==0.25.0 llama-index==0.10.17 langchain==0.1.11 chromadb==0.4.24 langchainhub bs4==0.0.2 langchain-openai==0.0.8 ipytree==0.2.2"
+    "#! pip install trulens-eval==0.25.1 llama-index==0.10.17 langchain==0.1.11 chromadb==0.4.24 langchainhub bs4==0.0.2 langchain-openai==0.0.8 ipytree==0.2.2"
    ]
   },
   {

--- a/trulens_eval/examples/expositional/models/azure_openai_langchain.ipynb
+++ b/trulens_eval/examples/expositional/models/azure_openai_langchain.ipynb
@@ -1,0 +1,500 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Azure OpenAI LangChain Quickstart\n",
+    "\n",
+    "In this quickstart you will create a simple LangChain App and learn how to log it and get feedback on an LLM response using both an embedding and chat completion model from Azure OpenAI.\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/truera/trulens/blob/main/trulens_eval/examples/expositional/models/azure_openai_langchain.ipynb)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "### Install dependencies\n",
+    "Let's install some of the dependencies for this notebook if we don't have them already"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#! pip install trulens-eval==0.25.0 llama-index==0.10.17 langchain==0.1.11 chromadb==0.4.24 langchainhub bs4==0.0.2 langchain-openai==0.0.8 ipytree==0.2.2"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Add API keys\n",
+    "For this quickstart, you will need a larger set of information from Azure OpenAI compared to typical OpenAI usage. These can be retrieved from https://oai.azure.com/ . Deployment name below is also found on the oai azure page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check your https://oai.azure.com dashboard to retrieve params:\n",
+    "\n",
+    "import os\n",
+    "os.environ[\"AZURE_OPENAI_API_KEY\"] = \"...\" # azure\n",
+    "os.environ[\"AZURE_OPENAI_ENDPOINT\"] = \"https://<your endpoint here>.openai.azure.com/\" # azure\n",
+    "os.environ[\"OPENAI_API_VERSION\"] = \"2023-07-01-preview\" # may need updating\n",
+    "os.environ[\"OPENAI_API_TYPE\"] = \"azure\""
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Import from TruLens"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Imports main tools:\n",
+    "from trulens_eval import TruChain, Feedback, Tru\n",
+    "tru = Tru()\n",
+    "tru.reset_database()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create Simple LLM Application\n",
+    "\n",
+    "This example uses LangChain and is set to use Azure OpenAI LLM & Embedding Models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import bs4 \n",
+    "\n",
+    "# Langchain imports\n",
+    "from langchain import hub\n",
+    "from langchain.document_loaders import WebBaseLoader\n",
+    "from langchain.schema import StrOutputParser\n",
+    "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
+    "from langchain.vectorstores import Chroma\n",
+    "from langchain_core.runnables import RunnablePassthrough\n",
+    "\n",
+    "# Imports Azure LLM & Embedding from LangChain\n",
+    "from langchain_openai import AzureChatOpenAI\n",
+    "from langchain_openai import AzureOpenAIEmbeddings\n",
+    "\n",
+    "import logging\n",
+    "import sys\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define the LLM & Embedding Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get model from Azure\n",
+    "llm = AzureChatOpenAI(\n",
+    "    model=\"gpt-35-turbo\",\n",
+    "    deployment_name=\"<your azure deployment name>\", # Replace this with your azure deployment name\n",
+    "    api_key=os.environ[\"AZURE_OPENAI_API_KEY\"],\n",
+    "    azure_endpoint=os.environ[\"AZURE_OPENAI_ENDPOINT\"],\n",
+    "    api_version=os.environ[\"OPENAI_API_VERSION\"],\n",
+    ")\n",
+    "\n",
+    "# You need to deploy your own embedding model as well as your own chat completion model\n",
+    "embed_model = AzureOpenAIEmbeddings(\n",
+    "    azure_deployment=\"soc-text\",\n",
+    "    api_key=os.environ[\"AZURE_OPENAI_API_KEY\"],\n",
+    "    azure_endpoint=os.environ[\"AZURE_OPENAI_ENDPOINT\"],\n",
+    "    api_version=os.environ[\"OPENAI_API_VERSION\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load Doc & Split & Create Vectorstore\n",
+    "#### 1. Load the Document"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load a sample document\n",
+    "loader = WebBaseLoader(\n",
+    "    web_paths=(\"http://paulgraham.com/worked.html\",),\n",
+    ")\n",
+    "docs = loader.load()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 2. Split the Document"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define a text splitter\n",
+    "text_splitter = RecursiveCharacterTextSplitter(\n",
+    "    chunk_size=1000,\n",
+    "    chunk_overlap=200\n",
+    ")\n",
+    "\n",
+    "# Apply text splitter to docs\n",
+    "splits = text_splitter.split_documents(docs)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 3. Create a Vectorstore"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a vectorstore from splits\n",
+    "vectorstore = Chroma.from_documents(\n",
+    "    documents=splits,\n",
+    "    embedding=embed_model\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create a RAG Chain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "retriever = vectorstore.as_retriever()\n",
+    "\n",
+    "prompt = hub.pull(\"rlm/rag-prompt\")\n",
+    "llm = llm\n",
+    "\n",
+    "def format_docs(docs):\n",
+    "    return \"\\n\\n\".join(doc.page_content for doc in docs)\n",
+    "\n",
+    "rag_chain = (\n",
+    "    {\"context\": retriever | format_docs, \"question\": RunnablePassthrough()}\n",
+    "    | prompt\n",
+    "    | llm\n",
+    "    | StrOutputParser()\n",
+    ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Send your first request"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"What is most interesting about this essay?\"\n",
+    "answer = rag_chain.invoke(query)\n",
+    "\n",
+    "print(\"query was:\", query)\n",
+    "print(\"answer was:\", answer)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize Feedback Function(s)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens_eval.feedback.provider import AzureOpenAI\n",
+    "from trulens_eval.feedback import Groundedness\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "# Initialize AzureOpenAI-based feedback function collection class:\n",
+    "azopenai = AzureOpenAI(\n",
+    "     # Replace this with your azure deployment name\n",
+    "    deployment_name=\"<your azure deployment name>\")\n",
+    "\n",
+    "\n",
+    "# select context to be used in feedback. the location of context is app specific.\n",
+    "from trulens_eval.app import App\n",
+    "context = App.select_context(rag_chain)\n",
+    "\n",
+    "\n",
+    "# Question/answer relevance between overall question and answer.\n",
+    "f_qa_relevance = Feedback(\n",
+    "    azopenai.relevance, \n",
+    "    name = \"Answer Relevance\"\n",
+    "    ).on_input_output()\n",
+    "\n",
+    "# Question/statement relevance between question and each context chunk.\n",
+    "f_qs_relevance = Feedback(\n",
+    "    azopenai.qs_relevance_with_cot_reasons, name = \"Context Relevance\").on_input().on(context).aggregate(np.mean)\n",
+    "\n",
+    "# groundedness of output on the context\n",
+    "groundedness = Groundedness(groundedness_provider=azopenai)\n",
+    "\n",
+    "f_groundedness = (Feedback(groundedness.groundedness_measure_with_cot_reasons, name = \"Groundedness\")\n",
+    "    .on(context.collect())\n",
+    "    .on_output()\n",
+    "    .aggregate(groundedness.grounded_statements_aggregator)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom functions can also use the Azure provider"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Tuple, Dict\n",
+    "from trulens_eval.feedback import prompts\n",
+    "\n",
+    "from trulens_eval.utils.generated import re_0_10_rating\n",
+    "\n",
+    "class Custom_AzureOpenAI(AzureOpenAI):\n",
+    "    def style_check_professional(self, response: str) -> float:\n",
+    "        \"\"\"\n",
+    "        Custom feedback function to grade the professional style of the resposne, extending AzureOpenAI provider.\n",
+    "\n",
+    "        Args:\n",
+    "            response (str): text to be graded for professional style.\n",
+    "\n",
+    "        Returns:\n",
+    "            float: A value between 0 and 1. 0 being \"not professional\" and 1 being \"professional\".\n",
+    "        \"\"\"\n",
+    "        professional_prompt = str.format(\"Please rate the professionalism of the following text on a scale from 0 to 10, where 0 is not at all professional and 10 is extremely professional: \\n\\n{}\", response)\n",
+    "        return self.generate_score(system_prompt=professional_prompt)\n",
+    "    \n",
+    "    def qs_relevance_with_cot_reasons_extreme(self, question: str, statement: str) -> Tuple[float, Dict]:\n",
+    "        \"\"\"\n",
+    "        Tweaked version of question statement relevance, extending AzureOpenAI provider.\n",
+    "        A function that completes a template to check the relevance of the statement to the question.\n",
+    "        Scoring guidelines for scores 5-8 are removed to push the LLM to more extreme scores.\n",
+    "        Also uses chain of thought methodology and emits the reasons.\n",
+    "\n",
+    "        Args:\n",
+    "            question (str): A question being asked. \n",
+    "            statement (str): A statement to the question.\n",
+    "\n",
+    "        Returns:\n",
+    "            float: A value between 0 and 1. 0 being \"not relevant\" and 1 being \"relevant\".\n",
+    "        \"\"\"\n",
+    "\n",
+    "        system_prompt = str.format(prompts.CONTEXT_RELEVANCE, question = question, statement = statement)\n",
+    "\n",
+    "        # remove scoring guidelines around middle scores\n",
+    "        system_prompt = system_prompt.replace(\n",
+    "    \"- STATEMENT that is RELEVANT to most of the QUESTION should get a score of 5, 6, 7 or 8. Higher score indicates more RELEVANCE.\\n\\n\", \"\")\n",
+    "        \n",
+    "        system_prompt = system_prompt.replace(\n",
+    "            \"RELEVANCE:\", prompts.COT_REASONS_TEMPLATE\n",
+    "        )\n",
+    "\n",
+    "        return self.generate_score_and_reasons(system_prompt)\n",
+    "    \n",
+    "# Add your Azure deployment name\n",
+    "custom_azopenai = Custom_AzureOpenAI(deployment_name=\"<your azure deployment name>\")\n",
+    "    \n",
+    "# Question/statement relevance between question and each context chunk.\n",
+    "f_qs_relevance_extreme = (\n",
+    "    Feedback(custom_azopenai.qs_relevance_with_cot_reasons_extreme, name = \"Context Relevance - Extreme\")\n",
+    "    .on_input()\n",
+    "    .on(context)\n",
+    "    .aggregate(np.mean)\n",
+    ")\n",
+    "\n",
+    "f_style_check = (\n",
+    "    Feedback(custom_azopenai.style_check_professional, name = \"Professional Style\")\n",
+    "    .on_output()\n",
+    ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Instrument chain for logging with TruLens"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tru_query_engine_recorder = TruChain(rag_chain,\n",
+    "    llm=azopenai,\n",
+    "    app_id='LangChain_App1_AzureOpenAI',\n",
+    "    feedbacks=[f_groundedness, f_qa_relevance, f_qs_relevance, f_qs_relevance_extreme, f_style_check])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"What is most interesting about this essay?\"\n",
+    "with tru_query_engine_recorder as recording:\n",
+    "    answer = rag_chain.invoke(query)\n",
+    "    print(\"query was:\", query)\n",
+    "    print(\"answer was:\", answer)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Explore in a Dashboard"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tru.run_dashboard() # open a local streamlit app to explore\n",
+    "\n",
+    "# tru.stop_dashboard() # stop if needed"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, you can run `trulens-eval` from a command line in the same folder to start the dashboard."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Or view results directly in your notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "records, feedback = tru.get_records_and_feedback(app_ids=['LangChain_App1_AzureOpenAI']) # pass an empty list of app_ids to get all\n",
+    "\n",
+    "records"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tru.get_leaderboard(app_ids=['LangChain_App1_AzureOpenAI'])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.11.4 ('agents')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.8"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "7d153714b979d5e6d08dd8ec90712dd93bff2c9b6c1f0c118169738af3430cd4"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/trulens_eval/examples/expositional/models/azure_openai_llama_index.ipynb
+++ b/trulens_eval/examples/expositional/models/azure_openai_llama_index.ipynb
@@ -5,11 +5,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Azure OpenAI\n",
+    "# Azure OpenAI Llama Index Quickstart\n",
     "\n",
     "In this quickstart you will create a simple Llama Index App and learn how to log it and get feedback on an LLM response using both an embedding and chat completion model from Azure OpenAI.\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/truera/trulens/blob/main/trulens_eval/examples/expositional/models/azure_openai.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/truera/trulens/blob/main/trulens_eval/examples/expositional/models/azure_openai_llama_index.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
Updates `/examples/expositional/models` to contain two quickstart versions for the Azure OpenAI API:

- `azure_openai_langchain` (addition of a new quickstart)
- `azure_openai_llama_index`(renames to differentiate between the two quickstarts)