### PR TITLE
doc usage formatting

### DIFF
--- a/trulens_eval/trulens_eval/db.py
+++ b/trulens_eval/trulens_eval/db.py
@@ -246,7 +246,7 @@ class DB(SerialModel, abc.ABC):
         
         Args:
             app_ids: If given, retrieve only the records for the given apps.
-            Otherwise all apps are retrieved.
+                Otherwise all apps are retrieved.
         
         Returns:
             A dataframe with the records.

--- a/trulens_eval/trulens_eval/db.py
+++ b/trulens_eval/trulens_eval/db.py
@@ -832,3 +832,19 @@ class LocalSQLite(DB):
         combined_df = df_records.merge(df_results, on=['record_id'])
 
         return combined_df, list(result_cols)
+
+    def get_feedback_count_by_status(
+        self,
+        record_id: Optional[RecordID] = None,
+        feedback_result_id: Optional[FeedbackResultID] = None,
+        feedback_definition_id: Optional[FeedbackDefinitionID] = None,
+        status: Optional[Union[FeedbackResultStatus,
+                               Sequence[FeedbackResultStatus]]] = None,
+        last_ts_before: Optional[datetime] = None,
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
+        shuffle: bool = False
+    ) -> Dict[FeedbackResultStatus, int]:
+        
+        raise NotImplementedError("This database implementation is deprecated.")
+    

--- a/trulens_eval/trulens_eval/feedback/embeddings.py
+++ b/trulens_eval/trulens_eval/feedback/embeddings.py
@@ -41,22 +41,23 @@ class Embeddings(WithClassInfo, SerialModel):
         """
         Runs cosine distance on the query and document embeddings
 
-        **Usage:**
-        ```
-        # Below is just one example. See supported embedders: https://gpt-index.readthedocs.io/en/latest/core_modules/model_modules/embeddings/root.html
-        from langchain.embeddings.openai import OpenAIEmbeddings
+        Usage:
+            ```python
+            # Below is just one example. See supported embedders: https://gpt-index.readthedocs.io/en/latest/core_modules/model_modules/embeddings/root.html
+            from langchain.embeddings.openai import OpenAIEmbeddings
 
-        model_name = 'text-embedding-ada-002'
+            model_name = 'text-embedding-ada-002'
 
-        embed_model = OpenAIEmbeddings(
-            model=model_name,
-            openai_api_key=OPENAI_API_KEY
-        )
+            embed_model = OpenAIEmbeddings(
+                model=model_name,
+                openai_api_key=OPENAI_API_KEY
+            )
 
-        # Create the feedback function
-        f_embed = feedback.Embeddings(embed_model=embed_model)
-        f_embed_dist = feedback.Feedback(f_embed.cosine_distance).on_input().on(Select.Record.app.combine_documents_chain._call.args.inputs.input_documents[:].page_content)
-        ```
+            # Create the feedback function
+            f_embed = feedback.Embeddings(embed_model=embed_model)
+            f_embed_dist = feedback.Feedback(f_embed.cosine_distance).on_input().on(Select.Record.app.combine_documents_chain._call.args.inputs.input_documents[:].page_content)
+            ```
+
         The `on(...)` selector can be changed. See [Feedback Function Guide : Selectors](https://www.trulens.org/trulens_eval/feedback_function_guide/#selector-details)
 
         Args:
@@ -90,22 +91,23 @@ class Embeddings(WithClassInfo, SerialModel):
         """
         Runs L1 distance on the query and document embeddings
 
-        **Usage:**
-        ```
-        # Below is just one example. See supported embedders: https://gpt-index.readthedocs.io/en/latest/core_modules/model_modules/embeddings/root.html
-        from langchain.embeddings.openai import OpenAIEmbeddings
+        Usage:
+            ```python
+            # Below is just one example. See supported embedders: https://gpt-index.readthedocs.io/en/latest/core_modules/model_modules/embeddings/root.html
+            from langchain.embeddings.openai import OpenAIEmbeddings
 
-        model_name = 'text-embedding-ada-002'
+            model_name = 'text-embedding-ada-002'
 
-        embed_model = OpenAIEmbeddings(
-            model=model_name,
-            openai_api_key=OPENAI_API_KEY
-        )
+            embed_model = OpenAIEmbeddings(
+                model=model_name,
+                openai_api_key=OPENAI_API_KEY
+            )
 
-        # Create the feedback function
-        f_embed = feedback.Embeddings(embed_model=embed_model)
-        f_embed_dist = feedback.Feedback(f_embed.manhattan_distance).on_input().on(Select.Record.app.combine_documents_chain._call.args.inputs.input_documents[:].page_content)
-        ```
+            # Create the feedback function
+            f_embed = feedback.Embeddings(embed_model=embed_model)
+            f_embed_dist = feedback.Feedback(f_embed.manhattan_distance).on_input().on(Select.Record.app.combine_documents_chain._call.args.inputs.input_documents[:].page_content)
+            ```
+
         The `on(...)` selector can be changed. See [Feedback Function Guide : Selectors](https://www.trulens.org/trulens_eval/feedback_function_guide/#selector-details)
 
         Args:
@@ -139,23 +141,24 @@ class Embeddings(WithClassInfo, SerialModel):
         """
         Runs L2 distance on the query and document embeddings
 
-        **Usage:**
-        ```
-        # Below is just one example. See supported embedders: https://gpt-index.readthedocs.io/en/latest/core_modules/model_modules/embeddings/root.html
-        from langchain.embeddings.openai import OpenAIEmbeddings
+        Usage:
+            ```python
+            # Below is just one example. See supported embedders: https://gpt-index.readthedocs.io/en/latest/core_modules/model_modules/embeddings/root.html
+            from langchain.embeddings.openai import OpenAIEmbeddings
 
-        model_name = 'text-embedding-ada-002'
+            model_name = 'text-embedding-ada-002'
 
-        embed_model = OpenAIEmbeddings(
-            model=model_name,
-            openai_api_key=OPENAI_API_KEY
-        )
+            embed_model = OpenAIEmbeddings(
+                model=model_name,
+                openai_api_key=OPENAI_API_KEY
+            )
 
-        # Create the feedback function
-        f_embed = feedback.Embeddings(embed_model=embed_model)
-        f_embed_dist = feedback.Feedback(f_embed.euclidean_distance).on_input().on(Select.Record.app.combine_documents_chain._call.args.inputs.input_documents[:].page_content)
-        ```
-        The `on(...)` selector can be changed. See [Feedback Function Guide : Selectors](https://www.trulens.org/trulens_eval/feedback_function_guide/#selector-details)
+            # Create the feedback function
+            f_embed = feedback.Embeddings(embed_model=embed_model)
+            f_embed_dist = feedback.Feedback(f_embed.euclidean_distance).on_input().on(Select.Record.app.combine_documents_chain._call.args.inputs.input_documents[:].page_content)
+            ```
+
+            The `on(...)` selector can be changed. See [Feedback Function Guide : Selectors](https://www.trulens.org/trulens_eval/feedback_function_guide/#selector-details)
 
         Args:
             query (str): A text prompt to a vector DB. 

--- a/trulens_eval/trulens_eval/feedback/groundtruth.py
+++ b/trulens_eval/trulens_eval/feedback/groundtruth.py
@@ -137,19 +137,19 @@ class GroundTruthAgreement(WithClassInfo, SerialModel):
         with a prompt that the original response is correct, and measures
         whether previous Chat GPT's response is similar.
 
-        **Usage:**
-        ```
-        from trulens_eval import Feedback
-        from trulens_eval.feedback import GroundTruthAgreement
-        golden_set = [
-            {"query": "who invented the lightbulb?", "response": "Thomas Edison"},
-            {"query": "¿quien invento la bombilla?", "response": "Thomas Edison"}
-        ]
-        ground_truth_collection = GroundTruthAgreement(golden_set)
+        Usage:
+            ```python
+            from trulens_eval import Feedback
+            from trulens_eval.feedback import GroundTruthAgreement
+            golden_set = [
+                {"query": "who invented the lightbulb?", "response": "Thomas Edison"},
+                {"query": "¿quien invento la bombilla?", "response": "Thomas Edison"}
+            ]
+            ground_truth_collection = GroundTruthAgreement(golden_set)
 
-        feedback = Feedback(ground_truth_collection.agreement_measure).on_input_output() 
-        ```
-        The `on_input_output()` selector can be changed. See [Feedback Function Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            feedback = Feedback(ground_truth_collection.agreement_measure).on_input_output() 
+            ```
+            The `on_input_output()` selector can be changed. See [Feedback Function Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Args:
             prompt (str): A text prompt to an agent. 
@@ -179,19 +179,19 @@ class GroundTruthAgreement(WithClassInfo, SerialModel):
 
         Primarily used for evaluation of model generated feedback against human feedback
 
-        **Usage**
-        ```
-        from trulens_eval import Feedback
-        from trulens_eval.feedback import GroundTruthAgreement
+        Usage:
+            ```python
+            from trulens_eval import Feedback
+            from trulens_eval.feedback import GroundTruthAgreement
 
-        golden_set =
-        {"query": "How many stomachs does a cow have?", "response": "Cows' diet relies primarily on grazing.", "expected_score": 0.4},
-        {"query": "Name some top dental floss brands", "response": "I don't know", "expected_score": 0.8}
-        ]
-        ground_truth_collection = GroundTruthAgreement(golden_set)
+            golden_set =
+            {"query": "How many stomachs does a cow have?", "response": "Cows' diet relies primarily on grazing.", "expected_score": 0.4},
+            {"query": "Name some top dental floss brands", "response": "I don't know", "expected_score": 0.8}
+            ]
+            ground_truth_collection = GroundTruthAgreement(golden_set)
 
-        f_groundtruth = Feedback(ground_truth.mae).on(Select.Record.calls[0].args.args[0]).on(Select.Record.calls[0].args.args[1]).on_output()
-        ```
+            f_groundtruth = Feedback(ground_truth.mae).on(Select.Record.calls[0].args.args[0]).on(Select.Record.calls[0].args.args[1]).on_output()
+            ```
 
         """
 
@@ -210,19 +210,19 @@ class GroundTruthAgreement(WithClassInfo, SerialModel):
         Uses BERT Score. A function that that measures
         similarity to ground truth using bert embeddings. 
 
-        **Usage:**
-        ```
-        from trulens_eval import Feedback
-        from trulens_eval.feedback import GroundTruthAgreement
-        golden_set = [
-            {"query": "who invented the lightbulb?", "response": "Thomas Edison"},
-            {"query": "¿quien invento la bombilla?", "response": "Thomas Edison"}
-        ]
-        ground_truth_collection = GroundTruthAgreement(golden_set)
+        Usage:
+            ```python
+            from trulens_eval import Feedback
+            from trulens_eval.feedback import GroundTruthAgreement
+            golden_set = [
+                {"query": "who invented the lightbulb?", "response": "Thomas Edison"},
+                {"query": "¿quien invento la bombilla?", "response": "Thomas Edison"}
+            ]
+            ground_truth_collection = GroundTruthAgreement(golden_set)
 
-        feedback = Feedback(ground_truth_collection.bert_score).on_input_output() 
-        ```
-        The `on_input_output()` selector can be changed. See [Feedback Function Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            feedback = Feedback(ground_truth_collection.bert_score).on_input_output() 
+            ```
+            The `on_input_output()` selector can be changed. See [Feedback Function Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
 
         Args:
@@ -256,19 +256,19 @@ class GroundTruthAgreement(WithClassInfo, SerialModel):
         Uses BLEU Score. A function that that measures
         similarity to ground truth using token overlap. 
 
-        **Usage:**
-        ```
-        from trulens_eval import Feedback
-        from trulens_eval.feedback import GroundTruthAgreement
-        golden_set = [
-            {"query": "who invented the lightbulb?", "response": "Thomas Edison"},
-            {"query": "¿quien invento la bombilla?", "response": "Thomas Edison"}
-        ]
-        ground_truth_collection = GroundTruthAgreement(golden_set)
+        Usage:
+            ```python
+            from trulens_eval import Feedback
+            from trulens_eval.feedback import GroundTruthAgreement
+            golden_set = [
+                {"query": "who invented the lightbulb?", "response": "Thomas Edison"},
+                {"query": "¿quien invento la bombilla?", "response": "Thomas Edison"}
+            ]
+            ground_truth_collection = GroundTruthAgreement(golden_set)
 
-        feedback = Feedback(ground_truth_collection.bleu).on_input_output() 
-        ```
-        The `on_input_output()` selector can be changed. See [Feedback Function Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            feedback = Feedback(ground_truth_collection.bleu).on_input_output() 
+            ```
+            The `on_input_output()` selector can be changed. See [Feedback Function Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Args:
             prompt (str): A text prompt to an agent. 

--- a/trulens_eval/trulens_eval/feedback/provider/base.py
+++ b/trulens_eval/trulens_eval/feedback/provider/base.py
@@ -321,21 +321,20 @@ class LLMProvider(Provider):
         template to check the relevance of the context to the question.
         Also uses chain of thought methodology and emits the reasons.
 
-        **Usage:**
-        Usage on RAG Contexts:
+        Usage:
+            Usage on RAG Contexts:
 
-        ```
-        from trulens_eval.app import App
-        context = App.select_context(rag_app)
-        feedback = (
-            Feedback(provider.context_relevance_with_cot_reasons)
-            .on_input()
-            .on(context)
-            .aggregate(np.mean)
-            )
-        ```
-        The `on(...)` selector can be changed. See [Feedback Function Guide : Selectors](https://www.trulens.org/trulens_eval/feedback_function_guide/#selector-details)
-
+            ```python
+            from trulens_eval.app import App
+            context = App.select_context(rag_app)
+            feedback = (
+                Feedback(provider.context_relevance_with_cot_reasons)
+                .on_input()
+                .on(context)
+                .aggregate(np.mean)
+                )
+            ```
+            The `on(...)` selector can be changed. See [Feedback Function Guide : Selectors](https://www.trulens.org/trulens_eval/feedback_function_guide/#selector-details)
 
         Args:
             question (str): A question being asked. 
@@ -359,20 +358,19 @@ class LLMProvider(Provider):
         template to check the relevance of the context to the question.
         Also uses chain of thought methodology and emits the reasons.
 
-        **Usage:**
-        Usage on RAG Contexts:
-        ```
-        from trulens_eval.app import App
-        context = App.select_context(rag_app)
-        feedback = (
-            Feedback(provider.qs_relevance_with_cot_reasons)
-            .on_input()
-            .on(context)
-            .aggregate(np.mean)
-            )
-        ```
-        The `on(...)` selector can be changed. See [Feedback Function Guide : Selectors](https://www.trulens.org/trulens_eval/feedback_function_guide/#selector-details)
-
+        Usage:
+            Usage on RAG Contexts:
+            ```python
+            from trulens_eval.app import App
+            context = App.select_context(rag_app)
+            feedback = (
+                Feedback(provider.qs_relevance_with_cot_reasons)
+                .on_input()
+                .on(context)
+                .aggregate(np.mean)
+                )
+            ```
+            The `on(...)` selector can be changed. See [Feedback Function Guide : Selectors](https://www.trulens.org/trulens_eval/feedback_function_guide/#selector-details)
 
         Args:
             question (str): A question being asked. 
@@ -401,24 +399,23 @@ class LLMProvider(Provider):
         Uses chat completion model. A function that completes a
         template to check the relevance of the response to a prompt.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.relevance).on_input_output()
-        ```
-        
-        The `on_input_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+        Usage:
+            ```python
+            feedback = Feedback(provider.relevance).on_input_output()
+            ```
+            
+            The `on_input_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Usage on RAG Contexts:
+            ```python
+            feedback = Feedback(provider.relevance).on_input().on(
+                TruLlama.select_source_nodes().node.text # See note below
+            ).aggregate(np.mean) 
+            ```
 
-        ```python
-        feedback = Feedback(provider.relevance).on_input().on(
-            TruLlama.select_source_nodes().node.text # See note below
-        ).aggregate(np.mean) 
-        ```
-
-        The `on(...)` selector can be changed. See [Feedback Function Guide :
-        Selectors](https://www.trulens.org/trulens_eval/feedback_function_guide/#selector-details)
+            The `on(...)` selector can be changed. See [Feedback Function Guide :
+            Selectors](https://www.trulens.org/trulens_eval/feedback_function_guide/#selector-details)
 
         Parameters:
             prompt (str): A text prompt to an agent.
@@ -440,24 +437,24 @@ class LLMProvider(Provider):
         check the relevance of the response to a prompt. Also uses chain of
         thought methodology and emits the reasons.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.relevance_with_cot_reasons).on_input_output()
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.relevance_with_cot_reasons).on_input_output()
+            ```
 
-        The `on_input_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            The `on_input_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Usage on RAG Contexts:
-        ```python
+            ```python
 
-        feedback = Feedback(provider.relevance_with_cot_reasons).on_input().on(
-            TruLlama.select_source_nodes().node.text # See note below
-        ).aggregate(np.mean) 
-        ```
+            feedback = Feedback(provider.relevance_with_cot_reasons).on_input().on(
+                TruLlama.select_source_nodes().node.text # See note below
+            ).aggregate(np.mean) 
+            ```
 
-        The `on(...)` selector can be changed. See [Feedback Function Guide :
-        Selectors](https://www.trulens.org/trulens_eval/feedback_function_guide/#selector-details)
+            The `on(...)` selector can be changed. See [Feedback Function Guide :
+            Selectors](https://www.trulens.org/trulens_eval/feedback_function_guide/#selector-details)
 
         Args:
             prompt (str): A text prompt to an agent. 
@@ -504,14 +501,13 @@ class LLMProvider(Provider):
         template to check the sentiment of some text.
         Also uses chain of thought methodology and emits the reasons.
 
-        **Usage:**
-
-        ```python
-        feedback = Feedback(provider.sentiment_with_cot_reasons).on_output() 
-        ```
-        
-        The `on_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+        Usage:
+            ```python
+            feedback = Feedback(provider.sentiment_with_cot_reasons).on_output() 
+            ```
+            
+            The `on_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Args:
             text (str): Text to evaluate.
@@ -530,14 +526,13 @@ class LLMProvider(Provider):
         is given to the model with a prompt that the original response is
         correct, and measures whether previous chat completion response is similar.
 
-        **Usage:**
+        Usage:
+            ```python
+            feedback = Feedback(provider.model_agreement).on_input_output() 
+            ```
 
-        ```python
-        feedback = Feedback(provider.model_agreement).on_input_output() 
-        ```
-
-        The `on_input_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            The `on_input_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Parameters:
             prompt (str): A text prompt to an agent.
@@ -705,10 +700,10 @@ class LLMProvider(Provider):
         Uses chat completion model. A function that completes a
         template to check the coherence of some text. Prompt credit to Langchain Eval.
         
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.coherence).on_output() 
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.coherence).on_output() 
+            ```
 
         The `on_output()` selector can be changed. See [Feedback Function
         Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
@@ -729,10 +724,10 @@ class LLMProvider(Provider):
         check the coherence of some text. Prompt credit to Langchain Eval. Also
         uses chain of thought methodology and emits the reasons.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.coherence_with_cot_reasons).on_output() 
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.coherence_with_cot_reasons).on_output() 
+            ```
 
         The `on_output()` selector can be changed. See [Feedback Function
         Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
@@ -752,10 +747,10 @@ class LLMProvider(Provider):
         Uses chat completion model. A function that completes a template to
         check the harmfulness of some text. Prompt credit to Langchain Eval.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.harmfulness).on_output() 
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.harmfulness).on_output() 
+            ```
 
         The `on_output()` selector can be changed. See [Feedback Function
         Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
@@ -776,10 +771,11 @@ class LLMProvider(Provider):
         check the harmfulness of some text. Prompt credit to Langchain Eval.
         Also uses chain of thought methodology and emits the reasons.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.harmfulness_with_cot_reasons).on_output() 
-        
+        Usage:
+            ```python
+            feedback = Feedback(provider.harmfulness_with_cot_reasons).on_output()
+            ```
+            
         Args:
             text (str): The text to evaluate.
 
@@ -796,10 +792,10 @@ class LLMProvider(Provider):
         Uses chat completion model. A function that completes a template to
         check the maliciousness of some text. Prompt credit to Langchain Eval.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.maliciousness).on_output() 
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.maliciousness).on_output() 
+            ```
 
         The `on_output()` selector can be changed. See [Feedback Function
         Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)

--- a/trulens_eval/trulens_eval/feedback/provider/base.py
+++ b/trulens_eval/trulens_eval/feedback/provider/base.py
@@ -677,13 +677,13 @@ class LLMProvider(Provider):
         check the correctness of some text. Prompt credit to Langchain Eval.
         Also uses chain of thought methodology and emits the reasons.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.correctness_with_cot_reasons).on_output() 
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.correctness_with_cot_reasons).on_output() 
+            ```
 
-        The `on_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            The `on_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Args:
             text (str): Text to evaluate.
@@ -817,13 +817,13 @@ class LLMProvider(Provider):
         template to check the maliciousness of some text. Prompt credit to Langchain Eval.
         Also uses chain of thought methodology and emits the reasons.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.maliciousness_with_cot_reasons).on_output() 
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.maliciousness_with_cot_reasons).on_output() 
+            ```
 
-        The `on_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            The `on_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Args:
             text (str): The text to evaluate.
@@ -840,13 +840,13 @@ class LLMProvider(Provider):
         Uses chat completion model. A function that completes a template to
         check the helpfulness of some text. Prompt credit to Langchain Eval.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.helpfulness).on_output() 
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.helpfulness).on_output() 
+            ```
 
-        The `on_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            The `on_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Args:
             text (str): The text to evaluate.
@@ -864,13 +864,13 @@ class LLMProvider(Provider):
         check the helpfulness of some text. Prompt credit to Langchain Eval.
         Also uses chain of thought methodology and emits the reasons.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.helpfulness_with_cot_reasons).on_output() 
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.helpfulness_with_cot_reasons).on_output() 
+            ```
 
-        The `on_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            The `on_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Args:
             text (str): The text to evaluate.
@@ -888,13 +888,13 @@ class LLMProvider(Provider):
         check the controversiality of some text. Prompt credit to Langchain
         Eval.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.controversiality).on_output() 
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.controversiality).on_output() 
+            ```
 
-        The `on_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            The `on_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Args:
             text (str): The text to evaluate.
@@ -914,14 +914,14 @@ class LLMProvider(Provider):
         check the controversiality of some text. Prompt credit to Langchain
         Eval. Also uses chain of thought methodology and emits the reasons.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.controversiality_with_cot_reasons).on_output() 
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.controversiality_with_cot_reasons).on_output() 
+            ```
 
-        The `on_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
-        
+            The `on_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            
         Args:
             text (str): The text to evaluate.
 
@@ -937,13 +937,13 @@ class LLMProvider(Provider):
         Uses chat completion model. A function that completes a template to
         check the misogyny of some text. Prompt credit to Langchain Eval.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.misogyny).on_output() 
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.misogyny).on_output() 
+            ```
 
-        The `on_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            The `on_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Args:
             text (str): The text to evaluate.
@@ -961,13 +961,13 @@ class LLMProvider(Provider):
         check the misogyny of some text. Prompt credit to Langchain Eval. Also
         uses chain of thought methodology and emits the reasons.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.misogyny_with_cot_reasons).on_output() 
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.misogyny_with_cot_reasons).on_output() 
+            ```
 
-        The `on_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            The `on_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Args:
             text (str): The text to evaluate.
@@ -984,13 +984,13 @@ class LLMProvider(Provider):
         Uses chat completion model. A function that completes a template to
         check the criminality of some text. Prompt credit to Langchain Eval.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.criminality).on_output()
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.criminality).on_output()
+            ```
 
-        The `on_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            The `on_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Args:
             text (str): The text to evaluate.
@@ -1009,13 +1009,13 @@ class LLMProvider(Provider):
         check the criminality of some text. Prompt credit to Langchain Eval.
         Also uses chain of thought methodology and emits the reasons.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.criminality_with_cot_reasons).on_output()
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.criminality_with_cot_reasons).on_output()
+            ```
 
-        The `on_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            The `on_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Args:
             text (str): The text to evaluate.
@@ -1032,13 +1032,13 @@ class LLMProvider(Provider):
         Uses chat completion model. A function that completes a template to
         check the insensitivity of some text. Prompt credit to Langchain Eval.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.insensitivity).on_output()
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.insensitivity).on_output()
+            ```
 
-        The `on_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            The `on_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Args:
             text (str): The text to evaluate.
@@ -1056,13 +1056,13 @@ class LLMProvider(Provider):
         check the insensitivity of some text. Prompt credit to Langchain Eval.
         Also uses chain of thought methodology and emits the reasons.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.insensitivity_with_cot_reasons).on_output()
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.insensitivity_with_cot_reasons).on_output()
+            ```
 
-        The `on_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            The `on_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Args:
             text (str): The text to evaluate.
@@ -1106,10 +1106,10 @@ class LLMProvider(Provider):
         only has a chain of thought implementation as it is extremely important
         in function assessment.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.comprehensiveness_with_cot_reasons).on_input_output()
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.comprehensiveness_with_cot_reasons).on_input_output()
+            ```
 
         Args:
             source (str): Text corresponding to source material. 
@@ -1141,10 +1141,10 @@ class LLMProvider(Provider):
         check adding assumed stereotypes in the response when not present in the
         prompt.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.stereotypes).on_input_output()
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.stereotypes).on_input_output()
+            ```
 
         Args:
             prompt (str): A text prompt to an agent. 
@@ -1167,10 +1167,10 @@ class LLMProvider(Provider):
         check adding assumed stereotypes in the response when not present in the
         prompt.
 
-        **Usage:**
-        ```python
-        feedback = Feedback(provider.stereotypes).on_input_output()
-        ```
+        Usage:
+            ```python
+            feedback = Feedback(provider.stereotypes).on_input_output()
+            ```
 
         Args:
             prompt (str): A text prompt to an agent. 

--- a/trulens_eval/trulens_eval/feedback/provider/hugs.py
+++ b/trulens_eval/trulens_eval/feedback/provider/hugs.py
@@ -131,16 +131,17 @@ class Huggingface(Provider):
         function is: `1.0 - (|probit_language_text1(text1) -
         probit_language_text1(text2))`
         
-        **Usage:**
-        ```python
-        from trulens_eval import Feedback
-        from trulens_eval.feedback.provider.hugs import Huggingface
-        huggingface_provider = Huggingface()
+        Usage:
+            ```python
+            from trulens_eval import Feedback
+            from trulens_eval.feedback.provider.hugs import Huggingface
+            huggingface_provider = Huggingface()
 
-        feedback = Feedback(huggingface_provider.language_match).on_input_output() 
-        ```
-        The `on_input_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            feedback = Feedback(huggingface_provider.language_match).on_input_output() 
+            ```
+
+            The `on_input_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Args:
             text1 (str): Text to evaluate.
@@ -189,16 +190,17 @@ class Huggingface(Provider):
         Uses Huggingface's cardiffnlp/twitter-roberta-base-sentiment model. A
         function that uses a sentiment classifier on `text`.
         
-        **Usage:**
-        ```python
-        from trulens_eval import Feedback
-        from trulens_eval.feedback.provider.hugs import Huggingface
-        huggingface_provider = Huggingface()
+        Usage:
+            ```python
+            from trulens_eval import Feedback
+            from trulens_eval.feedback.provider.hugs import Huggingface
+            huggingface_provider = Huggingface()
 
-        feedback = Feedback(huggingface_provider.positive_sentiment).on_output() 
-        ```
-        The `on_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            feedback = Feedback(huggingface_provider.positive_sentiment).on_output() 
+            ```
+
+            The `on_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         Args:
             text (str): Text to evaluate.
@@ -229,16 +231,17 @@ class Huggingface(Provider):
         Uses Huggingface's martin-ha/toxic-comment-model model. A function that
         uses a toxic comment classifier on `text`.
         
-        **Usage:**
-        ```python
-        from trulens_eval import Feedback
-        from trulens_eval.feedback.provider.hugs import Huggingface
-        huggingface_provider = Huggingface()
+        Usage:
+            ```python
+            from trulens_eval import Feedback
+            from trulens_eval.feedback.provider.hugs import Huggingface
+            huggingface_provider = Huggingface()
 
-        feedback = Feedback(huggingface_provider.not_toxic).on_output() 
-        ```
-        The `on_output()` selector can be changed. See [Feedback Function
-        Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
+            feedback = Feedback(huggingface_provider.not_toxic).on_output() 
+            ```
+
+            The `on_output()` selector can be changed. See [Feedback Function
+            Guide](https://www.trulens.org/trulens_eval/feedback_function_guide/)
 
         
         Args:
@@ -379,14 +382,17 @@ class Huggingface(Provider):
         """
         NER model to detect PII, with reasons.
 
-        **Usage:**
-        ```
-        hugs = Huggingface()
+        Usage:
+            ```python
+            hugs = Huggingface()
 
-        # Define a pii_detection feedback function using HuggingFace.
-        f_pii_detection = Feedback(hugs.pii_detection).on_input()
-        ```
-        The `on(...)` selector can be changed. See [Feedback Function Guide : Selectors](https://www.trulens.org/trulens_eval/feedback_function_guide/#selector-details)
+            # Define a pii_detection feedback function using HuggingFace.
+            f_pii_detection = Feedback(hugs.pii_detection).on_input()
+            ```
+            
+            The `on(...)` selector can be changed. See [Feedback Function Guide
+            :
+            Selectors](https://www.trulens.org/trulens_eval/feedback_function_guide/#selector-details)
         """
 
         # Initialize a dictionary to store reasons


### PR DESCRIPTION
- Fix formatting for some code blocks docstrings in LLMProvider methods.
- Add missing abstract method implementation to deprecated DB so it can be initialized.