### PR TITLE
Add if_missing.

### DIFF
--- a/docs/trulens_eval/api/feedback.md
+++ b/docs/trulens_eval/api/feedback.md
@@ -22,6 +22,8 @@ non-serializable instantiations.
 
 ::: trulens_eval.schema.FeedbackCombinations
 
+::: trulens_eval.schema.FeedbackOnMissingParameters
+
 ::: trulens_eval.schema.FeedbackMode
 
 ::: trulens_eval.schema.FeedbackResult

--- a/trulens_eval/examples/experimental/dev_notebook.ipynb
+++ b/trulens_eval/examples/experimental/dev_notebook.ipynb
@@ -20,8 +20,8 @@
     "\n",
     "# trulens_eval notebook dev\n",
     "\n",
-    "%load_ext autoreload\n",
-    "%autoreload 2\n",
+    "# %load_ext autoreload\n",
+    "# %autoreload 2\n",
     "from pathlib import Path\n",
     "import sys\n",
     "\n",
@@ -98,9 +98,27 @@
     "from trulens_eval import Select\n",
     "from trulens_eval.feedback.feedback import Feedback\n",
     "\n",
-    "f = Feedback(Dummy().language_match).on(Select.RecordCalls._retriever.retrieve.rets[42])\n",
+    "f = Feedback(Dummy().language_match, if_missing=\"ignore\").on(Select.RecordCalls._retriever.retrieve.rets[42])\n",
     "\n",
     "tru_query_engine_recorder = TruLlama(query_engine, feedbacks=[f])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Tru().db.get_feedback()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recs"
    ]
   },
   {
@@ -115,6 +133,24 @@
     "    query_engine.aquery, \"What did the author do growing up?\"\n",
     ")\n",
     "record_async"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = record_async.feedback_results[0].result()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res.result"
    ]
   },
   {

--- a/trulens_eval/tests/unit/test_feedback_score_generation.py
+++ b/trulens_eval/tests/unit/test_feedback_score_generation.py
@@ -1,35 +1,37 @@
-import re
+"""
+Test suites meant for testing the reliability and robustness of the regex
+pattern matching of feedback scores from LLM responses.
+"""
+
 
 import pytest
 
-from trulens_eval.utils.generated import PATTERN_0_10
-"""
-Test suites meant for testing the reliability and robustness of the regex pattern matching of feedback scores from LLM responses.
-"""
-
-# Original regex pattern
-PATTERN_0_10_ORIGINAL: re.Pattern = re.compile(r"\s*([0-9]+)\s*$")
-
-# Enhanced regex pattern
-PATTERN_0_10_ENHANCED: re.Pattern = PATTERN_0_10
+from trulens_eval.utils.generated import ParseError
+from trulens_eval.utils.generated import re_0_10_rating
 
 test_data = [
-    ("The relevance score is 7.", "7"),
-    ("I rate this an 8 out of 10.", "10"
-    ),  # note that even with the enhanced pattern, this will still fail to extract 8.
-    ("This should be a 10!", "10"),
-    ("The score is 5", "5"),
-    ("A perfect score: 10.", "10"),
+    ("The relevance score is 7.", 7),
+    ("I rate this an 8 out of 10.", 8),
+    ("In the range of 0-10, I give this a 9.", 0),
+    # Currently does not have ideal handling as it returns the minimum integer found.
+    ("This should be a 10!", 10),
+    ("The score is 5", 5),
+    ("A perfect score: 10.", 10),
     ("Irrelevant text 123 Main Street.", None),
-    ("Score: 9.", "9"),
-    ("7", "7"),
-    ("This deserves a 6, I believe.", "6"),
-    ("Not relevant. Score: 0.", "0")
+    ("Score: 9.", 9),
+    ("7", 7),
+    ("This deserves a 6, I believe.", 6),
+    ("Not relevant. Score: 0.", 0)
 ]
 
 
 @pytest.mark.parametrize("test_input,expected", test_data)
-def test_enhanced_regex_pattern(test_input, expected):
-    match = PATTERN_0_10_ENHANCED.search(test_input)
-    result = match.group(1) if match else None
+def test_re_0_10_rating(test_input, expected):
+    """Check that re_0_10_rating can extract the correct score from a string."""
+
+    try:
+        result = re_0_10_rating(test_input)
+    except ParseError:
+        result = None
+
     assert result == expected, f"Failed on {test_input}: expected {expected}, got {result}"

--- a/trulens_eval/trulens_eval/database/sqlalchemy_db.py
+++ b/trulens_eval/trulens_eval/database/sqlalchemy_db.py
@@ -3,9 +3,8 @@ from datetime import datetime
 import json
 import logging
 from sqlite3 import OperationalError
-from typing import (
-    Any, ClassVar, Dict, Iterable, List, Optional, Sequence, Tuple, Union
-)
+from typing import (Any, ClassVar, Dict, Iterable, List, Optional, Sequence,
+                    Tuple, Union)
 import warnings
 
 import numpy as np
@@ -25,10 +24,6 @@ from trulens_eval.database.exceptions import DatabaseVersionException
 from trulens_eval.database.migrations import DbRevisions
 from trulens_eval.database.migrations import upgrade_db
 from trulens_eval.database.migrations.db_data_migration import data_migrate
-from trulens_eval.database.orm import AppDefinition
-from trulens_eval.database.orm import FeedbackDefinition
-from trulens_eval.database.orm import FeedbackResult
-from trulens_eval.database.orm import Record
 from trulens_eval.database.utils import check_db_revision
 from trulens_eval.database.utils import for_all_methods
 from trulens_eval.database.utils import is_legacy_sqlite
@@ -40,7 +35,6 @@ from trulens_eval.db_migration import MIGRATION_UNKNOWN_STR
 from trulens_eval.schema import FeedbackDefinitionID
 from trulens_eval.schema import FeedbackResultID
 from trulens_eval.schema import FeedbackResultStatus
-from trulens_eval.schema import Perf
 from trulens_eval.schema import RecordID
 from trulens_eval.utils.pyschema import Class
 from trulens_eval.utils.python import locals_except

--- a/trulens_eval/trulens_eval/feedback/feedback.py
+++ b/trulens_eval/trulens_eval/feedback/feedback.py
@@ -24,7 +24,7 @@ from rich.pretty import pretty_repr
 
 from trulens_eval.feedback.provider.base import LLMProvider
 from trulens_eval.feedback.provider.endpoint.base import Endpoint
-from trulens_eval.schema import AppDefinition
+from trulens_eval.schema import AppDefinition, FeedbackOnMissingParameters
 from trulens_eval.schema import Cost
 from trulens_eval.schema import FeedbackCall
 from trulens_eval.schema import FeedbackCombinations
@@ -64,6 +64,18 @@ float and a dictionary (of metadata)."""
 AggCallable = Callable[[Iterable[float]], float]
 """Signature of aggregation functions."""
 
+class InvalidSelector(Exception):
+    """Raised when a selector names something that is missing in a record/app."""
+
+    def __init__(self, selector: Lens, source_data: Optional[Dict[str, Any]] = None):
+        self.selector = selector
+        self.source_data = source_data
+
+    def __str__(self):
+        return f"Selector {self.selector} does not exist in source data."
+
+    def __repr__(self):
+        return f"InvalidSelector({self.selector})"
 
 def rag_triad(
     provider: LLMProvider,
@@ -802,10 +814,30 @@ Feedback function signature:
                 )
             )
 
-        except Exception as e:
-            # TODO: Block here to remind us that we may want to do something
-            # better here.
-            raise e
+        except InvalidSelector as e:
+            # Handle the cases where a selector named something that does not
+            # exist in source data.
+            
+            if self.if_missing == FeedbackOnMissingParameters.ERROR:
+                feedback_result.status = FeedbackResultStatus.FAILED
+                raise e
+
+            if self.if_missing == FeedbackOnMissingParameters.WARN:
+                feedback_result.status = FeedbackResultStatus.SKIPPED
+                logger.warning(
+                    "Feedback %s cannot run as %s does not exist in record or app.", self.name,
+                    e.selector
+                )
+                return feedback_result
+
+            if self.if_missing == FeedbackOnMissingParameters.IGNORE:
+                feedback_result.status = FeedbackResultStatus.SKIPPED
+                return feedback_result
+
+            feedback_result.status = FeedbackResultStatus.FAILED
+            raise ValueError(
+                f"Unknown value for `if_missing` {self.if_missing}."
+            ) from e
 
         try:
             # Total cost, will accumulate.
@@ -1018,8 +1050,8 @@ Feedback function signature:
                 else:
                     arg_vals[k] = list(q.get(source_data))
             except Exception as e:
-                raise RuntimeError(
-                    f"Could not locate {q} in recorded data."
+                raise InvalidSelector(
+                    selector=q, source_data=source_data
                 ) from e
 
         # For anything specified in kwargs that did not have a selector, set the

--- a/trulens_eval/trulens_eval/schema.py
+++ b/trulens_eval/trulens_eval/schema.py
@@ -203,12 +203,16 @@ class RecordAppCall(serial.SerialModel):
 
 
 class Record(serial.SerialModel, Hashable):
-    """Each instrumented method call produces one of these "record" instances."""
+    """The record of a single main method call.
 
-    model_config: ClassVar[dict] = dict(
+    Note:
+        This class will be renamed to `Trace` in the future.
+    """
+
+    model_config: ClassVar[dict] = {
         # for `Future[FeedbackResult]`
-        arbitrary_types_allowed=True
-    )
+        'arbitrary_types_allowed' : True
+    }
 
     record_id: RecordID
     """Unique identifier for this record."""
@@ -298,7 +302,7 @@ class Record(serial.SerialModel, Hashable):
 
         return ret
 
-    def layout_calls_as_app(self) -> serial.JSON:
+    def layout_calls_as_app(self) -> Bunch:
         """Layout the calls in this record into the structure that follows that of
         the app that created this record.
         
@@ -489,8 +493,41 @@ class FeedbackResultStatus(Enum):
     """Run completed successfully."""
 
     SKIPPED = "skipped"
-    """This feedback was skipped because it had an `if_exists` selector and did not select anything."""
+    """This feedback was skipped.
+     
+    This can be because because it had an `if_exists` selector and did not
+    select anything or it has a selector that did not select anything the
+    `on_missing` was set to warn or ignore.
+    """
 
+
+class FeedbackOnMissingParameters(str, Enum):
+    """How to handle missing parameters in feedback function calls.
+    
+    This is specifically for the case were a feedback function has a selector
+    that selects something that does not exist in a record/app.
+    """
+
+    ERROR = "error"
+    """Raise an error if a parameter is missing.
+    
+    The result status will be set to
+    [FAILED][trulens_eval.schema.FeedbackResultStatus.FAILED].
+    """
+
+    WARN = "warn"
+    """Warn if a parameter is missing.
+    
+    The result status will be set to
+    [SKIPPED][trulens_eval.schema.FeedbackResultStatus.SKIPPED].
+    """
+
+    IGNORE = "ignore"
+    """Do nothing. 
+    
+    No warning or error message will be shown. The result status will be set to
+    [SKIPPED][trulens_eval.schema.FeedbackResultStatus.SKIPPED].
+    """
 
 class FeedbackCall(serial.SerialModel):
     """Invocations of feedback function results in one of these instances.
@@ -692,11 +729,17 @@ class FeedbackDefinition(pyschema.WithClassInfo, serial.SerialModel, Hashable):
     """Only execute the feedback function if the following selector names
     something that exists in a record/app.
     
-    Can use this to evaluate conditionally on presence of some calls, for example.
+    Can use this to evaluate conditionally on presence of some calls, for
+    example. Feedbacks skipped this way will have a status of
+    [FeedbackResultStatus.SKIPPED][trulens_eval.schema.FeedbackResultStatus.SKIPPED].
     """
 
+    if_missing: FeedbackOnMissingParameters = FeedbackOnMissingParameters.ERROR
+    """How to handle missing parameters in feedback function calls."""
+
     selectors: Dict[str, serial.Lens]
-    """Selectors; pointers into Records of where to get arguments for `imp`."""
+    """Selectors; pointers into [Records][trulens_eval.schema.Record] of where
+    to get arguments for `imp`."""
 
     supplied_name: Optional[str] = None
     """An optional name. Only will affect displayed tables."""
@@ -711,6 +754,7 @@ class FeedbackDefinition(pyschema.WithClassInfo, serial.SerialModel, Hashable):
                                        pyschema.Method]] = None,
         aggregator: Optional[Union[pyschema.Function, pyschema.Method]] = None,
         if_exists: Optional[serial.Lens] = None,
+        if_missing: FeedbackOnMissingParameters = FeedbackOnMissingParameters.ERROR,
         selectors: Optional[Dict[str, serial.Lens]] = None,
         name: Optional[str] = None,
         higher_is_better: Optional[bool] = None,
@@ -727,6 +771,7 @@ class FeedbackDefinition(pyschema.WithClassInfo, serial.SerialModel, Hashable):
             aggregator=aggregator,
             selectors=selectors,
             if_exists=if_exists,
+            if_missing=if_missing,
             **kwargs
         )
 

--- a/trulens_eval/trulens_eval/utils/generated.py
+++ b/trulens_eval/trulens_eval/utils/generated.py
@@ -37,15 +37,18 @@ def validate_rating(rating) -> int:
 PATTERN_0_10: re.Pattern = re.compile(r"([0-9]+)(?=\D*$)")
 """Regex that matches the last integer."""
 
-PATTERN_NUMBER: re.Pattern = re.compile(r"([+-]?[0-9]+\.[0-9]*|[0-9]+)")
+PATTERN_NUMBER: re.Pattern = re.compile(r"([+-]?[0-9]+\.[0-9]*|[1-9][0-9]*|0)")
 """Regex that matches floating point and integer numbers."""
+
+PATTERN_INTEGER: re.Pattern = re.compile(r"([+-]?[1-9][0-9]*|0)")
+"""Regex that matches integers."""
 
 def re_0_10_rating(s: str) -> int:
     """Extract a 0-10 rating from a string.
     
-    If the string does not match a number or matches a number outside the 0-10
-    range, raises an error instead. If multiple numbers are found within the
-    expected 0-10 range, the smallest is returned.
+    If the string does not match an integer or matches an integer outside the
+    0-10 range, raises an error instead. If multiple numbers are found within
+    the expected 0-10 range, the smallest is returned.
 
     Args:
         s: String to extract rating from.
@@ -57,9 +60,9 @@ def re_0_10_rating(s: str) -> int:
         ParseError: If no integers between 0 and 10 are found in the string.
     """
 
-    matches = PATTERN_NUMBER.findall(s)
+    matches = PATTERN_INTEGER.findall(s)
     if not matches:
-        raise ParseError("int or float number", s, pattern=PATTERN_NUMBER)
+        raise ParseError("int or float number", s, pattern=PATTERN_INTEGER)
 
     vals = set()
     for match in matches:


### PR DESCRIPTION
Items to add to release announcement:
- **Feedback.if_missing**: configure feedback functions to do something other than raise an error if a selector is wrong or whatever it wants to select does not exist. You can use this to let feedback ignore records that do not have the data that was called for. Supported are error as before (default), warn (issue warning and mark feedback as skipped), or ignore (just mark as skipped).
- **No -1 results**: if a feedback function implementation fails to find a 0-10 score in some generated text, the result will no longer be -10 (or normalized score -1). Instead the result will remain None and an exception will be raised.
