### PR TITLE
Queue fixed for python version lower than 3.9

### DIFF
--- a/trulens_eval/trulens_eval/app.py
+++ b/trulens_eval/trulens_eval/app.py
@@ -13,7 +13,6 @@ from inspect import BoundArguments
 from inspect import Signature
 import logging
 from pprint import PrettyPrinter
-import queue
 import threading
 from threading import Lock
 from typing import (
@@ -503,7 +502,7 @@ class App(AppDefinition, WithInstrumentCallbacks, Hashable):
     function) to their path in this app."""
 
     records_with_pending_feedback_results: Queue[Record] = \
-        pydantic.Field(exclude=True, default_factory=lambda: queue.Queue(maxsize=1024))
+        pydantic.Field(exclude=True, default_factory=lambda: Queue(maxsize=1024))
     """Records produced by this app which might have yet to finish
     feedback runs."""
 


### PR DESCRIPTION
Related to issue #1060 

Queue class is not directly supported for python versions lower than 3.9. This PR replaces the Queue with the custom override that we already have in `utils/python.py` for this exact problem