### PR TITLE
better singleton already made warnings

### DIFF
--- a/trulens_eval/trulens_eval/feedback/provider/endpoint/litellm.py
+++ b/trulens_eval/trulens_eval/feedback/provider/endpoint/litellm.py
@@ -75,6 +75,12 @@ class LiteLLMEndpoint(Endpoint):
     def __init__(self, litellm_provider: str = "openai", **kwargs):
         if hasattr(self, "name"):
             # singleton already made
+            if len(kwargs) > 0:
+                logger.warning(
+                    "Ignoring additional kwargs for singleton endpoint %s: %s",
+                    self.name, pp.pformat(kwargs)
+                )
+                self.warning()
             return
 
         kwargs['name'] = "litellm"

--- a/trulens_eval/trulens_eval/feedback/provider/endpoint/openai.py
+++ b/trulens_eval/trulens_eval/feedback/provider/endpoint/openai.py
@@ -231,6 +231,7 @@ class OpenAIEndpoint(Endpoint):
                     "OpenAIClient singleton already made, ignoring arguments %s",
                     kwargs
                 )
+                self.warning() # issue info about where the singleton was originally created
             return
 
         self_kwargs = {

--- a/trulens_eval/trulens_eval/tru.py
+++ b/trulens_eval/trulens_eval/tru.py
@@ -186,10 +186,10 @@ class Tru(python.SingletonPerName):
                     "Tru was already initialized. "
                     "Cannot change database configuration after initialization."
                 )
+                self.warning()
 
-            # Already initialized by SingletonByName mechanism.
             return
-
+        
         if database is not None:
             self.db = database
         else:
@@ -201,6 +201,7 @@ class Tru(python.SingletonPerName):
             except DatabaseVersionException as e:
                 print(e)
                 self.db = OpaqueWrapper(obj=self.db, e=e)
+
 
     def Chain(
         self, chain: langchain.chains.base.Chain, **kwargs: dict


### PR DESCRIPTION
Other details that are good to know but need not be announced:
- Added a better warning message when creating an instance of a singleton class that was already made. For example:

```python
from trulens_eval import OpenAI
from trulens_eval.feedback import Groundedness

Groundedness()
OpenAI(client=42, something=42)
```

Will print out
```
OpenAIClient singleton already made, ignoring arguments {'something': 42}
Singleton instance of type OpenAIEndpoint already created at:
[/var/folders/2j/xg0_cv993gl37s_8qs5qrdxm0000gn/T/ipykernel_82627/1090973180.py:1](https://file+.vscode-resource.vscode-cdn.net/var/folders/2j/xg0_cv993gl37s_8qs5qrdxm0000gn/T/ipykernel_82627/1090973180.py:1)
	Groundedness()
```

The first part is the existing warning but the second points out the source code line that caused the singleton to be created to begin with. In this case, the call to Groundedness created a default openai client hence the second one's configuration is ignored.