### PR TITLE
Remove references to running moderation endpoint on AzureOpenAI

### DIFF
--- a/docs/trulens_eval/api/provider/openai/azureopenai.md
+++ b/docs/trulens_eval/api/provider/openai/azureopenai.md
@@ -5,9 +5,6 @@ Below is how you can instantiate _AzureOpenAI_ as a provider.
 All feedback functions listed in the base [LLMProvider
 class][trulens_eval.feedback.provider.base.LLMProvider] can be run with the _AzureOpenAI_ Provider.
 
-- [OpenAI class][trulens_eval.feedback.provider.openai.OpenAI]
-- [LLMProvider class][trulens_eval.feedback.provider.base.LLMProvider]
-
 !!! warning
 
     _AzureOpenAI_ does not support the _OpenAI_ moderation endpoint.

--- a/docs/trulens_eval/api/provider/openai/azureopenai.md
+++ b/docs/trulens_eval/api/provider/openai/azureopenai.md
@@ -1,10 +1,15 @@
 # AzureOpenAI Provider
 
-Below is how you can instantiate AzureOpenAI as a provider.
+Below is how you can instantiate _AzureOpenAI_ as a provider.
 
-Additionally, all feedback functions listed in these two classes can be run with AzureOpenAI:
+All feedback functions listed in the base [LLMProvider
+class][trulens_eval.feedback.provider.base.LLMProvider] can be run with the _AzureOpenAI_ Provider.
 
-* [OpenAI class][trulens_eval.feedback.provider.openai.OpenAI]
-* [LLMProvider class][trulens_eval.feedback.provider.base.LLMProvider]
+- [OpenAI class][trulens_eval.feedback.provider.openai.OpenAI]
+- [LLMProvider class][trulens_eval.feedback.provider.base.LLMProvider]
+
+!!! warning
+
+    _AzureOpenAI_ does not support the _OpenAI_ moderation endpoint.
 
 ::: trulens_eval.feedback.provider.openai.AzureOpenAI

--- a/docs/trulens_eval/api/provider/openai/azureopenai.md
+++ b/docs/trulens_eval/api/provider/openai/azureopenai.md
@@ -1,12 +1,12 @@
 # AzureOpenAI Provider
 
-Below is how you can instantiate _AzureOpenAI_ as a provider.
+Below is how you can instantiate _Azure OpenAI_ as a provider.
 
 All feedback functions listed in the base [LLMProvider
-class][trulens_eval.feedback.provider.base.LLMProvider] can be run with the _AzureOpenAI_ Provider.
+class][trulens_eval.feedback.provider.base.LLMProvider] can be run with the AzureOpenAI Provider.
 
 !!! warning
 
-    _AzureOpenAI_ does not support the _OpenAI_ moderation endpoint.
+    _Azure OpenAI_ does not support the _OpenAI_ moderation endpoint.
 
 ::: trulens_eval.feedback.provider.openai.AzureOpenAI

--- a/trulens_eval/trulens_eval/feedback/provider/openai.py
+++ b/trulens_eval/trulens_eval/feedback/provider/openai.py
@@ -406,7 +406,8 @@ class OpenAI(LLMProvider):
 class AzureOpenAI(OpenAI):
     """
     Out of the box feedback functions calling AzureOpenAI APIs. Has the same
-    functionality as OpenAI out of the box feedback functions. Please export the
+    functionality as OpenAI out of the box feedback functions, excluding the 
+    moderation endpoint which is not supported by Azure. Please export the
     following env variables. These can be retrieved from https://oai.azure.com/
     .
 


### PR DESCRIPTION
Other details that are good to know but need not be announced:
- Moderation endpoint is not available on Azure. Instead, the moderation functions are run as content filters with every api call. Make this clear in docs.
