### PR TITLE
Remove placeholder feedback for asynchronous responses

### DIFF
--- a/trulens_eval/trulens_eval/instruments.py
+++ b/trulens_eval/trulens_eval/instruments.py
@@ -578,27 +578,11 @@ class Instrument(object):
                 return records
 
             if isinstance(rets, Awaitable):
-                # If method produced an awaitable, add a placeholder record
-                # stating that results are not ready and return an awaitable
-                # that will capture the results when they are ready.
+                # If method produced an awaitable
 
-                # Placeholder:
-                records: Dict = handle_done(
-                    rets=(
-                        f"""
-NOTE from trulens_eval:
-This app produced an asynchronous response of type `{class_name(type(rets))}`. This record will be updated once
-the response is available. If this message persists, check that you are
-using the correct version of the app method and `await` any asynchronous
-results. Additional information about this call: 
-    
-```
-{pformat(locals())}
-```
-    """
-                    ),
-                )
-
+                logger.info(f"""This app produced an asynchronous response of type `{class_name(type(rets))}`. 
+                            This record will be updated once the response is available""")
+                            
                 # TODO(piotrm): need to track costs of awaiting the ret in the
                 # below.
 


### PR DESCRIPTION
Other details that are good to know but need not be announced:
- Removed placeholder feedback that was stored when asynchronous process starts. (This stops multiple feedbacks from being recorded.)
