### PR TITLE
dont iterate streams in openai cost tracking

### DIFF
--- a/trulens_eval/examples/experimental/dev_notebook.ipynb
+++ b/trulens_eval/examples/experimental/dev_notebook.ipynb
@@ -11,9 +11,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Volumes/dev_new/Dropbox/repos/truera/trulens/trulens_eval\n",
+      "✅ Key OPENAI_API_KEY set from .env file at /Volumes/dev_new/.env.\n",
+      "✅ Key HUGGINGFACE_API_KEY set from .env file at /Volumes/dev_new/.env.\n",
+      "🦑 Tru initialized with db url sqlite:///default.sqlite .\n",
+      "🛑 Secret keys may be written to the database. See the `database_redact_keys` option of Tru` to prevent this.\n"
+     ]
+    }
+   ],
    "source": [
     "# pip uninstall -y trulens_eval\n",
     "# pip install git+https://github.com/truera/trulens@piotrm/azure_bugfixes#subdirectory=trulens_eval\n",
@@ -30,15 +42,14 @@
     "    base = base.parent\n",
     "\n",
     "\n",
-    "import os\n",
-    "if os.path.exists(\"default.sqlite\"):\n",
-    "    os.unlink(\"default.sqlite\")\n",
+    "#import os\n",
+    "#if os.path.exists(\"default.sqlite\"):\n",
+    "#    os.unlink(\"default.sqlite\")\n",
     "\n",
     "print(base)\n",
     "\n",
-    "import shutil\n",
-    "shutil.copy(base / \"release_dbs\" / \"0.19.0\" / \"default.sqlite\", \"default.sqlite\")\n",
-    "\n",
+    "# import shutil\n",
+    "#shutil.copy(base / \"release_dbs\" / \"0.19.0\" / \"default.sqlite\", \"default.sqlite\")\n",
     "\n",
     "# If running from github repo, can use this:\n",
     "sys.path.append(str(base))\n",
@@ -72,12 +83,168 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Database does not need migration.\n"
+     ]
+    }
+   ],
    "source": [
     "# tru.db.migrate_database()\n",
     "tru.migrate_database()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/piotrm/miniconda3/envs/py312/lib/python3.12/site-packages/langchain_core/_api/deprecation.py:119: LangChainDeprecationWarning: The class `ChatOpenAI` was deprecated in LangChain 0.0.10 and will be removed in 0.3.0. An updated version of the class exists in the langchain-openai package and should be used instead. To use it run `pip install -U langchain-openai` and import as `from langchain_openai import ChatOpenAI`.\n",
+      "  warn_deprecated(\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain import hub\n",
+    "from langchain_community.chat_models import ChatOpenAI\n",
+    "from langchain.agents import AgentExecutor, create_structured_chat_agent\n",
+    "from langchain_core.messages import AIMessage, HumanMessage\n",
+    "\n",
+    "prompt = hub.pull(\"hwchase17/structured-chat-agent\")\n",
+    "model = ChatOpenAI()\n",
+    "tools = []\n",
+    "\n",
+    "agent = create_structured_chat_agent(model, tools, prompt)\n",
+    "agent_executor = AgentExecutor(agent=agent, tools=tools)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res1 = agent_executor.invoke({\"input\": \"hi\"})\n",
+    "\n",
+    "# Using with chat history\n",
+    "\n",
+    "res2 = agent_executor.invoke(\n",
+    "    {\n",
+    "        \"input\": \"what's my name?\",\n",
+    "        \"chat_history\": [\n",
+    "            HumanMessage(content=\"hi! my name is bob\"),\n",
+    "            AIMessage(content=\"Hello Bob! How can I assist you today?\"),\n",
+    "        ],\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'input': \"what's my name?\",\n",
+       " 'chat_history': [HumanMessage(content='hi! my name is bob'),\n",
+       "  AIMessage(content='Hello Bob! How can I assist you today?')],\n",
+       " 'output': 'Your name is Bob.'}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "res2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens_eval import TruChain\n",
+    "recorder = TruChain(agent_executor)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Cannot track costs from a OpenAI Stream.\n",
+      "Cannot track costs from a OpenAI Stream.\n",
+      "Cannot track costs from a OpenAI Stream.\n",
+      "Cannot track costs from a OpenAI Stream.\n",
+      "langchain app has no `output_keys`. `main_output` might not be detected.\n"
+     ]
+    }
+   ],
+   "source": [
+    "with recorder as recs:\n",
+    "\n",
+    "    agent_executor.invoke({\"input\": \"hi\"})\n",
+    "\n",
+    "    # Using with chat history\n",
+    "\n",
+    "    \"\"\"\n",
+    "    agent_executor.invoke(\n",
+    "        {\n",
+    "            \"input\": \"what's my name?\",\n",
+    "            \"chat_history\": [\n",
+    "                HumanMessage(content=\"hi! my name is bob\"),\n",
+    "                AIMessage(content=\"Hello Bob! How can I assist you today?\"),\n",
+    "            ],\n",
+    "        }\n",
+    "    )\n",
+    "    \"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "record = recs.get()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Hello! How can I assist you today?'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "record.main_output"
    ]
   },
   {
@@ -277,7 +444,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.12.0"
   }
  },
  "nbformat": 4,

--- a/trulens_eval/examples/experimental/dev_notebook.ipynb
+++ b/trulens_eval/examples/experimental/dev_notebook.ipynb
@@ -11,21 +11,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/Volumes/dev_new/Dropbox/repos/truera/trulens/trulens_eval\n",
-      "✅ Key OPENAI_API_KEY set from .env file at /Volumes/dev_new/.env.\n",
-      "✅ Key HUGGINGFACE_API_KEY set from .env file at /Volumes/dev_new/.env.\n",
-      "🦑 Tru initialized with db url sqlite:///default.sqlite .\n",
-      "🛑 Secret keys may be written to the database. See the `database_redact_keys` option of Tru` to prevent this.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# pip uninstall -y trulens_eval\n",
     "# pip install git+https://github.com/truera/trulens@piotrm/azure_bugfixes#subdirectory=trulens_eval\n",
@@ -83,17 +71,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Database does not need migration.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# tru.db.migrate_database()\n",
     "tru.migrate_database()"
@@ -101,18 +81,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/piotrm/miniconda3/envs/py312/lib/python3.12/site-packages/langchain_core/_api/deprecation.py:119: LangChainDeprecationWarning: The class `ChatOpenAI` was deprecated in LangChain 0.0.10 and will be removed in 0.3.0. An updated version of the class exists in the langchain-openai package and should be used instead. To use it run `pip install -U langchain-openai` and import as `from langchain_openai import ChatOpenAI`.\n",
-      "  warn_deprecated(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from langchain import hub\n",
     "from langchain_community.chat_models import ChatOpenAI\n",
@@ -129,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,30 +121,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'input': \"what's my name?\",\n",
-       " 'chat_history': [HumanMessage(content='hi! my name is bob'),\n",
-       "  AIMessage(content='Hello Bob! How can I assist you today?')],\n",
-       " 'output': 'Your name is Bob.'}"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "res2"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,21 +140,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Cannot track costs from a OpenAI Stream.\n",
-      "Cannot track costs from a OpenAI Stream.\n",
-      "Cannot track costs from a OpenAI Stream.\n",
-      "Cannot track costs from a OpenAI Stream.\n",
-      "langchain app has no `output_keys`. `main_output` might not be detected.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with recorder as recs:\n",
     "\n",
@@ -220,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,20 +174,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Hello! How can I assist you today?'"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "record.main_output"
    ]

--- a/trulens_eval/trulens_eval/app.py
+++ b/trulens_eval/trulens_eval/app.py
@@ -751,7 +751,7 @@ class App(mod_app_schema.AppDefinition, mod_instruments.WithInstrumentCallbacks,
 
         raise NotImplementedError()
 
-    def _extract_content(self, value):
+    def _extract_content(self, value, content_keys = ['content']):
         """
         Extracts the 'content' from various data types commonly used by libraries
         like OpenAI, Canopy, LiteLLM, etc. This method navigates nested data
@@ -773,38 +773,42 @@ class App(mod_app_schema.AppDefinition, mod_instruments.WithInstrumentCallbacks,
             content = getattr(value, 'content', None)
             if content is not None:
                 return content
-            else:
-                # If 'content' is not found, check for 'choices' attribute which indicates a ChatResponse
-                choices = getattr(value, 'choices', None)
-                if choices is not None:
-                    # Extract 'content' from the 'message' attribute of each _Choice in 'choices'
-                    return [
-                        self._extract_content(choice.message)
-                        for choice in choices
-                    ]
-                else:
-                    # Recursively extract content from nested pydantic models
-                    return {
-                        k: self._extract_content(v) if
-                        isinstance(v, (pydantic.BaseModel, dict, list)) else v
-                        for k, v in value.dict().items()
-                    }
+            
+            # If 'content' is not found, check for 'choices' attribute which indicates a ChatResponse
+            choices = getattr(value, 'choices', None)
+            if choices is not None:
+                # Extract 'content' from the 'message' attribute of each _Choice in 'choices'
+                return [
+                    self._extract_content(choice.message)
+                    for choice in choices
+                ]
+            
+            # Recursively extract content from nested pydantic models
+            return {
+                k: self._extract_content(v) if
+                isinstance(v, (pydantic.BaseModel, dict, list)) else v
+                for k, v in value.dict().items()
+            }
+        
         elif isinstance(value, dict):
             # Check for 'content' key in the dictionary
-            content = value.get('content')
-            if content is not None:
-                return content
-            else:
-                # Recursively extract content from nested dictionaries
-                return {
-                    k:
-                    self._extract_content(v) if isinstance(v,
-                                                           (dict, list)) else v
-                    for k, v in value.items()
-                }
+            for key in content_keys:
+                content = value.get(key)
+                if content is not None:
+                    return content
+
+            # Recursively extract content from nested dictionaries
+            return {
+                k:
+                self._extract_content(v) if isinstance(v,
+                                                        (dict, list)) else v
+                for k, v in value.items()
+            }
+        
         elif isinstance(value, list):
             # Handle lists by extracting content from each item
             return [self._extract_content(item) for item in value]
+
         else:
             return value
 
@@ -828,7 +832,10 @@ class App(mod_app_schema.AppDefinition, mod_instruments.WithInstrumentCallbacks,
 
         while not isinstance(focus, JSON_BASES) and len(focus) == 1:
             focus = focus[0]
-            focus = self._extract_content(focus)
+            focus = self._extract_content(
+                focus,
+                content_keys=['content', 'input']
+            )
 
             if not isinstance(focus, Sequence):
                 logger.warning("Focus %s is not a sequence.", focus)
@@ -873,7 +880,10 @@ class App(mod_app_schema.AppDefinition, mod_instruments.WithInstrumentCallbacks,
         """
 
         # Use _extract_content to get the content out of the return value
-        content = self._extract_content(ret)
+        content = self._extract_content(
+            ret,
+            content_keys=['content', 'output']
+        )
 
         if isinstance(content, str):
             return content

--- a/trulens_eval/trulens_eval/feedback/provider/endpoint/openai.py
+++ b/trulens_eval/trulens_eval/feedback/provider/endpoint/openai.py
@@ -304,10 +304,9 @@ class OpenAIEndpoint(Endpoint):
             model_name = bindings.kwargs["model"]
 
         if isinstance(response, oai.Stream):
-            # NOTE(piotrm): Merely checking membership in these will exhaust
-            # internal genertors or iterators which will break users' code.
-            # While we work out something, I'm disabling any cost-tracking for
-            # these streams.
+            # NOTE(piotrm): Merely checking membership in these will exhaust internal
+            # genertors or iterators which will break users' code. While we work
+            # out something, I'm disabling any cost-tracking for these streams.
             logger.warning("Cannot track costs from a OpenAI Stream.")
             return
 
@@ -320,7 +319,6 @@ class OpenAIEndpoint(Endpoint):
 
             counted_something = True
 
-            """
             if isinstance(response.usage, pydantic.BaseModel):
                 usage = response.usage.model_dump()
             elif isinstance(response.usage, pydantic.v1.BaseModel):
@@ -329,7 +327,6 @@ class OpenAIEndpoint(Endpoint):
                 usage = response.usage
             else:
                 usage = None
-            """
 
             # See how to construct in langchain.llms.openai.OpenAIChat._generate
             llm_res = LLMResult(
@@ -365,6 +362,6 @@ class OpenAIEndpoint(Endpoint):
 
         if not counted_something:
             logger.warning(
-                f"Could not find usage information in openai response:\n" +
+                "Could not find usage information in openai response:\n%s",
                 pp.pformat(response)
             )

--- a/trulens_eval/trulens_eval/tru_chain.py
+++ b/trulens_eval/trulens_eval/tru_chain.py
@@ -305,9 +305,9 @@ class TruChain(mod_app.App):
 
             if len(self.app.input_keys) == 0:
                 logger.warning(
-                    "langchain app has no inputs. `main_input` will be `None`."
+                    "langchain app has no `input_keys`. `main_input` might not be detected."
                 )
-                return None
+                return super().main_input(func, sig, bindings)
 
             return ins[self.app.input_keys[0]]
 
@@ -324,6 +324,12 @@ class TruChain(mod_app.App):
 
         if isinstance(ret, Dict) and safe_hasattr(self.app, "output_keys"):
             # langchain specific:
+            if len(self.app.output_keys) == 0:
+                logger.warning(
+                    "langchain app has no `output_keys`. `main_output` might not be detected."
+                )
+                return super().main_output(func, sig, bindings, ret)
+
             if self.app.output_keys[0] in ret:
                 return ret[self.app.output_keys[0]]
 


### PR DESCRIPTION
Other details that are good to know but need not be announced:
- Prevent exhausting iterables in cost-tracking code. This is responsible for some bugs. A side effect is that cost-tracking may not be working for some streaming methods for now.
- Detect `main_input` and `main_output` by presence of `"input"` and `"output"` in dicts.