### PR TITLE
Very minor fix of print statement

### DIFF
--- a/trulens_eval/trulens_eval/database/sqlalchemy.py
+++ b/trulens_eval/trulens_eval/database/sqlalchemy.py
@@ -163,7 +163,7 @@ class SQLAlchemyDB(DB):
         else:
             print(
                 f"{text.UNICODE_STOP} Secret keys may be written to the database. "
-                "See the `database_redact_keys` option of Tru` to prevent this."
+                "See the `database_redact_keys` option of `Tru` to prevent this."
             )
 
         return new_db


### PR DESCRIPTION
Items to add to release announcement:
- **Heading**: Fix print statement:
 


before:  "See the `database_redact_keys` option of Tru` to prevent this."
              
 after:  "See the `database_redact_keys` option of `Tru` to prevent this."

Other details that are good to know but need not be announced:
- There should be something here at least.
