### PR TITLE
added option to make deferred evaluation quieter

### DIFF
--- a/trulens_eval/trulens_eval/feedback/provider/base.py
+++ b/trulens_eval/trulens_eval/feedback/provider/base.py
@@ -5,7 +5,6 @@ import warnings
 import nltk
 from nltk.tokenize import sent_tokenize
 import numpy as np
-from tqdm.auto import tqdm
 
 from trulens_eval.feedback import prompts
 from trulens_eval.feedback.provider.endpoint import base as mod_endpoint
@@ -1198,14 +1197,13 @@ class LLMProvider(Provider):
         Returns:
             Tuple[float, str]: A tuple containing a value between 0.0 (not grounded) and 1.0 (grounded) and a string containing the reasons for the evaluation.
         """
-        nltk.download('punkt')
+        nltk.download('punkt', quiet=True)
         groundedness_scores = {}
         reasons_str = ""
 
         hypotheses = sent_tokenize(statement)
         system_prompt = prompts.LLM_GROUNDEDNESS_SYSTEM
-        for i, hypothesis in enumerate(tqdm(
-                hypotheses, desc="Groundedness per statement in source")):
+        for i, hypothesis in enumerate(hypotheses):
             user_prompt = prompts.LLM_GROUNDEDNESS_USER.format(
                 premise=f"{source}", hypothesis=f"{hypothesis}"
             )

--- a/trulens_eval/trulens_eval/feedback/provider/base.py
+++ b/trulens_eval/trulens_eval/feedback/provider/base.py
@@ -1202,12 +1202,8 @@ class LLMProvider(Provider):
 
         hypotheses = sent_tokenize(statement)
         system_prompt = prompts.LLM_GROUNDEDNESS_SYSTEM
-<<<<<<< esp/quieter_eval
-        for i, hypothesis in enumerate(hypotheses):
-=======
-        
+
         def evaluate_hypothesis(index, hypothesis):
->>>>>>> main
             user_prompt = prompts.LLM_GROUNDEDNESS_USER.format(
                 premise=f"{source}", hypothesis=f"{hypothesis}"
             )

--- a/trulens_eval/trulens_eval/feedback/provider/hugs.py
+++ b/trulens_eval/trulens_eval/feedback/provider/hugs.py
@@ -218,7 +218,7 @@ class Huggingface(Provider):
         Returns:
             Tuple[float, str]: A tuple containing a value between 0.0 (not grounded) and 1.0 (grounded) and a string containing the reasons for the evaluation.
         """
-        nltk.download('punkt')
+        nltk.download('punkt', quiet=True)
         groundedness_scores = {}
 
         reasons_str = ""

--- a/trulens_eval/trulens_eval/tru.py
+++ b/trulens_eval/trulens_eval/tru.py
@@ -749,6 +749,8 @@ class Tru(python.SingletonPerName):
             fork: If set, will start the evaluator in a new process instead of a
                 thread. NOT CURRENTLY SUPPORTED.
 
+            disable_tqdm: If set, will disable progress bar logging from the evaluator.
+
         Returns:
             The started process or thread that is executing the deferred feedback
                 evaluator.
@@ -816,14 +818,15 @@ class Tru(python.SingletonPerName):
                 total=queue_total,
                 postfix={
                     status.name: count for status, count in queue_stats.items()
-                }
+                },
+                disable=disable_tqdm
             )
 
             # Show the status of the results so far.
-            tqdm_total = tqdm(desc="Done Runs", initial=0, unit="runs")
+            tqdm_total = tqdm(desc="Done Runs", initial=0, unit="runs", disable=disable_tqdm)
 
             # Show what is being waited for right now.
-            tqdm_waiting = tqdm(desc="Waiting for Runs", initial=0, unit="runs")
+            tqdm_waiting = tqdm(desc="Waiting for Runs", initial=0, unit="runs", disable=disable_tqdm)
 
             runs_stats = defaultdict(int)
 

--- a/trulens_eval/trulens_eval/tru.py
+++ b/trulens_eval/trulens_eval/tru.py
@@ -738,7 +738,9 @@ class Tru(python.SingletonPerName):
 
     def start_evaluator(self,
                         restart: bool = False,
-                        fork: bool = False) -> Union[Process, Thread]:
+                        fork: bool = False,
+                        disable_tqdm: bool = False
+                       ) -> Union[Process, Thread]:
         """
         Start a deferred feedback function evaluation thread or process.
 


### PR DESCRIPTION
Items to add to release announcement:
- **Added Option to make deferred evaluation quieter**: 
  - If using Deferred evaluation mode with the `tru.start_evaluator()` method, there is a new `disable_tqdm` flag (default `False`), that disables the tqdm progress bars written to stdout when set `True`.
  - This is useful when you are managing the evaluation progress via some other method.

Other details that are good to know but need not be announced:
- This also disables:
  - the `nltk.download()` logging that appears very often in the deferred evaluation log output.
  - the progress bars from the `groundedness_measure_with_cot_reasons` feedback function.
    - Note: I wanted to make a flag to also optionally disable these progress bars, but I was un-successful.