### PR TITLE
Allow transforms to produce main input, output

### DIFF
--- a/trulens_eval/trulens_eval/app.py
+++ b/trulens_eval/trulens_eval/app.py
@@ -1104,8 +1104,19 @@ class App(mod_app_schema.AppDefinition, mod_instruments.WithInstrumentCallbacks,
 
             assert len(calls) > 0, "No information recorded in call."
 
-            main_in = self.main_input(func, sig, bindings, args_transform=args_transform)
-            main_out = self.main_output(func, sig, bindings, ret, ret_transform=ret_transform)
+            main_in = self.main_input(
+                func,
+                sig,
+                bindings,
+                args_transform
+            )
+            main_out = self.main_output(
+                func,
+                sig,
+                bindings,
+                ret,
+                ret_transform
+            )
 
             updates = dict(
                 main_input=jsonify(main_in),

--- a/trulens_eval/trulens_eval/instruments.py
+++ b/trulens_eval/trulens_eval/instruments.py
@@ -133,7 +133,9 @@ class WithInstrumentCallbacks:
         error: Any,
         perf: mod_base_schema.Perf,
         cost: mod_base_schema.Cost,
-        existing_record: Optional[mod_record_schema.Record] = None
+        existing_record: Optional[mod_record_schema.Record] = None,
+        args_transform: Optional[Callable] = None,
+        ret_transform: Optional[Callable] = None
     ):
         """
         Called by instrumented methods if they are root calls (first instrumned
@@ -331,7 +333,7 @@ class Instrument(object):
 
     def tracked_method_wrapper(
         self, query: Lens, func: Callable, method_name: str, cls: type,
-        obj: object
+        obj: object, **tracked_method_kwargs
     ):
         """Wrap a method to capture its inputs/outputs/errors."""
 
@@ -578,7 +580,8 @@ class Instrument(object):
                                 start_time=start_time, end_time=end_time
                             ),
                             cost=cost,
-                            existing_record=records.get(ctx)
+                            existing_record=records.get(ctx),
+                            **tracked_method_kwargs
                         )
 
                 if error is not None:


### PR DESCRIPTION
Items to add to release announcement:
- **Heading**: delete this list if this PR does not introduce any changes that need announcing.
- Optional args_transform and ret_transform arguments to `Instrument.tracked_method_wrapper` that will be called on arguments and return values to determine main input string and output string respectively

Other details that are good to know but need not be announced:
- There should be something here at least.
- No decided interface for this method yet. Can be a decorator argument