### PR TITLE
Evaluation Benchmarks Page

### DIFF
--- a/docs/javascript/tablesort.js
+++ b/docs/javascript/tablesort.js
@@ -1,0 +1,6 @@
+document$.subscribe(function() {
+    var tables = document.querySelectorAll("article table:not([class])")
+    tables.forEach(function(table) {
+      new Tablesort(table)
+    })
+  })

--- a/docs/trulens_eval/evaluation/feedback_evaluations/answer_relevance_benchmark_small.ipynb
+++ b/docs/trulens_eval/evaluation/feedback_evaluations/answer_relevance_benchmark_small.ipynb
@@ -1,1 +1,0 @@
-../../../../trulens_eval/trulens_eval/tests/answer_relevance_benchmark_small.ipynb

--- a/docs/trulens_eval/evaluation/feedback_evaluations/comprehensiveness_benchmark.ipynb
+++ b/docs/trulens_eval/evaluation/feedback_evaluations/comprehensiveness_benchmark.ipynb
@@ -1,1 +1,0 @@
-../../../../trulens_eval/trulens_eval/tests/comprehensiveness_benchmark.ipynb

--- a/docs/trulens_eval/evaluation/feedback_evaluations/context_relevance_benchmark.ipynb
+++ b/docs/trulens_eval/evaluation/feedback_evaluations/context_relevance_benchmark.ipynb
@@ -1,1 +1,0 @@
-../../../../trulens_eval/trulens_eval/tests/context_relevance_benchmark.ipynb

--- a/docs/trulens_eval/evaluation/feedback_evaluations/context_relevance_benchmark_small.ipynb
+++ b/docs/trulens_eval/evaluation/feedback_evaluations/context_relevance_benchmark_small.ipynb
@@ -1,1 +1,0 @@
-../../../../trulens_eval/trulens_eval/tests/context_relevance_benchmark_small.ipynb

--- a/docs/trulens_eval/evaluation/feedback_evaluations/groundedness_benchmark.ipynb
+++ b/docs/trulens_eval/evaluation/feedback_evaluations/groundedness_benchmark.ipynb
@@ -1,1 +1,0 @@
-../../../../trulens_eval/trulens_eval/tests/groundedness_benchmark.ipynb

--- a/docs/trulens_eval/evaluation/feedback_evaluations/index.md
+++ b/docs/trulens_eval/evaluation/feedback_evaluations/index.md
@@ -1,5 +1,0 @@
-# Feedback Evaluations
-
-This is a section heading page. It is presently unused. We can add summaries of
-the content in this section here then uncomment out the appropriate line in
-`mkdocs.yml` to include this section summary in the navigation bar.

--- a/docs/trulens_eval/evaluation_benchmarks/answer_relevance_benchmark_small.ipynb
+++ b/docs/trulens_eval/evaluation_benchmarks/answer_relevance_benchmark_small.ipynb
@@ -1,0 +1,1 @@
+../../../trulens_eval/trulens_eval/tests/answer_relevance_benchmark_small.ipynb

--- a/docs/trulens_eval/evaluation_benchmarks/comprehensiveness_benchmark.ipynb
+++ b/docs/trulens_eval/evaluation_benchmarks/comprehensiveness_benchmark.ipynb
@@ -1,0 +1,1 @@
+../../../trulens_eval/trulens_eval/tests/comprehensiveness_benchmark.ipynb

--- a/docs/trulens_eval/evaluation_benchmarks/context_relevance_benchmark.ipynb
+++ b/docs/trulens_eval/evaluation_benchmarks/context_relevance_benchmark.ipynb
@@ -1,0 +1,1 @@
+../../../trulens_eval/trulens_eval/tests/context_relevance_benchmark.ipynb

--- a/docs/trulens_eval/evaluation_benchmarks/context_relevance_benchmark_calibration.ipynb
+++ b/docs/trulens_eval/evaluation_benchmarks/context_relevance_benchmark_calibration.ipynb
@@ -1,0 +1,1 @@
+../../../trulens_eval/trulens_eval/tests/context_relevance_benchmark_calibration.ipynb

--- a/docs/trulens_eval/evaluation_benchmarks/context_relevance_benchmark_small.ipynb
+++ b/docs/trulens_eval/evaluation_benchmarks/context_relevance_benchmark_small.ipynb
@@ -1,0 +1,1 @@
+../../../trulens_eval/trulens_eval/tests/context_relevance_benchmark_small.ipynb

--- a/docs/trulens_eval/evaluation_benchmarks/groundedness_benchmark.ipynb
+++ b/docs/trulens_eval/evaluation_benchmarks/groundedness_benchmark.ipynb
@@ -1,0 +1,1 @@
+../../../trulens_eval/trulens_eval/tests/groundedness_benchmark.ipynb

--- a/docs/trulens_eval/evaluation_benchmarks/index.md
+++ b/docs/trulens_eval/evaluation_benchmarks/index.md
@@ -6,8 +6,6 @@ TruLens relies on feedback functions to score the performance of LLM apps, which
 
 Consequently, these feedback functions face typical large language model (LLM) challenges in rigorous production environments, including prompt sensitivity and non-determinism, especially when incorporating Mixture-of-Experts and model-as-a-service solutions like those from _OpenAI_, _Mistral_, and others. Drawing inspiration from works on [Judging LLM-as-a-Judge](https://arxiv.org/pdf/2306.05685), we outline findings from our analysis of feedback function performance against task-aligned benchmark data. To accomplish this, we first need to align feedback function tasks to relevant benchmarks in order to gain access to large scale ground truth data for the feedback functions. We then are able to easily compute metrics across a variety of implementations and models.
 
-Here, we'll outline the primary findings from these analyses on critical feedback functions across a variety of implementations. We will continue to expand this benchmarking over time.
-
 ## Context Relevance
 
 ### Methods
@@ -21,7 +19,7 @@ Observing that many information retrieval (IR) benchmarks, such as [MS MARCO](ht
 Here, we leverage the 500 random sampled rows from [MS MARCO](https://arxiv.org/abs/1611.09268) dataset for benchmarking context relevance.
 
 | **Feedback Function Base Model** | **MS MARCO nDCG** | **MS MARCO ECE** | **MS MARCO Recall@5** | **MS MARCO Precision@1** |
-| --- | --- | --- | --- | --- | --- | --- |
+| :---: | :---: | :---: | :---: | :---: |
 | GPT 3.5 Turbo | 0.567230 | 0.5474 | 0.94 | 0.218365 |
 | GPT 4 Turbo | 0.66496 | 0.4430 | 0.94 | 0.312167 |
 | Claude 2 | 0.599110 | 0.6690 | 0.90 | 0.268214 |
@@ -31,7 +29,7 @@ Here, we leverage the 500 random sampled rows from [MS MARCO](https://arxiv.org/
 Calibrations are crucial steps in the evaluation process of feedback functions. They help fine-tune the models and ensure their performance aligns with the desired benchmarks. In this context, we test ablations of LLMs with varying temperatures to understand the relationship between the temperature parameter and evaluation reliability.
 
 | **Temperature** | **Feedback Function Base Model**       | **ECE**      |
-| --- | --- | --- |
+| :---: | :---: | :---: |
 | 0.0         | GPT-3.5-Turbo | 0.492735 |
 | 0.3         | GPT-3.5-Turbo | 0.477844 |
 | 0.7         | GPT-3.5-Turbo | 0.467127 |
@@ -39,7 +37,7 @@ Calibrations are crucial steps in the evaluation process of feedback functions. 
 
 
 | **Temperature** | **Feedback Function Base Model**       | **ECE**      |
-| --- | --- | --- |
+| :---: | :---: | :---: |
 | 0.0         | GPT-4-Turbo | 0.741519 |
 | 0.3         | GPT-4-Turbo | 0.742373 |
 | 0.7         | GPT-4-Turbo | 0.737771 |
@@ -53,7 +51,7 @@ Calibrations are crucial steps in the evaluation process of feedback functions. 
 
 Observing that many summarization benchmarks, such as those found at [SummEval](https://arxiv.org/abs/2007.12626), use human annotation of numerical scores, we propose to frame the problem of evaluating groundedness tasks as evaluating a summarization system. In particular, we generate test cases from [SummEval](https://arxiv.org/abs/2007.12626).
 
-SummEval is one of the datasets dedicated to automated evaluations on summarization tasks, which are closely related to the groundedness evaluation in RAG with the retrieved context (i.e. the source) and response (i.e. the summary). It contains human annotation of numerical score (**1** to **5**) comprised of scoring from 3 human expert annotators and 5 croweded-sourced annotators. There are 16 models being used for generation in total for 100 paragraphs in the test set, so there are a total of 16,000 machine-generated summaries. Each paragraph also has several human-written summaries for comparative analysis. 
+SummEval is one of the datasets dedicated to automated evaluations on summarization tasks, which are closely related to the groundedness evaluation in RAG with the retrieved context (i.e. the source) and response (i.e. the summary). It contains human annotation of numerical score (**1** to **5**) comprised of scoring from 3 human expert annotators and 5 crowd-sourced annotators. There are 16 models being used for generation in total for 100 paragraphs in the test set, so there are a total of 16,000 machine-generated summaries. Each paragraph also has several human-written summaries for comparative analysis. 
 
 For evaluating groundedness feedback functions, we compute the annotated "consistency" scores, a measure of whether the summarized response is factually consisntent with the source texts and hence can be used as a proxy to evaluate groundedness in our RAG triad, and normalized to **0** to **1** score as our **expected_score** and to match the output of feedback functions.
 
@@ -61,8 +59,8 @@ For evaluating groundedness feedback functions, we compute the annotated "consis
 
 ### Results
 
-| **Feedback Function Base Model** | **SummEval MAE** | **Latency** | **Cost / M Tokens** |
-| --- | --- | --- | --- |
+| **Feedback Function Base Model** | **SummEval MAE** | **Latency** | **Total Cost** |
+| :---: | :---: | :---: | :---: |
 | Llama-3 70B Instruct | 0.054653 | 12.184049 | 0.000005 |
 | Arctic Instruct | 0.076393 | 6.446394 | 0.000003 |
 | GPT 4o | 0.057695 | 6.440239 | 0.012691 |
@@ -94,8 +92,7 @@ as our **expected_score** and to match the output of feedback functions.
 ### Results
 
 | **Feedback Function Base Model** | **Meetingbank MAE** |
-| --- | --- | --- | --- |
+| :---: | :---: |
 | GPT 3.5 Turbo | 0.170573 |
 | GPT 4 Turbo | 0.163199 |
 | GPT 4o | 0.183592 |
-

--- a/docs/trulens_eval/evaluation_benchmarks/index.md
+++ b/docs/trulens_eval/evaluation_benchmarks/index.md
@@ -1,31 +1,58 @@
 # Evaluation Benchmarks
 
+## Introduction
+
 TruLens relies on feedback functions to score the performance of LLM apps, which are implemented across a variety of LLMs and smaller models. The numerical scoring scheme adopted by _TruLens_' feedback functions is intuitive for generating aggregated results from eval runs that are easy to interpret and visualize across different applications of interest. However, it begs the question how trustworthy these scores actually are, given they are at their core next-token-prediction-style generation from meticulously designed prompts.
 
-Consequently, these feedback functions face typical large language model (LLM) challenges in rigorous production environments, including prompt sensitivity and non-determinism, especially when incorporating Mixture-of-Experts and model-as-a-service solutions like those from _OpenAI_. Drawing inspiration from works on [Judging LLM-as-a-Judge](https://arxiv.org/pdf/2306.05685), we outline findings from our analysis of feedback function performance against task-aligned benchmark data. To accomplish this, we first need to align feedback function tasks to relevant benchmarks in order to gain access to large scale ground truth data for the feedback functions. We then are able to easily compute metrics such as MAE (mean absolute error) across a variety of implementations and models.
+Consequently, these feedback functions face typical large language model (LLM) challenges in rigorous production environments, including prompt sensitivity and non-determinism, especially when incorporating Mixture-of-Experts and model-as-a-service solutions like those from _OpenAI_, _Mistral_, and others. Drawing inspiration from works on [Judging LLM-as-a-Judge](https://arxiv.org/pdf/2306.05685), we outline findings from our analysis of feedback function performance against task-aligned benchmark data. To accomplish this, we first need to align feedback function tasks to relevant benchmarks in order to gain access to large scale ground truth data for the feedback functions. We then are able to easily compute metrics across a variety of implementations and models.
 
 Here, we'll outline the primary findings from these analyses on critical feedback functions across a variety of implementations. We will continue to expand this benchmarking over time.
 
 ## Context Relevance
 
-Observing that many information retrieval (IR) benchmarks, such as those found at https://huggingface.co/datasets/ms_marco/viewer/v2.1, use binary labels, we propose to frame the problem of evaluating context relevance tasks as evaluating a recommender system. In essence, we argue that the relative importance or ranking based on the score assignments is all you need to achieve meta-evaluation against human golden sets. The intuition is that it is a sufficient proxy to trustworthiness if feedback functions demonstrate discriminative capabilities that reliably and consistently assign items, be they context chunks or generated responses, with weights and ordering closely mirroring human preferences.
+### Methods
+
+Observing that many information retrieval (IR) benchmarks, such as [MS MARCO](https://huggingface.co/datasets/ms_marco/viewer/v2.1), use binary labels, we propose to frame the problem of evaluating context relevance tasks as evaluating a recommender system. In essence, we argue that the relative importance or ranking based on the score assignments is all you need to achieve meta-evaluation against human golden sets. The intuition is that it is a sufficient proxy to trustworthiness if feedback functions demonstrate discriminative capabilities that reliably and consistently assign items, be they context chunks or generated responses, with weights and ordering closely mirroring human preferences.
+
+[See the code.](context_relevance_benchmark.ipynb)
+
+### Results
 
 Here, we leverage the 500 random sampled rows from [MS MARCO](https://arxiv.org/abs/1611.09268) dataset for benchmarking context relevance.
 
-### Performance on MS MARCO
+| **Feedback Function Base Model** | **MS MARCO NDCG** | **MS MARCO nDCG** | **MS MARCO Recall@K** | **MS MARCO Precision@1** | **Latency** | **Cost/M Tokens** |
+| --- | --- | --- | --- | --- | --- | --- |
+| GPT 3.5 Turbo | XX | XX | XX | XX | XX | XX |
+| GPT 4 Turbo | XX | XX | XX | XX | XX | XX |
+| GPT 4o | XX | XX | XX | XX | XX | XX |
+| Arctic Instruct | XX | XX | XX | XX | XX | XX |
+| Llama 3 8B | XX | XX | XX | XX | XX | XX |
+| Mistral 7B | XX | XX | XX | XX | XX | XX |
 
-| Feedback Function Base Model | NDCG | nDCG | Recall@K | Precision@1 |
-| --- | --- | --- | --- | --- |
-| GPT 3.5 Turbo | XX | XX | XX | XX |
-| GPT 4 Turbo | XX | XX | XX | XX |
-| GPT 4o | XX | XX | XX | XX |
-| Arctic Instruct | XX | XX | XX | XX |
-| Llama 3 8B | XX | XX | XX | XX |
-| Mistral 7B | XX | XX | XX | XX |
+### Ablations
 
-[Benchmarking code](context_relevance_benchmark.ipynb)
+Calibrations are crucial steps in the evaluation process of feedback functions. They help fine-tune the models and ensure their performance aligns with the desired benchmarks. In this context, we test ablations of LLMs with varying temperatures to understand the relationship between the temperature parameter and evaluation reliability.
+
+| **Temperature** | **Feedback Function Base Model**       | **ECE**      |
+| --- | --- | --- |
+| 0.0         | GPT-3.5-Turbo | 0.492735 |
+| 0.3         | GPT-3.5-Turbo | 0.477844 |
+| 0.7         | GPT-3.5-Turbo | 0.467127 |
+| 1.0         | GPT-3.5-Turbo | 0.465417 |
+
+
+| **Temperature** | **Feedback Function Base Model**       | **ECE**      |
+| --- | --- | --- |
+| 0.0         | GPT-4-Turbo | 0.741519 |
+| 0.3         | GPT-4-Turbo | 0.742373 |
+| 0.7         | GPT-4-Turbo | 0.737771 |
+| 1.0         | GPT-4-Turbo | 0.732807 |
+
+[See the code.](context_relevance_calibration.ipynb)
 
 ## Groundedness
+
+### Methods
 
 Observing that many summarization benchmarks, such as those found at [SummEval](https://arxiv.org/abs/2007.12626), use human annotation of numerical scores, we propose to frame the problem of evaluating groundedness tasks as evaluating a summarization system. In particular, we generate test cases from [SummEval](https://arxiv.org/abs/2007.12626).
 
@@ -33,21 +60,23 @@ SummEval is one of the datasets dedicated to automated evaluations on summarizat
 
 For evaluating groundedness feedback functions, we compute the annotated "consistency" scores, a measure of whether the summarized response is factually consisntent with the source texts and hence can be used as a proxy to evaluate groundedness in our RAG triad, and normalized to **0** to **1** score as our **expected_score** and to match the output of feedback functions.
 
-| Feedback Function Base Model | MAE | Latency | Total Cost |
-| --- | --- | --- | --- |
-| GPT 3.5 Turbo | XX | XX | XX |
-| GPT 4 Turbo | XX | XX | XX |
-| GPT 4o | XX | XX | XX |
-| Arctic Instruct | XX | XX | XX |
-| Llama 3 8B | XX | XX | XX |
-| Mistral 7B | XX | XX | XX |
+[See the code.](groundedness_benchmark.ipynb)
 
-[Benchmarking code](groundedness_benchmark.ipynb)
+### Results
+
+| **Feedback Function Base Model** | **SummEval MAE** | **Latency** | **Cost / M Tokens** |
+| --- | --- | --- | --- |
+| Llama-3 70B Instruct | 0.054653 | 12.184049 | 0.000005 |
+| Arctic Instruct | 0.076393 | 6.446394 | 0.000003 |
+| GPT 4o | 0.057695 | 6.440239 | 0.012691 |
+| Mixtral 8x7B Instruct | 0.340668 | 4.89267 | 0.000264 |
 
 ## Comprehensiveness
 
+### Methods
+
 This notebook follows an evaluation of a set of test cases generated from human
-annotated datasets. In particular, we generate test cases from
+annotated datasets. In particular, we generate test cases from 
 [MeetingBank](https://arxiv.org/abs/2305.17529) to evaluate our
 comprehensiveness feedback function.
 
@@ -62,4 +91,14 @@ For evaluating comprehensiveness feedback functions, we compute the annotated
 main points of the meeting segment. A good summary should contain all and only
 the important information of the source., and normalized to **0** to **1** score
 as our **expected_score** and to match the output of feedback functions.
+
+[See the code.](comprehensiveness_benchmark.ipynb)
+
+### Results
+
+| **Feedback Function Base Model** | **Meetingbank MAE** | **Latency** | **Cost / M Tokens** |
+| --- | --- | --- | --- |
+| GPT 3.5 Turbo | 0.170573 | XX | XX |
+| GPT 4 Turbo | 0.163199 | XX | XX |
+| GPT 4o | XX | 0.183592 | XX |
 

--- a/docs/trulens_eval/evaluation_benchmarks/index.md
+++ b/docs/trulens_eval/evaluation_benchmarks/index.md
@@ -20,14 +20,11 @@ Observing that many information retrieval (IR) benchmarks, such as [MS MARCO](ht
 
 Here, we leverage the 500 random sampled rows from [MS MARCO](https://arxiv.org/abs/1611.09268) dataset for benchmarking context relevance.
 
-| **Feedback Function Base Model** | **MS MARCO NDCG** | **MS MARCO nDCG** | **MS MARCO Recall@K** | **MS MARCO Precision@1** | **Latency** | **Cost/M Tokens** |
+| **Feedback Function Base Model** | **MS MARCO nDCG** | **MS MARCO ECE** | **MS MARCO Recall@5** | **MS MARCO Precision@1** |
 | --- | --- | --- | --- | --- | --- | --- |
-| GPT 3.5 Turbo | XX | XX | XX | XX | XX | XX |
-| GPT 4 Turbo | XX | XX | XX | XX | XX | XX |
-| GPT 4o | XX | XX | XX | XX | XX | XX |
-| Arctic Instruct | XX | XX | XX | XX | XX | XX |
-| Llama 3 8B | XX | XX | XX | XX | XX | XX |
-| Mistral 7B | XX | XX | XX | XX | XX | XX |
+| GPT 3.5 Turbo | 0.567230 | 0.5474 | 0.94 | 0.218365 |
+| GPT 4 Turbo | 0.66496 | 0.4430 | 0.94 | 0.312167 |
+| Claude 2 | 0.599110 | 0.6690 | 0.90 | 0.268214 |
 
 ### Ablations
 
@@ -96,9 +93,9 @@ as our **expected_score** and to match the output of feedback functions.
 
 ### Results
 
-| **Feedback Function Base Model** | **Meetingbank MAE** | **Latency** | **Cost / M Tokens** |
+| **Feedback Function Base Model** | **Meetingbank MAE** |
 | --- | --- | --- | --- |
-| GPT 3.5 Turbo | 0.170573 | XX | XX |
-| GPT 4 Turbo | 0.163199 | XX | XX |
-| GPT 4o | XX | 0.183592 | XX |
+| GPT 3.5 Turbo | 0.170573 |
+| GPT 4 Turbo | 0.163199 |
+| GPT 4o | 0.183592 |
 

--- a/docs/trulens_eval/evaluation_benchmarks/index.md
+++ b/docs/trulens_eval/evaluation_benchmarks/index.md
@@ -1,0 +1,65 @@
+# Evaluation Benchmarks
+
+TruLens relies on feedback functions to score the performance of LLM apps, which are implemented across a variety of LLMs and smaller models. The numerical scoring scheme adopted by _TruLens_' feedback functions is intuitive for generating aggregated results from eval runs that are easy to interpret and visualize across different applications of interest. However, it begs the question how trustworthy these scores actually are, given they are at their core next-token-prediction-style generation from meticulously designed prompts.
+
+Consequently, these feedback functions face typical large language model (LLM) challenges in rigorous production environments, including prompt sensitivity and non-determinism, especially when incorporating Mixture-of-Experts and model-as-a-service solutions like those from _OpenAI_. Drawing inspiration from works on [Judging LLM-as-a-Judge](https://arxiv.org/pdf/2306.05685), we outline findings from our analysis of feedback function performance against task-aligned benchmark data. To accomplish this, we first need to align feedback function tasks to relevant benchmarks in order to gain access to large scale ground truth data for the feedback functions. We then are able to easily compute metrics such as MAE (mean absolute error) across a variety of implementations and models.
+
+Here, we'll outline the primary findings from these analyses on critical feedback functions across a variety of implementations. We will continue to expand this benchmarking over time.
+
+## Context Relevance
+
+Observing that many information retrieval (IR) benchmarks, such as those found at https://huggingface.co/datasets/ms_marco/viewer/v2.1, use binary labels, we propose to frame the problem of evaluating context relevance tasks as evaluating a recommender system. In essence, we argue that the relative importance or ranking based on the score assignments is all you need to achieve meta-evaluation against human golden sets. The intuition is that it is a sufficient proxy to trustworthiness if feedback functions demonstrate discriminative capabilities that reliably and consistently assign items, be they context chunks or generated responses, with weights and ordering closely mirroring human preferences.
+
+Here, we leverage the 500 random sampled rows from [MS MARCO](https://arxiv.org/abs/1611.09268) dataset for benchmarking context relevance.
+
+### Performance on MS MARCO
+
+| Feedback Function Base Model | NDCG | nDCG | Recall@K | Precision@1 |
+| --- | --- | --- | --- | --- |
+| GPT 3.5 Turbo | XX | XX | XX | XX |
+| GPT 4 Turbo | XX | XX | XX | XX |
+| GPT 4o | XX | XX | XX | XX |
+| Arctic Instruct | XX | XX | XX | XX |
+| Llama 3 8B | XX | XX | XX | XX |
+| Mistral 7B | XX | XX | XX | XX |
+
+[Benchmarking code](context_relevance_benchmark.ipynb)
+
+## Groundedness
+
+Observing that many summarization benchmarks, such as those found at [SummEval](https://arxiv.org/abs/2007.12626), use human annotation of numerical scores, we propose to frame the problem of evaluating groundedness tasks as evaluating a summarization system. In particular, we generate test cases from [SummEval](https://arxiv.org/abs/2007.12626).
+
+SummEval is one of the datasets dedicated to automated evaluations on summarization tasks, which are closely related to the groundedness evaluation in RAG with the retrieved context (i.e. the source) and response (i.e. the summary). It contains human annotation of numerical score (**1** to **5**) comprised of scoring from 3 human expert annotators and 5 croweded-sourced annotators. There are 16 models being used for generation in total for 100 paragraphs in the test set, so there are a total of 16,000 machine-generated summaries. Each paragraph also has several human-written summaries for comparative analysis. 
+
+For evaluating groundedness feedback functions, we compute the annotated "consistency" scores, a measure of whether the summarized response is factually consisntent with the source texts and hence can be used as a proxy to evaluate groundedness in our RAG triad, and normalized to **0** to **1** score as our **expected_score** and to match the output of feedback functions.
+
+| Feedback Function Base Model | MAE | Latency | Total Cost |
+| --- | --- | --- | --- |
+| GPT 3.5 Turbo | XX | XX | XX |
+| GPT 4 Turbo | XX | XX | XX |
+| GPT 4o | XX | XX | XX |
+| Arctic Instruct | XX | XX | XX |
+| Llama 3 8B | XX | XX | XX |
+| Mistral 7B | XX | XX | XX |
+
+[Benchmarking code](groundedness_benchmark.ipynb)
+
+## Comprehensiveness
+
+This notebook follows an evaluation of a set of test cases generated from human
+annotated datasets. In particular, we generate test cases from
+[MeetingBank](https://arxiv.org/abs/2305.17529) to evaluate our
+comprehensiveness feedback function.
+
+MeetingBank is one of the datasets dedicated to automated evaluations on
+summarization tasks, which are closely related to the comprehensiveness
+evaluation in RAG with the retrieved context (i.e. the source) and response
+(i.e. the summary). It contains human annotation of numerical score (**1** to
+**5**). 
+
+For evaluating comprehensiveness feedback functions, we compute the annotated
+"informativeness" scores, a measure of how well  the summaries capture all the
+main points of the meeting segment. A good summary should contain all and only
+the important information of the source., and normalized to **0** to **1** score
+as our **expected_score** and to match the output of feedback functions.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -306,3 +306,5 @@ extra_javascript:
   - https://polyfill.io/v3/polyfill.min.js?features=es6
   - javascript/tex-mml-chtml-3.0.0.js
   - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
+  - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js
+  - javascript/tablesort.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -206,8 +206,9 @@ nav:
           - Running on existing data: trulens_eval/evaluation/running_feedback_functions/existing_data.md
       - Generating Test Cases:
           - trulens_eval/evaluation/generate_test_cases/index.md
-      - Feedback Evaluations:
-          # PLACEHOLDER: - trulens_eval/evaluation/feedback_evaluations/index.md
+  - 📊 Evaluation Benchmarks:
+      - trulens_eval/evaluation_benchmarks/index.md
+      - Evaluation Benchmark Code:
           - Answer Relevance Benchmark (small): trulens_eval/evaluation/feedback_evaluations/answer_relevance_benchmark_small.ipynb
           - Comprehensiveness Benchmark: trulens_eval/evaluation/feedback_evaluations/comprehensiveness_benchmark.ipynb
           - Context Relevance Benchmark (small): trulens_eval/evaluation/feedback_evaluations/context_relevance_benchmark_small.ipynb


### PR DESCRIPTION
Items to add to release announcement:
- New top-level page for displaying evaluation benchmarks
- Add instant-load & tablesort

<img width="1499" alt="Screenshot 2024-06-11 at 12 37 04 PM" src="https://github.com/truera/trulens/assets/171636836/762bdb26-9929-4f21-a9d4-640e59bb21d5">
<img width="798" alt="Screenshot 2024-06-11 at 12 37 44 PM" src="https://github.com/truera/trulens/assets/171636836/d4bc98aa-c32a-4efb-82f5-f5fc52c3675c">
