### PR TITLE
fix groundedness with no supporting evidence

### DIFF
--- a/trulens_eval/trulens_eval/feedback/provider/base.py
+++ b/trulens_eval/trulens_eval/feedback/provider/base.py
@@ -1222,7 +1222,8 @@ class LLMProvider(Provider):
 
         for i, score, reason in results:
             groundedness_scores[f"statement_{i}"] = score
-            reasons_str += f"STATEMENT {i}:\n{reason['reason']}\n"
+            reason_str = reason['reason'] if 'reason' in reason else ""
+            reasons_str += f"STATEMENT {i}:\n{reason_str}\n"
 
         # Calculate the average groundedness score from the scores dictionary
         average_groundedness_score = float(np.mean(list(groundedness_scores.values())))

--- a/trulens_eval/trulens_eval/feedback/provider/base.py
+++ b/trulens_eval/trulens_eval/feedback/provider/base.py
@@ -1222,7 +1222,7 @@ class LLMProvider(Provider):
 
         for i, score, reason in results:
             groundedness_scores[f"statement_{i}"] = score
-            reason_str = reason['reason'] if 'reason' in reason else ""
+            reason_str = reason['reason'] if 'reason' in reason else "reason not generated"
             reasons_str += f"STATEMENT {i}:\n{reason_str}\n"
 
         # Calculate the average groundedness score from the scores dictionary


### PR DESCRIPTION
Items to add to release announcement:
- **Heading**: fix groundedness feedback with no supporting evidence


Currently if you use feedback `groundedness_measure_with_cot_reasons` and one of the hypothesis is returning no supporting evidence, the feedback is completely broken and not even the score is visible. This is due to the fact this feedback implies to always have a "reason" behind the score. 

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1c9a72915db6391a341824c6ad5b7fea5d88c4dd  | 
|--------|--------|

### Summary:
This PR fixes an issue in the `groundedness_measure_with_cot_reasons` feedback function to handle cases with no supporting evidence without breaking.

**Key points**:
- Modified `evaluate_hypothesis` function in `Provider` class to handle missing 'reason' key gracefully.
- Ensures feedback system remains operational even when no supporting evidence is provided.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->