### PR TITLE
improve langchain prompting using native messages

### DIFF
--- a/trulens_eval/trulens_eval/feedback/provider/langchain.py
+++ b/trulens_eval/trulens_eval/feedback/provider/langchain.py
@@ -1,14 +1,25 @@
-import json
 import logging
 from typing import Dict, Optional, Sequence, Union
 
 from langchain.chat_models.base import BaseChatModel
 from langchain.llms.base import BaseLLM
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    BaseMessage
+)
 
 from trulens_eval.feedback.provider.base import LLMProvider
 from trulens_eval.feedback.provider.endpoint import LangchainEndpoint
 
 logger = logging.getLogger(__name__)
+
+
+def _convert_message(message: Dict) -> BaseMessage:
+    """Convert a message to a LangChain BaseMessage."""
+    if not "role" in message or message["role"] == "user":
+        return HumanMessage(content=message["content"])
+    return AIMessage(content=message["content"])
 
 
 class Langchain(LLMProvider):
@@ -57,8 +68,8 @@ class Langchain(LLMProvider):
             predict = self.endpoint.chain.predict(prompt, **kwargs)
 
         elif messages is not None:
-            prompt = json.dumps(messages)
-            predict = self.endpoint.chain.predict(prompt, **kwargs)
+            messages = [_convert_message(message) for message in messages]
+            predict = self.endpoint.chain.predict_messages(messages, **kwargs).content
 
         else:
             raise ValueError("`prompt` or `messages` must be specified.")


### PR DESCRIPTION
Currently when using LangChain chain as eval, the messages are serialized as json in the llm prompt, giving really bad results. 
Instead langchain llm offers a method `predict_messages` that handles the prompt in a more performant way.

Changes:
- Switches to the native langchain prompting for messages

This directly impact all the builtin feedback functions
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 30ddaac71e2a898ca2a89be2f13eb082db7f4218  | 
|--------|--------|

### Summary:
Enhances LangChain prompting by using native `predict_messages` and a new helper function `_convert_message` for message conversion.

**Key points**:
- Removed JSON serialization in message prompting
- Added `_convert_message` to convert dict to `BaseMessage`
- Used `predict_messages` for better performance


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->