### PR TITLE
Fix cost tracking in OpenAI and LiteLLM endpoints

### DIFF
--- a/trulens_eval/trulens_eval/feedback/provider/endpoint/litellm.py
+++ b/trulens_eval/trulens_eval/feedback/provider/endpoint/litellm.py
@@ -51,7 +51,11 @@ class LiteLLMCallback(EndpointCallback):
                 ("n_prompt_tokens", "prompt_tokens"),
                 ("n_completion_tokens", "completion_tokens"),
             ]:
-                setattr(self.cost, cost_field, usage.get(litellm_field, 0))
+                setattr(
+                    self.cost, cost_field,
+                    getattr(self.cost, cost_field, 0) +
+                    usage.get(litellm_field, 0)
+                )
 
         if self.endpoint.litellm_provider not in ["openai"]:
             # The total cost does not seem to be properly tracked except by

--- a/trulens_eval/trulens_eval/feedback/provider/endpoint/openai.py
+++ b/trulens_eval/trulens_eval/feedback/provider/endpoint/openai.py
@@ -198,7 +198,8 @@ class OpenAICallback(EndpointCallback):
         ]:
             setattr(
                 self.cost, cost_field,
-                getattr(self.langchain_handler, langchain_field)
+                getattr(self.cost, cost_field, 0) +
+                getattr(self.langchain_handler, langchain_field, 0)
             )
 
 


### PR DESCRIPTION
Items to add to release announcement:
- **Heading**: 
As each `EndpointCallback` can be invoked multiple times throughout the lifetime of a thunk / instrumented wrapped call, we need to increment instead of just overriding the cost fields in each request. 

Thanks @sfc-gh-dkurokawa for catching this in https://github.com/truera/trulens/pull/1202#discussion_r1639276937


