### PR TITLE
remove deprecated legacy caching

### DIFF
--- a/trulens_eval/trulens_eval/Leaderboard.py
+++ b/trulens_eval/trulens_eval/Leaderboard.py
@@ -9,16 +9,14 @@ from millify import millify
 import streamlit as st
 from streamlit_extras.switch_page_button import switch_page
 
+from trulens_eval import Tru
 from trulens_eval.database import base as mod_db
 from trulens_eval.database.legacy.migration import MIGRATION_UNKNOWN_STR
 from trulens_eval.utils.streamlit import init_from_args
-from trulens_eval.ux.page_config import set_page_config
-from trulens_eval.ux.styles import CATEGORY
-
-from trulens_eval import Tru
 from trulens_eval.ux import styles
 from trulens_eval.ux.components import draw_metadata
 from trulens_eval.ux.page_config import set_page_config
+from trulens_eval.ux.styles import CATEGORY
 
 if __name__ == "__main__":
     # If not imported, gets args from command line and creates Tru singleton

--- a/trulens_eval/trulens_eval/Leaderboard.py
+++ b/trulens_eval/trulens_eval/Leaderboard.py
@@ -15,8 +15,6 @@ from trulens_eval.utils.streamlit import init_from_args
 from trulens_eval.ux.page_config import set_page_config
 from trulens_eval.ux.styles import CATEGORY
 
-st.runtime.legacy_caching.clear_cache()
-
 from trulens_eval import Tru
 from trulens_eval.ux import styles
 from trulens_eval.ux.components import draw_metadata


### PR DESCRIPTION
Other details that are good to know but need not be announced:
- Streamlit deprecated legacy caching. Removing from the leaderboard