### PR TITLE
Use float instead of flooring in feedback score extraction + update docstring

### DIFF
--- a/trulens_eval/tests/unit/test_feedback_score_generation.py
+++ b/trulens_eval/tests/unit/test_feedback_score_generation.py
@@ -21,9 +21,9 @@ test_data = [
     ("7", 7),
     ("This deserves a 6, I believe.", 6),
     ("Not relevant. Score: 0.", 0),
-    ("Some text here. Score: 10.0", 10),
-    ("Score: 4.5", 4),
-    ("Score is 8.333", 8)
+    ("Some text here. Score: 10.0", 10.0),
+    ("Score: 4.5", 4.5),
+    ("Score is 8.333", 8.333)
 ]
 
 

--- a/trulens_eval/trulens_eval/utils/generated.py
+++ b/trulens_eval/trulens_eval/utils/generated.py
@@ -26,7 +26,7 @@ class ParseError(Exception):
         self.pattern = pattern
 
 
-def validate_rating(rating) -> int:
+def validate_rating(rating) -> float:
     """Validate a rating is between 0 and 10."""
 
     if not 0 <= rating <= 10:
@@ -73,7 +73,7 @@ def re_0_10_rating(s: str) -> int:
     for match in matches:
         try:
             vals.add(
-                validate_rating(round(float(match)))
+                validate_rating(float(match))
             )  # Handle float numbers as well
         except ValueError:
             pass

--- a/trulens_eval/trulens_eval/utils/generated.py
+++ b/trulens_eval/trulens_eval/utils/generated.py
@@ -51,7 +51,7 @@ PATTERN_INTEGER: re.Pattern = re.compile(r"([+-]?[1-9][0-9]*|0)")
 def re_0_10_rating(s: str) -> int:
     """Extract a 0-10 rating from a string.
     
-    If the string does not match an integer or matches an integer outside the
+    If the string does not match an integer/a float or matches an integer/a float outside the
     0-10 range, raises an error instead. If multiple numbers are found within
     the expected 0-10 range, the smallest is returned.
 
@@ -62,7 +62,7 @@ def re_0_10_rating(s: str) -> int:
         int: Extracted rating. 
     
     Raises:
-        ParseError: If no integers between 0 and 10 are found in the string.
+        ParseError: If no integers/floats between 0 and 10 are found in the string.
     """
 
     matches = PATTERN_NUMBER.findall(s)
@@ -73,7 +73,7 @@ def re_0_10_rating(s: str) -> int:
     for match in matches:
         try:
             vals.add(
-                validate_rating(int(float(match)))
+                validate_rating(round(float(match)))
             )  # Handle float numbers as well
         except ValueError:
             pass


### PR DESCRIPTION
# Description

Use rounding instead of flooring in feedback score extraction + update docstring

## Other details good to know for developers

Please include any other details of this change useful for TruLens developers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
