### PR TITLE
Fix small typo in arctic quickstart notebook

### DIFF
--- a/trulens_eval/examples/expositional/models/arctic_quickstart.ipynb
+++ b/trulens_eval/examples/expositional/models/arctic_quickstart.ipynb
@@ -315,7 +315,7 @@
    ],
    "source": [
     "from trulens_eval import Feedback, Select\n",
-    "froom trulens_eval.feedback.provider import Cortex\n",
+    "from trulens_eval.feedback.provider import Cortex\n",
     "\n",
     "import numpy as np\n",
     "\n",


### PR DESCRIPTION
# Description

Fix small typo in arctic quickstart notebook (`froom` to `from`)
## Other details good to know for developers

Please include any other details of this change useful for TruLens developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
