### PR TITLE
Change context_filter guard rail to take in an argument for what to use as the prompt as it was confusing and causing issues before.

### DIFF
--- a/trulens_eval/examples/snowflake_demo/feedback.py
+++ b/trulens_eval/examples/snowflake_demo/feedback.py
@@ -34,12 +34,12 @@ small_local_model_provider = SmallLocalModels()
 f_groundedness = (
     Feedback(
         provider.groundedness_measure_with_cot_reasons, name="Groundedness"
-    ).on(Select.RecordCalls.retrieve_context.rets[1][:]).on_output()
+    ).on(Select.RecordCalls.retrieve_context.rets[:]).on_output()
 )
 f_context_relevance = (
     Feedback(provider.context_relevance,
              name="Context Relevance").on_input().on(
-                 Select.RecordCalls.retrieve_context.rets[1][:]
+                 Select.RecordCalls.retrieve_context.rets[:]
              ).aggregate(np.mean
                         )  # choose a different aggregation method if you wish
 )
@@ -47,7 +47,7 @@ f_small_local_models_context_relevance = (
     Feedback(
         small_local_model_provider.context_relevance,
         name="[Small Local Model] Context Relevance",
-    ).on_input().on(Select.RecordCalls.retrieve_context.rets[1][:]).aggregate(
+    ).on_input().on(Select.RecordCalls.retrieve_context.rets[:]).aggregate(
         np.mean
     )  # choose a different aggregation method if you wish
 )

--- a/trulens_eval/examples/snowflake_demo/llm.py
+++ b/trulens_eval/examples/snowflake_demo/llm.py
@@ -2,6 +2,7 @@ import json
 import re
 from typing import AsyncIterator, List, Optional
 
+from feedback import f_small_local_models_context_relevance
 import replicate
 from retrieve import AVAILABLE_RETRIEVERS
 from schema import Conversation
@@ -9,11 +10,9 @@ from schema import Message
 import streamlit as st
 from streamlit.delta_generator import DeltaGenerator
 
+from trulens_eval.guardrails.base import context_filter
 # replicate key for running model
 from trulens_eval.tru_custom_app import instrument
-from trulens_eval.guardrails.base import context_filter
-
-from feedback import f_context_relevance
 
 FRIENDLY_MAPPING = {
     "Snowflake Arctic": "snowflake/snowflake-arctic-instruct",
@@ -160,9 +159,14 @@ class StreamGenerator:
         self, last_user_message: str, prompt_str: str,
         conversation: Conversation
     ):
-        @context_filter(f_context_relevance, conversation.model_config.retrieval_filter, "query")
+
+        @context_filter(
+            f_small_local_models_context_relevance,
+            conversation.model_config.retrieval_filter, "query"
+        )
         def retrieve(*, query: str):
-            retriever = AVAILABLE_RETRIEVERS[conversation.model_config.retriever]
+            retriever = AVAILABLE_RETRIEVERS[conversation.model_config.retriever
+                                            ]
             return retriever.retrieve(query=last_user_message)
 
         return retrieve(query=last_user_message)

--- a/trulens_eval/examples/snowflake_demo/llm.py
+++ b/trulens_eval/examples/snowflake_demo/llm.py
@@ -13,7 +13,7 @@ from streamlit.delta_generator import DeltaGenerator
 from trulens_eval.tru_custom_app import instrument
 from trulens_eval.guardrails.base import context_filter
 
-from feedback import f_small_local_models_context_relevance
+from feedback import f_context_relevance
 
 FRIENDLY_MAPPING = {
     "Snowflake Arctic": "snowflake/snowflake-arctic-instruct",
@@ -160,14 +160,12 @@ class StreamGenerator:
         self, last_user_message: str, prompt_str: str,
         conversation: Conversation
     ):
-        @context_filter(f_small_local_models_context_relevance, conversation.model_config.retrieval_filter)
-        def retrieve():
+        @context_filter(f_context_relevance, conversation.model_config.retrieval_filter, "query")
+        def retrieve(*, query: str):
             retriever = AVAILABLE_RETRIEVERS[conversation.model_config.retriever]
-            texts = retriever.retrieve(query=last_user_message)
-            context_message = "\n\n".join(texts)
-            return _reencode_outputs(context_message), texts
+            return retriever.retrieve(query=last_user_message)
 
-        return retrieve()
+        return retrieve(query=last_user_message)
 
     @instrument
     def retrieve_and_generate_response(
@@ -177,11 +175,12 @@ class StreamGenerator:
         conversation: Conversation,
         st_container: Optional[DeltaGenerator] = None
     ) -> str:
-        context_message, nodes = self.retrieve_context(
+        contexts = self.retrieve_context(
             last_user_message=last_user_message,
             prompt_str=prompt_str,
             conversation=conversation
         )  # Fixed by passing the conversation object instead of prompt_str
+        context_message = _reencode_outputs("\n\n".join(contexts))
         model_config = conversation.model_config
         full_model_name = FRIENDLY_MAPPING[model_config.model]
 

--- a/trulens_eval/trulens_eval/guardrails/base.py
+++ b/trulens_eval/trulens_eval/guardrails/base.py
@@ -11,24 +11,29 @@ class context_filter:
     Parameters:
     feedback (Feedback): The feedback object to use for filtering.
     threshold (float): The minimum feedback value required for a context to be included.
+    keyword_for_prompt (str): Keyword argument to decorator to use for prompt.
 
     !!! example
 
         ```python
-        feedback = Feedback(provider.groundedness_measure_with_cot_reasons, name="Groundedness")
-        @context_filter(feedback, 0.5)
-        def retrieve(query: str) -> list:
-            results = vector_store.query(
-            query_texts=query,
-            n_results=3
-        )
-        return [doc for sublist in results['documents'] for doc in sublist]
+        feedback = Feedback(provider.context_relevance, name="Context Relevance")
+        class RAG_from_scratch:
+            ...
+            @context_filter(feedback, 0.5, "query")
+            def retrieve(self, *, query: str) -> list:
+                results = vector_store.query(
+                    query_texts=query,
+                    n_results=3
+                )
+                return [doc for sublist in results['documents'] for doc in sublist]
+            ...
         ```
     """
 
-    def __init__(self, feedback: Feedback, threshold: float):
+    def __init__(self, feedback: Feedback, threshold: float, keyword_for_prompt: str):
         self.feedback = feedback
         self.threshold = threshold
+        self.keyword_for_prompt = keyword_for_prompt
 
     def __call__(self, func):
 
@@ -37,7 +42,7 @@ class context_filter:
             with ThreadPoolExecutor(max_workers=max(1, len(contexts))) as ex:
                 future_to_context = {
                     ex.submit(
-                        lambda context=context: self.feedback(args[1], context)
+                        lambda context=context: self.feedback(kwargs[self.keyword_for_prompt], context)
                     ): context for context in contexts
                 }
                 filtered = []

--- a/trulens_eval/trulens_eval/guardrails/base.py
+++ b/trulens_eval/trulens_eval/guardrails/base.py
@@ -30,7 +30,9 @@ class context_filter:
         ```
     """
 
-    def __init__(self, feedback: Feedback, threshold: float, keyword_for_prompt: str):
+    def __init__(
+        self, feedback: Feedback, threshold: float, keyword_for_prompt: str
+    ):
         self.feedback = feedback
         self.threshold = threshold
         self.keyword_for_prompt = keyword_for_prompt
@@ -42,7 +44,8 @@ class context_filter:
             with ThreadPoolExecutor(max_workers=max(1, len(contexts))) as ex:
                 future_to_context = {
                     ex.submit(
-                        lambda context=context: self.feedback(kwargs[self.keyword_for_prompt], context)
+                        lambda context=context: self.
+                        feedback(kwargs[self.keyword_for_prompt], context)
                     ): context for context in contexts
                 }
                 filtered = []


### PR DESCRIPTION
# Description
Change context_filter guard rail to take in an argument for what to use as the prompt as it was confusing and causing issues before.

Before, it was taking the second positional argument arbitrarily.

I also fixed the demo here to work now.

## Other details good to know for developers

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
