### PR TITLE
virtual record should use supplied perf, cost

### DIFF
--- a/trulens_eval/trulens_eval/tru_virtual.py
+++ b/trulens_eval/trulens_eval/tru_virtual.py
@@ -407,12 +407,11 @@ class VirtualRecord(mod_record_schema.Record):
         if (end_time - start_time).total_seconds() == 0.0:
             end_time += datetime.timedelta(microseconds=1)
 
-        if "cost" not in kwargs:
-            kwargs['cost'] = mod_base_schema.Cost()
-        if "perf" not in kwargs:
-            kwargs['perf'] = mod_base_schema.Perf(
-                start_time=start_time, end_time=end_time
-            )
+
+        kwargs['cost'] = cost or mod_base_schema.Cost()
+        kwargs['perf'] = perf or mod_base_schema.Perf(
+            start_time=start_time, end_time=end_time
+        )
 
         if "main_input" not in kwargs:
             kwargs['main_input'] = "No main_input provided."

--- a/trulens_eval/trulens_eval/tru_virtual.py
+++ b/trulens_eval/trulens_eval/tru_virtual.py
@@ -407,7 +407,6 @@ class VirtualRecord(mod_record_schema.Record):
         if (end_time - start_time).total_seconds() == 0.0:
             end_time += datetime.timedelta(microseconds=1)
 
-
         kwargs['cost'] = cost or mod_base_schema.Cost()
         kwargs['perf'] = perf or mod_base_schema.Perf(
             start_time=start_time, end_time=end_time


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue that can be inlcuded in the release announcement. Please also include relevant motivation and context.

When supplied, VirtualRecord should use supplied perf and cost args

## Other details good to know for developers

Please include any other details of this change useful for TruLens developers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
