### PR TITLE
timeouts for wait_for_feedback_results

### DIFF
--- a/trulens_eval/examples/experimental/dummy_example.ipynb
+++ b/trulens_eval/examples/experimental/dummy_example.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,9 +37,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🦑 Tru initialized with db url sqlite:///default.sqlite .\n",
+      "🛑 Secret keys may be written to the database. See the `database_redact_keys` option of `Tru` to prevent this.\n",
+      "Force stopping dashboard ...\n",
+      "Starting dashboard ...\n",
+      "Config file already exists. Skipping writing process.\n",
+      "Credentials file already exists. Skipping writing process.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "16b5ab5c60f347e5906f5559afef54dd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Accordion(children=(VBox(children=(VBox(children=(Label(value='STDOUT'), Output())), VBox(children=(Label(valu…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dashboard started at http://172.17.97.146:8501 .\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Popen: returncode: None args: ['streamlit', 'run', '--server.headless=True'...>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from concurrent.futures import as_completed\n",
     "from time import sleep\n",
@@ -58,8 +102,8 @@
     "\n",
     "d_error = Dummy(\n",
     "    loading_prob=0.0,\n",
-    "    freeze_prob=1.0, # we expect requests to have their own timeouts so freeze should never happen\n",
-    "    error_prob=0.0,\n",
+    "    freeze_prob=0.0, # we expect requests to have their own timeouts so freeze should never happen\n",
+    "    error_prob=1.0,\n",
     "    overloaded_prob=0.0,\n",
     "    rpm=1000,\n",
     "    alloc = 0, # how much fake data to allocate during requests\n",
@@ -88,9 +132,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ In language_match, input text1 will be set to __record__.main_input or `Select.RecordInput` .\n",
+      "✅ In language_match, input text2 will be set to __record__.main_output or `Select.RecordOutput` .\n",
+      "✅ In output sentiment, input text will be set to __record__.main_output or `Select.RecordOutput` .\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Exception in thread Thread-6 (_future_target_wrapper):\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/opt/miniconda3/envs/py312/lib/python3.12/threading.py\", line 1052, in _bootstrap_inner\n",
+      "    self.run()\n",
+      "  File \"/opt/miniconda3/envs/py312/lib/python3.12/site-packages/ipykernel/ipkernel.py\", line 766, in run_closure\n",
+      "    _threading_Thread_run(self)\n",
+      "  File \"/opt/miniconda3/envs/py312/lib/python3.12/threading.py\", line 989, in run\n",
+      "    self._target(*self._args, **self._kwargs)\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/utils/python.py\", line 475, in _future_target_wrapper\n",
+      "    return func(*args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/app.py\", line 614, in _manage_pending_feedback_results\n",
+      "    self.records_with_pending_feedback_results.remove(record)\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/utils/containers.py\", line 73, in remove\n",
+      "    self.content.remove(item)\n",
+      "KeyError: Record(record_id='record_hash_7154900aaf3c9bcb000c04edca79df33', app_id='customapp', cost=Cost(n_requests=0, n_successful_requests=0, n_classes=0, n_tokens=0, n_stream_chunks=0, n_prompt_tokens=0, n_completion_tokens=0, cost=0.0), perf=Perf(start_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 579412), end_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 779123)), ts=datetime.datetime(2024, 6, 27, 17, 2, 0, 779200), tags='-', meta=None, main_input='hello there', main_output=\"The answer to hello there is probably herp dessecorp .gnihtemos gniod m'I dneterp ot setyb 65 detacolla I :knuhc tnaveleR,dessecorp hello there :knuhc tnaveleR,dessecorp EREHT OLLEH :knuhc tnaveleR derp and 56 bytes or something ...\", main_error=None, calls=[RecordAppCall(call_id='a7f3acaa-e590-44f3-a561-dd4c56216f3f', stack=[RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='respond_to_query')), RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='retrieve_chunks')), RecordAppCallMethod(path=Lens().app.retriever, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_retriever.CustomRetriever, id=13520090272, init_bindings=None), name='retrieve_chunks'))], args={'data': 'hello there'}, rets=['Relevant chunk: HELLO THERE', 'Relevant chunk: ereht olleh', \"Relevant chunk: I allocated 56 bytes to pretend I'm doing something.\"], error=None, perf=Perf(start_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 644995), end_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 651674)), pid=56677, tid=5956724), RecordAppCall(call_id='ea74911c-47ad-402c-82e3-8d3da97e158b', stack=[RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='respond_to_query')), RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='retrieve_chunks'))], args={'data': 'hello there'}, rets=['Relevant chunk: HELLO THERE', 'Relevant chunk: ereht olleh', \"Relevant chunk: I allocated 56 bytes to pretend I'm doing something.\"], error=None, perf=Perf(start_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 618582), end_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 651720)), pid=56677, tid=5956724), RecordAppCall(call_id='9eea511b-1647-4d93-97dd-bd4d153f39cb', stack=[RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='respond_to_query')), RecordAppCallMethod(path=Lens().app.memory, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_memory.CustomMemory, id=13520092336, init_bindings=None), name='remember'))], args={'data': 'hello there'}, rets=None, error=None, perf=Perf(start_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 691218), end_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 697436)), pid=56677, tid=5956724), RecordAppCall(call_id='14213ee1-b2d7-43ac-901e-ff862d1eb182', stack=[RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='respond_to_query')), RecordAppCallMethod(path=Lens().app.llm, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_llm.CustomLLM, id=13520089936, init_bindings=None), name='generate'))], args={'prompt': \"Relevant chunk: HELLO THERE processed,Relevant chunk: ereht olleh processed,Relevant chunk: I allocated 56 bytes to pretend I'm doing something. processed\"}, rets=\"herp dessecorp .gnihtemos gniod m'I dneterp ot setyb 65 detacolla I :knuhc tnaveleR,dessecorp hello there :knuhc tnaveleR,dessecorp EREHT OLLEH :knuhc tnaveleR derp and 56 bytes\", error=None, perf=Perf(start_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 718604), end_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 725227)), pid=56677, tid=5956724), RecordAppCall(call_id='5500fd17-5fec-4cfc-9976-b7949349ae11', stack=[RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='respond_to_query')), RecordAppCallMethod(path=Lens().app.template, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomTemplate, id=13520092768, init_bindings=None), name='fill'))], args={'question': 'hello there', 'answer': \"herp dessecorp .gnihtemos gniod m'I dneterp ot setyb 65 detacolla I :knuhc tnaveleR,dessecorp hello there :knuhc tnaveleR,dessecorp EREHT OLLEH :knuhc tnaveleR derp and 56 bytes\"}, rets=\"The answer to hello there is probably herp dessecorp .gnihtemos gniod m'I dneterp ot setyb 65 detacolla I :knuhc tnaveleR,dessecorp hello there :knuhc tnaveleR,dessecorp EREHT OLLEH :knuhc tnaveleR derp and 56 bytes or something ...\", error=None, perf=Perf(start_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 745224), end_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 751950)), pid=56677, tid=5956724), RecordAppCall(call_id='c533e5bc-1821-4c20-96c9-aab704926156', stack=[RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='respond_to_query')), RecordAppCallMethod(path=Lens().app.memory, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_memory.CustomMemory, id=13520092336, init_bindings=None), name='remember'))], args={'data': \"The answer to hello there is probably herp dessecorp .gnihtemos gniod m'I dneterp ot setyb 65 detacolla I :knuhc tnaveleR,dessecorp hello there :knuhc tnaveleR,dessecorp EREHT OLLEH :knuhc tnaveleR derp and 56 bytes or something ...\"}, rets=None, error=None, perf=Perf(start_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 772799), end_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 779098)), pid=56677, tid=5956724), RecordAppCall(call_id='2555fd1e-a7ed-4e95-92dd-54b46d5f6863', stack=[RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='respond_to_query'))], args={'input': 'hello there'}, rets=\"The answer to hello there is probably herp dessecorp .gnihtemos gniod m'I dneterp ot setyb 65 detacolla I :knuhc tnaveleR,dessecorp hello there :knuhc tnaveleR,dessecorp EREHT OLLEH :knuhc tnaveleR derp and 56 bytes or something ...\", error=None, perf=Perf(start_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 579412), end_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 779123)), pid=56677, tid=5956724)], feedback_and_future_results=[(FeedbackDefinition(language_match,\n",
+      "\tselectors={'text1': Lens().__record__.main_input, 'text2': Lens().__record__.main_output},\n",
+      "\tif_exists=None\n",
+      "), <Future at 0x16fafdbe0 state=finished returned FeedbackResult>), (FeedbackDefinition(output sentiment,\n",
+      "\tselectors={'text': Lens().__record__.main_output},\n",
+      "\tif_exists=None\n",
+      "), <Future at 0x16fafd820 state=finished returned FeedbackResult>)], feedback_results=[<Future at 0x16fafdbe0 state=finished returned FeedbackResult>, <Future at 0x16fafd820 state=finished returned FeedbackResult>])\n"
+     ]
+    }
+   ],
    "source": [
     "tru.get_records_and_feedback(limit=10)[0]"
    ]
@@ -123,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,9 +215,121 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Feedback Function exception caught: Traceback (most recent call last):\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/feedback.py\", line 899, in run\n",
+      "    result_and_meta, part_cost = mod_base_endpoint.Endpoint.track_all_costs_tally(\n",
+      "                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py\", line 503, in track_all_costs_tally\n",
+      "    result, cbs = Endpoint.track_all_costs(\n",
+      "                  ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py\", line 483, in track_all_costs\n",
+      "    return Endpoint._track_costs(\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py\", line 581, in _track_costs\n",
+      "    result: T = __func(*args, **kwargs)\n",
+      "                ^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/provider/hugs.py\", line 82, in wrapper\n",
+      "    return func(*bindings.args, **bindings.kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/provider/hugs.py\", line 299, in positive_sentiment\n",
+      "    return self._positive_sentiment_endpoint(truncated_text)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/provider/hugs.py\", line 530, in _positive_sentiment_endpoint\n",
+      "    hf_response = self.endpoint.post(\n",
+      "                  ^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py\", line 853, in post\n",
+      "    raise RuntimeError(\"Simulated error happened.\")\n",
+      "RuntimeError: Simulated error happened.\n",
+      "\n",
+      "The above exception was the direct cause of the following exception:\n",
+      "\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/feedback.py\", line 913, in run\n",
+      "    raise RuntimeError(\n",
+      "RuntimeError: Evaluation of output sentiment failed on inputs: \n",
+      "{'text': 'The answer to hello there is probably herp dessecorp .gnihtemos '\n",
+      "         \"gniod m'I dneterp ot setyb 65 detacolla I .\n",
+      "\n",
+      "Feedback Function exception caught: Traceback (most recent call last):\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/feedback.py\", line 899, in run\n",
+      "    result_and_meta, part_cost = mod_base_endpoint.Endpoint.track_all_costs_tally(\n",
+      "                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py\", line 503, in track_all_costs_tally\n",
+      "    result, cbs = Endpoint.track_all_costs(\n",
+      "                  ^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py\", line 483, in track_all_costs\n",
+      "    return Endpoint._track_costs(\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py\", line 581, in _track_costs\n",
+      "    result: T = __func(*args, **kwargs)\n",
+      "                ^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/provider/hugs.py\", line 82, in wrapper\n",
+      "    return func(*bindings.args, **bindings.kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/provider/hugs.py\", line 175, in language_match\n",
+      "    scores1: Dict = f_scores1.result()\n",
+      "                    ^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/opt/miniconda3/envs/py312/lib/python3.12/concurrent/futures/_base.py\", line 449, in result\n",
+      "    return self.__get_result()\n",
+      "           ^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/opt/miniconda3/envs/py312/lib/python3.12/concurrent/futures/_base.py\", line 401, in __get_result\n",
+      "    raise self._exception\n",
+      "  File \"/opt/miniconda3/envs/py312/lib/python3.12/concurrent/futures/thread.py\", line 58, in run\n",
+      "    result = self.fn(*self.args, **self.kwargs)\n",
+      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/utils/python.py\", line 475, in _future_target_wrapper\n",
+      "    return func(*args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/provider/hugs.py\", line 511, in _language_scores_endpoint\n",
+      "    hf_response = self.endpoint.post(\n",
+      "                  ^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py\", line 853, in post\n",
+      "    raise RuntimeError(\"Simulated error happened.\")\n",
+      "RuntimeError: Simulated error happened.\n",
+      "\n",
+      "The above exception was the direct cause of the following exception:\n",
+      "\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/Users/pmardziel/repos/truera/trulens/trulens_eval/trulens_eval/feedback/feedback.py\", line 913, in run\n",
+      "    raise RuntimeError(\n",
+      "RuntimeError: Evaluation of language_match failed on inputs: \n",
+      "{'text1': 'hello there',\n",
+      " 'text2': 'The answer to hello there is probably herp dessecorp .gnihtemos '\n",
+      "          \"gniod m'I dnete.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Timeout waiting for feedback result for language_match.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[Record(record_id='record_hash_7154900aaf3c9bcb000c04edca79df33', app_id='customapp', cost=Cost(n_requests=0, n_successful_requests=0, n_classes=0, n_tokens=0, n_stream_chunks=0, n_prompt_tokens=0, n_completion_tokens=0, cost=0.0), perf=Perf(start_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 579412), end_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 779123)), ts=datetime.datetime(2024, 6, 27, 17, 2, 0, 779200), tags='-', meta=None, main_input='hello there', main_output=\"The answer to hello there is probably herp dessecorp .gnihtemos gniod m'I dneterp ot setyb 65 detacolla I :knuhc tnaveleR,dessecorp hello there :knuhc tnaveleR,dessecorp EREHT OLLEH :knuhc tnaveleR derp and 56 bytes or something ...\", main_error=None, calls=[RecordAppCall(call_id='a7f3acaa-e590-44f3-a561-dd4c56216f3f', stack=[RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='respond_to_query')), RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='retrieve_chunks')), RecordAppCallMethod(path=Lens().app.retriever, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_retriever.CustomRetriever, id=13520090272, init_bindings=None), name='retrieve_chunks'))], args={'data': 'hello there'}, rets=['Relevant chunk: HELLO THERE', 'Relevant chunk: ereht olleh', \"Relevant chunk: I allocated 56 bytes to pretend I'm doing something.\"], error=None, perf=Perf(start_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 644995), end_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 651674)), pid=56677, tid=5956724), RecordAppCall(call_id='ea74911c-47ad-402c-82e3-8d3da97e158b', stack=[RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='respond_to_query')), RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='retrieve_chunks'))], args={'data': 'hello there'}, rets=['Relevant chunk: HELLO THERE', 'Relevant chunk: ereht olleh', \"Relevant chunk: I allocated 56 bytes to pretend I'm doing something.\"], error=None, perf=Perf(start_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 618582), end_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 651720)), pid=56677, tid=5956724), RecordAppCall(call_id='9eea511b-1647-4d93-97dd-bd4d153f39cb', stack=[RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='respond_to_query')), RecordAppCallMethod(path=Lens().app.memory, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_memory.CustomMemory, id=13520092336, init_bindings=None), name='remember'))], args={'data': 'hello there'}, rets=None, error=None, perf=Perf(start_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 691218), end_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 697436)), pid=56677, tid=5956724), RecordAppCall(call_id='14213ee1-b2d7-43ac-901e-ff862d1eb182', stack=[RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='respond_to_query')), RecordAppCallMethod(path=Lens().app.llm, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_llm.CustomLLM, id=13520089936, init_bindings=None), name='generate'))], args={'prompt': \"Relevant chunk: HELLO THERE processed,Relevant chunk: ereht olleh processed,Relevant chunk: I allocated 56 bytes to pretend I'm doing something. processed\"}, rets=\"herp dessecorp .gnihtemos gniod m'I dneterp ot setyb 65 detacolla I :knuhc tnaveleR,dessecorp hello there :knuhc tnaveleR,dessecorp EREHT OLLEH :knuhc tnaveleR derp and 56 bytes\", error=None, perf=Perf(start_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 718604), end_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 725227)), pid=56677, tid=5956724), RecordAppCall(call_id='5500fd17-5fec-4cfc-9976-b7949349ae11', stack=[RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='respond_to_query')), RecordAppCallMethod(path=Lens().app.template, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomTemplate, id=13520092768, init_bindings=None), name='fill'))], args={'question': 'hello there', 'answer': \"herp dessecorp .gnihtemos gniod m'I dneterp ot setyb 65 detacolla I :knuhc tnaveleR,dessecorp hello there :knuhc tnaveleR,dessecorp EREHT OLLEH :knuhc tnaveleR derp and 56 bytes\"}, rets=\"The answer to hello there is probably herp dessecorp .gnihtemos gniod m'I dneterp ot setyb 65 detacolla I :knuhc tnaveleR,dessecorp hello there :knuhc tnaveleR,dessecorp EREHT OLLEH :knuhc tnaveleR derp and 56 bytes or something ...\", error=None, perf=Perf(start_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 745224), end_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 751950)), pid=56677, tid=5956724), RecordAppCall(call_id='c533e5bc-1821-4c20-96c9-aab704926156', stack=[RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='respond_to_query')), RecordAppCallMethod(path=Lens().app.memory, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_memory.CustomMemory, id=13520092336, init_bindings=None), name='remember'))], args={'data': \"The answer to hello there is probably herp dessecorp .gnihtemos gniod m'I dneterp ot setyb 65 detacolla I :knuhc tnaveleR,dessecorp hello there :knuhc tnaveleR,dessecorp EREHT OLLEH :knuhc tnaveleR derp and 56 bytes or something ...\"}, rets=None, error=None, perf=Perf(start_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 772799), end_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 779098)), pid=56677, tid=5956724), RecordAppCall(call_id='2555fd1e-a7ed-4e95-92dd-54b46d5f6863', stack=[RecordAppCallMethod(path=Lens().app, method=Method(obj=Obj(cls=examples.expositional.end2end_apps.custom_app.custom_app.CustomApp, id=13520091424, init_bindings=None), name='respond_to_query'))], args={'input': 'hello there'}, rets=\"The answer to hello there is probably herp dessecorp .gnihtemos gniod m'I dneterp ot setyb 65 detacolla I :knuhc tnaveleR,dessecorp hello there :knuhc tnaveleR,dessecorp EREHT OLLEH :knuhc tnaveleR derp and 56 bytes or something ...\", error=None, perf=Perf(start_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 579412), end_time=datetime.datetime(2024, 6, 27, 17, 2, 0, 779123)), pid=56677, tid=5956724)], feedback_and_future_results=[(FeedbackDefinition(language_match,\n",
+       " \tselectors={'text1': Lens().__record__.main_input, 'text2': Lens().__record__.main_output},\n",
+       " \tif_exists=None\n",
+       " ), <Future at 0x16fafdbe0 state=running>), (FeedbackDefinition(output sentiment,\n",
+       " \tselectors={'text': Lens().__record__.main_output},\n",
+       " \tif_exists=None\n",
+       " ), <Future at 0x16fafd820 state=finished returned FeedbackResult>)], feedback_results=[<Future at 0x16fafdbe0 state=running>, <Future at 0x16fafd820 state=finished returned FeedbackResult>])]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\n",
     "ta.wait_for_feedback_results(feedback_timeout=5)"

--- a/trulens_eval/examples/experimental/dummy_example.ipynb
+++ b/trulens_eval/examples/experimental/dummy_example.ipynb
@@ -56,7 +56,17 @@
     "\n",
     "tp = TP()\n",
     "\n",
-    "d = Dummy(\n",
+    "d_error = Dummy(\n",
+    "    loading_prob=0.0,\n",
+    "    freeze_prob=1.0, # we expect requests to have their own timeouts so freeze should never happen\n",
+    "    error_prob=0.0,\n",
+    "    overloaded_prob=0.0,\n",
+    "    rpm=1000,\n",
+    "    alloc = 0, # how much fake data to allocate during requests\n",
+    "    delay = 10.0\n",
+    ")\n",
+    "\n",
+    "d_noerror = Dummy(\n",
     "    loading_prob=0.0,\n",
     "    freeze_prob=0.0, # we expect requests to have their own timeouts so freeze should never happen\n",
     "    error_prob=0.0,\n",
@@ -92,17 +102,12 @@
    "outputs": [],
    "source": [
     "f_dummy1 = Feedback(\n",
-    "    d.language_match\n",
+    "    d_error.language_match\n",
     ").on_input_output()\n",
     "\n",
     "f_dummy2 = Feedback(\n",
-    "    d.positive_sentiment, name=\"output sentiment\"\n",
+    "    d_noerror.positive_sentiment, name=\"output sentiment\"\n",
     ").on_output()\n",
-    "\n",
-    "f_dummy3 = Feedback(\n",
-    "    d.positive_sentiment, name=\"input sentiment\"\n",
-    ").on_input()\n",
-    "\n",
     "\n",
     "# Create custom app:\n",
     "ca = CustomApp(delay=0.0, alloc=0)\n",
@@ -111,9 +116,29 @@
     "ta = TruCustomApp(\n",
     "    ca,\n",
     "    app_id=\"customapp\",\n",
-    "    feedbacks=[f_dummy1, f_dummy2, f_dummy3],\n",
-    "    feedback_mode=FeedbackMode.DEFERRED\n",
+    "    feedbacks=[f_dummy1, f_dummy2],\n",
+    "#    feedback_mode=FeedbackMode.DEFERRED\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with ta as recorder:\n",
+    "    res = ca.respond_to_query(f\"hello there\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "ta.wait_for_feedback_results(feedback_timeout=5)"
    ]
   },
   {
@@ -125,7 +150,7 @@
     "# Sequential app invocation.\n",
     "\n",
     "if True:\n",
-    "    for i in tqdm(range(128), desc=\"invoking app\"):\n",
+    "    for i in tqdm(range(2), desc=\"invoking app\"):\n",
     "        with ta as recorder:\n",
     "            res = ca.respond_to_query(f\"hello {i}\")\n",
     "\n",
@@ -238,7 +263,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.12.0"
   },
   "orig_nbformat": 4
  },

--- a/trulens_eval/trulens_eval/feedback/provider/cortex.py
+++ b/trulens_eval/trulens_eval/feedback/provider/cortex.py
@@ -8,13 +8,13 @@ from trulens_eval.feedback.provider.endpoint.cortex import CortexEndpoint
 from trulens_eval.utils.imports import OptionalImports
 from trulens_eval.utils.imports import REQUIREMENT_CORTEX
 
-with OptionalImports(messages=REQUIREMENT_CORTEX):
+with OptionalImports(messages=REQUIREMENT_CORTEX) as opt:
     import snowflake
     import snowflake.connector
     from snowflake.connector import SnowflakeConnection
 
 if sys.version_info < (3, 12):
-    OptionalImports(messages=REQUIREMENT_CORTEX).assert_installed(snowflake)
+    opt.assert_installed(snowflake)
 
 
 class Cortex(LLMProvider):

--- a/trulens_eval/trulens_eval/feedback/provider/endpoint/cortex.py
+++ b/trulens_eval/trulens_eval/feedback/provider/endpoint/cortex.py
@@ -14,13 +14,13 @@ logger = logging.getLogger(__name__)
 
 pp = pprint.PrettyPrinter()
 
-with OptionalImports(messages=REQUIREMENT_CORTEX):
+with OptionalImports(messages=REQUIREMENT_CORTEX) as opt:
     import snowflake
     from snowflake.snowpark import DataFrame
     from snowflake.snowpark import Session
 
 if sys.version_info < (3, 12):
-    OptionalImports(messages=REQUIREMENT_CORTEX).assert_installed(snowflake)
+    opt.assert_installed(snowflake)
 
 
 class CortexCallback(EndpointCallback):
@@ -61,7 +61,7 @@ class CortexEndpoint(Endpoint):
                     "Ignoring additional kwargs for singleton endpoint %s: %s",
                     self.name, pp.pformat(kwargs)
                 )
-            self.warning()
+                self.warning()
             return
 
         kwargs['name'] = "cortex"

--- a/trulens_eval/trulens_eval/requirements.optional.txt
+++ b/trulens_eval/trulens_eval/requirements.optional.txt
@@ -33,7 +33,7 @@ botocore >= 1.33.6
 litellm     >= 1.25.2
 
 # Cortex
-# snowflake-snowpark-python >= 1.18.0
+snowflake-snowpark-python >= 1.18.0; python_version < 3.12 # not available for 3.12
 snowflake-connector-python >= 3.11.0
 
 # Local models

--- a/trulens_eval/trulens_eval/requirements.optional.txt
+++ b/trulens_eval/trulens_eval/requirements.optional.txt
@@ -33,7 +33,7 @@ botocore >= 1.33.6
 litellm     >= 1.25.2
 
 # Cortex
-snowflake-snowpark-python >= 1.18.0; python_version < 3.12 # not available for 3.12
+snowflake-snowpark-python >= 1.18.0; python_version < "3.12" # not available for 3.12
 snowflake-connector-python >= 3.11.0
 
 # Local models

--- a/trulens_eval/trulens_eval/schema/record.py
+++ b/trulens_eval/trulens_eval/schema/record.py
@@ -14,6 +14,7 @@ from trulens_eval.schema import feedback as mod_feedback_schema
 from trulens_eval.schema import types as mod_types_schema
 from trulens_eval.utils import pyschema
 from trulens_eval.utils import serial
+from trulens_eval.utils import threading as mod_threading_utils
 from trulens_eval.utils.json import jsonify
 from trulens_eval.utils.json import obj_id_of_obj
 from trulens_eval.utils.python import Future
@@ -168,14 +169,23 @@ class Record(serial.SerialModel, Hashable):
         return hash(self.record_id)
 
     def wait_for_feedback_results(
-        self
+        self,
+        feedback_timeout: Optional[float] = None
     ) -> Dict[mod_feedback_schema.FeedbackDefinition,
               mod_feedback_schema.FeedbackResult]:
         """Wait for feedback results to finish.
 
+        Args:
+            feedback_timeout: Timeout in seconds for each feedback function. If
+                not given, will use the default timeout
+                `trulens_eval.utils.threading.TP.DEBUG_TIMEOUT`. 
+
         Returns:
             A mapping of feedback functions to their results.
         """
+
+        if feedback_timeout is None:
+            feedback_timeout = mod_threading_utils.TP.DEBUG_TIMEOUT
 
         if self.feedback_and_future_results is None:
             return {}
@@ -183,8 +193,14 @@ class Record(serial.SerialModel, Hashable):
         ret = {}
 
         for feedback_def, future_result in self.feedback_and_future_results:
-            feedback_result = future_result.result()
-            ret[feedback_def] = feedback_result
+            try:
+                feedback_result = future_result.result(timeout=feedback_timeout)
+                ret[feedback_def] = feedback_result
+            except TimeoutError:
+                logger.error(
+                    "Timeout waiting for feedback result for %s.",
+                    feedback_def.name
+                )
 
         return ret
 


### PR DESCRIPTION
# Description

Added a timeout option to `App.wait_for_feedback_results` and a default timeout of 5 minutes for each feedback function that is waited on. 

## Other details good to know for developers

Fixed a singleton warning and another stemming from snowflake-snowpark-python not being a listed package (enabled it in optional requirements with a python constraint).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
