### PR TITLE
Allow unused port

### DIFF
--- a/trulens_eval/trulens_eval/tru.py
+++ b/trulens_eval/trulens_eval/tru.py
@@ -997,7 +997,7 @@ class Tru(python.SingletonPerName):
 
     def run_dashboard(
         self,
-        port: Optional[int] = 8501,
+        port: Optional[int] = None,
         address: Optional[str] = None,
         force: bool = False,
         _dev: Optional[Path] = None


### PR DESCRIPTION
# Description

Run the dashboard on an unused port

## Other details good to know for developers

Requires setting to none by default

