### PR TITLE
Remove newsletter button from trulens.org

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -111,9 +111,6 @@
                         <a href="https://communityinviter.com/apps/aiqualityforum/josh" target="blank">
                             <li>Community</li>
                         </a>
-                        <a href="https://go.truera.com/newsletter-archive" target="blank">
-                            <li>Newsletter</li>
-                        </a>
                         <a href="/trulens_eval/getting_started" target="docs"
                             class="header__btn nav__btn d-if fd-r ai-c jc-c mt-xxl-mob">
                             <svg class="hide-desktop" width="24" height="25" viewBox="0 0 24 25" fill="none"


### PR DESCRIPTION
# Description

Removing broken newsletter button from trulens.org

See new page:
![Screenshot 2024-07-17 at 11 23 58 AM](https://github.com/user-attachments/assets/709e3df7-ef10-4cc5-b618-d5140f5e8285)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update
