### PR TITLE
abstention scores 0 for answer relevance

### DIFF
--- a/trulens_eval/trulens_eval/feedback/v2/feedback.py
+++ b/trulens_eval/trulens_eval/feedback/v2/feedback.py
@@ -285,8 +285,6 @@ class PromptResponseRelevance(Relevance, WithPrompt):
 
         - Long RESPONSES should score equally well as short RESPONSES.
 
-        - Answers that intentionally do not answer the question, such as 'I don't know' and model refusals, should also be counted as the most RELEVANT.
-
         - RESPONSE must be relevant to the entire PROMPT to get a score of 10.
 
         - RELEVANCE score should increase as the RESPONSE provides RELEVANT context to more parts of the PROMPT.
@@ -304,6 +302,8 @@ class PromptResponseRelevance(Relevance, WithPrompt):
         - RESPONSE that confidently FALSE should get a score of 0.
 
         - RESPONSE that is only seemingly RELEVANT should get a score of 0.
+
+        - Answers that intentionally do not answer the question, such as 'I don't know' and model refusals, should also be counted as the least RELEVANT and get a score of 0.
 
         - Never elaborate.
         """


### PR DESCRIPTION
# Description

Abstentions should score 0 for Answer Relevance. This is in concert with the definitive change to abstention handling of groundedness in #1298 

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
