### PR TITLE
Update openai provider model default to gpt-4o-mini

### DIFF
--- a/trulens_eval/trulens_eval/feedback/provider/openai.py
+++ b/trulens_eval/trulens_eval/feedback/provider/openai.py
@@ -36,7 +36,7 @@ class OpenAI(LLMProvider):
 
     Args:
         model_engine: The OpenAI completion model. Defaults to
-            `gpt-3.5-turbo`
+            `gpt-4o-mini`
 
         **kwargs: Additional arguments to pass to the
             [OpenAIEndpoint][trulens_eval.feedback.provider.endpoint.openai.OpenAIEndpoint]
@@ -45,7 +45,7 @@ class OpenAI(LLMProvider):
             and finally to the OpenAI client.
     """
 
-    DEFAULT_MODEL_ENGINE: ClassVar[str] = "gpt-3.5-turbo"
+    DEFAULT_MODEL_ENGINE: ClassVar[str] = "gpt-4o-mini"
 
     # Endpoint cannot presently be serialized but is constructed in __init__
     # below so it is ok.


### PR DESCRIPTION
# Description

Update the default OpenAI provider model from GPT-3.5-Turbo to GPT-4o-mini.

GPT-4o-mini is both more intelligent, cheaper and has a larger context window than GPT-3.5-Turbo.

**Model Evaluation Scores**

![Screenshot 2024-07-30 at 2 45 57 PM](https://github.com/user-attachments/assets/a1bcc410-f26f-4bdc-84bf-5de2d3b061b9)

**Cost**
gpt-4o-mini: $0.150/1M Input Tokens, $0.60/1M Output Tokens
gpt-3.5-turbo: $0.50/1M Input Tokens, $1.50/1M Output Tokens

**Context Window**
gpt-4o-mini: 128,000 tokens
gpt-3.5-turbo: 4,096 tokens

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
