### PR TITLE
Bug-fix: use 0 - 10 for default score range for ff other than context relevance

### DIFF
--- a/trulens_eval/trulens_eval/feedback/provider/base.py
+++ b/trulens_eval/trulens_eval/feedback/provider/base.py
@@ -137,7 +137,7 @@ class LLMProvider(Provider):
         system_prompt: str,
         user_prompt: Optional[str] = None,
         min_score_val: int = 0,
-        max_score_val: int = 3,
+        max_score_val: int = 10,
         temperature: float = 0.0,
     ) -> float:
         """
@@ -186,7 +186,7 @@ class LLMProvider(Provider):
         verb_confidence_prompt: str,
         user_prompt: Optional[str] = None,
         min_score_val: int = 0,
-        max_score_val: int = 3,
+        max_score_val: int = 10,
         temperature: float = 0.0,
     ) -> Tuple[float, Dict[str, float]]:
         """
@@ -250,7 +250,7 @@ class LLMProvider(Provider):
         system_prompt: str,
         user_prompt: Optional[str] = None,
         min_score_val: int = 0,
-        max_score_val: int = 3,
+        max_score_val: int = 10,
         temperature: float = 0.0,
     ) -> Tuple[float, Dict]:
         """


### PR DESCRIPTION
# Description

Rolling out likert scale 0 to 3 a bit too fast - we need to adjust prompts for feedback functions other than `context_relevance...` 
## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
