### PR TITLE
Set up a `run_location` that determines where a feedback function should be run if it's deferred.

### DIFF
--- a/src/core/trulens/core/__init__.py
+++ b/src/core/trulens/core/__init__.py
@@ -17,6 +17,7 @@ from trulens.core.app import TruCustomApp
 from trulens.core.app import TruVirtual
 from trulens.core.feedback import Feedback
 from trulens.core.feedback import Provider
+from trulens.core.feedback import SnowflakeFeedback
 from trulens.core.schema import FeedbackMode
 from trulens.core.schema import Select
 from trulens.core.tru import Tru
@@ -35,6 +36,7 @@ __all__ = [
     "FeedbackMode",
     # feedback setup
     "Feedback",
+    "SnowflakeFeedback",
     "Select",
     "Provider",
 ]

--- a/src/core/trulens/core/app/base.py
+++ b/src/core/trulens/core/app/base.py
@@ -1378,6 +1378,7 @@ you use the `%s` wrapper to make sure `%s` does get instrumented. `%s` method
                         name=f.name,
                         record_id=record_id,
                         feedback_definition_id=f.feedback_definition_id,
+                        run_location=f.run_location,
                     )
                 )
 

--- a/src/core/trulens/core/database/base.py
+++ b/src/core/trulens/core/database/base.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 from merkle_json import MerkleJson
 import pandas as pd
+from trulens.core.schema import feedback as mod_feedback_schema
 from trulens.core.schema import types as mod_types_schema
 from trulens.core.schema.app import AppDefinition
 from trulens.core.schema.feedback import FeedbackDefinition
@@ -219,6 +220,7 @@ class DB(SerialModel, abc.ABC):
         offset: Optional[int] = None,
         limit: Optional[int] = None,
         shuffle: Optional[bool] = None,
+        run_location: Optional[mod_feedback_schema.FeedbackRunLocation] = None,
     ) -> pd.DataFrame:
         """Get feedback results matching a set of optional criteria:
 
@@ -243,6 +245,8 @@ class DB(SerialModel, abc.ABC):
             limit: limit the number of rows returned.
 
             shuffle: shuffle the rows before returning them.
+
+            run_location: Only get feedback functions with this run_location.
         """
 
         raise NotImplementedError()
@@ -262,6 +266,7 @@ class DB(SerialModel, abc.ABC):
         offset: Optional[int] = None,
         limit: Optional[int] = None,
         shuffle: bool = False,
+        run_location: Optional[mod_feedback_schema.FeedbackRunLocation] = None,
     ) -> Dict[FeedbackResultStatus, int]:
         """Get count of feedback results matching a set of optional criteria grouped by
         their status.

--- a/src/core/trulens/core/database/migrations/versions/1_first_revision.py
+++ b/src/core/trulens/core/database/migrations/versions/1_first_revision.py
@@ -51,6 +51,7 @@ def upgrade(config) -> None:
         sa.Column("name", sa.Text(), nullable=False),
         sa.Column("cost_json", sa.Text(), nullable=False),
         sa.Column("multi_result", sa.Text(), nullable=True),
+        sa.Column("run_location", sa.Text(), nullable=True),
         sa.PrimaryKeyConstraint("feedback_result_id"),
     )
     op.create_table(

--- a/src/core/trulens/core/database/orm.py
+++ b/src/core/trulens/core/database/orm.py
@@ -270,6 +270,7 @@ def new_orm(base: Type[T]) -> Type[ORM[T]]:
             name = Column(Text, nullable=False)
             cost_json = Column(TYPE_JSON, nullable=False)
             multi_result = Column(TYPE_JSON)
+            run_location = Column(TYPE_ENUM, nullable=True)
 
             record = relationship(
                 "Record",
@@ -309,6 +310,9 @@ def new_orm(base: Type[T]) -> Type[ORM[T]]:
                         obj.cost, redact_keys=redact_keys
                     ),
                     multi_result=obj.multi_result,
+                    run_location=obj.run_location.value
+                    if obj.run_location is not None
+                    else None,
                 )
 
     configure_mappers()  # IMPORTANT

--- a/src/core/trulens/core/feedback/__init__.py
+++ b/src/core/trulens/core/feedback/__init__.py
@@ -2,10 +2,12 @@ from trulens.core.feedback.endpoint import Endpoint
 from trulens.core.feedback.endpoint import EndpointCallback
 from trulens.core.feedback.feedback import Feedback
 from trulens.core.feedback.feedback import SkipEval
+from trulens.core.feedback.feedback import SnowflakeFeedback
 from trulens.core.feedback.provider import Provider
 
 __all__ = [
     "Feedback",
+    "SnowflakeFeedback",
     "Provider",
     "Endpoint",
     "EndpointCallback",

--- a/src/core/trulens/core/feedback/feedback.py
+++ b/src/core/trulens/core/feedback/feedback.py
@@ -328,7 +328,10 @@ class Feedback(mod_feedback_schema.FeedbackDefinition):
 
     @staticmethod
     def evaluate_deferred(
-        tru: Tru, limit: Optional[int] = None, shuffle: bool = False
+        tru: Tru,
+        limit: Optional[int] = None,
+        shuffle: bool = False,
+        run_location: Optional[mod_feedback_schema.FeedbackRunLocation] = None,
     ) -> List[
         Tuple[
             pandas.Series,
@@ -345,6 +348,8 @@ class Feedback(mod_feedback_schema.FeedbackDefinition):
             limit: The maximum number of evals to start.
 
             shuffle: Shuffle the order of the feedbacks to evaluate.
+
+            run_location: Only run feedback functions with this run_location.
 
         Constants that govern behaviour:
 
@@ -391,6 +396,7 @@ class Feedback(mod_feedback_schema.FeedbackDefinition):
             ],
             limit=limit,
             shuffle=shuffle,
+            run_location=run_location,
         )
 
         tp = mod_threading_utils.TP()
@@ -1217,6 +1223,12 @@ Feedback function signature:
                 app=app, record=record, source_data=source_data
             )
         )
+
+
+class SnowflakeFeedback(Feedback):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.run_location = mod_feedback_schema.FeedbackRunLocation.SNOWFLAKE
 
 
 Feedback.model_rebuild()

--- a/src/core/trulens/core/schema/feedback.py
+++ b/src/core/trulens/core/schema/feedback.py
@@ -59,6 +59,16 @@ class FeedbackMode(str, Enum):
     `DEFERRED` mode using `tru.start_deferred_feedback_evaluator`."""
 
 
+class FeedbackRunLocation(str, Enum):
+    """Where the feedback evaluation takes place (e.g. locally, at a Snowflake server, etc)."""
+
+    LOCAL = "local"
+    """Run on the same process (or child process) of the app invocation."""
+
+    SNOWFLAKE = "snowflake"
+    """Run on a Snowflake server."""
+
+
 class FeedbackResultStatus(Enum):
     """For deferred feedback evaluation, these values indicate status of evaluation."""
 
@@ -192,6 +202,9 @@ class FeedbackResult(serial.SerialModel):
         default_factory=datetime.datetime.now
     )
 
+    run_location: Optional[FeedbackRunLocation]
+    """Where the feedback evaluation takes place (e.g. locally, at a Snowflake server, etc)."""
+
     status: FeedbackResultStatus = FeedbackResultStatus.NONE
     """For deferred feedback evaluation, the status of the evaluation."""
 
@@ -219,6 +232,9 @@ class FeedbackResult(serial.SerialModel):
         feedback_result_id: Optional[mod_types_schema.FeedbackResultID] = None,
         **kwargs,
     ):
+        if "run_location" not in kwargs:
+            kwargs["run_location"] = None
+
         super().__init__(feedback_result_id="temporary", **kwargs)
 
         if feedback_result_id is None:
@@ -326,6 +342,9 @@ class FeedbackDefinition(pyschema.WithClassInfo, serial.SerialModel, Hashable):
     if_missing: FeedbackOnMissingParameters = FeedbackOnMissingParameters.ERROR
     """How to handle missing parameters in feedback function calls."""
 
+    run_location: Optional[FeedbackRunLocation]
+    """Where the feedback evaluation takes place (e.g. locally, at a Snowflake server, etc)."""
+
     selectors: Dict[str, serial.Lens]
     """Selectors; pointers into [Records][trulens.core.schema.record.Record] of where
     to get arguments for `imp`."""
@@ -350,6 +369,7 @@ class FeedbackDefinition(pyschema.WithClassInfo, serial.SerialModel, Hashable):
         selectors: Optional[Dict[str, serial.Lens]] = None,
         name: Optional[str] = None,
         higher_is_better: Optional[bool] = None,
+        run_location: Optional[FeedbackRunLocation] = None,
         **kwargs,
     ):
         selectors = selectors or {}
@@ -364,6 +384,7 @@ class FeedbackDefinition(pyschema.WithClassInfo, serial.SerialModel, Hashable):
             selectors=selectors,
             if_exists=if_exists,
             if_missing=if_missing,
+            run_location=run_location,
             **kwargs,
         )
 

--- a/tests/e2e/test_snowflake_connection.py
+++ b/tests/e2e/test_snowflake_connection.py
@@ -2,62 +2,19 @@
 Tests for a Snowflake connection.
 """
 
-import os
-from unittest import TestCase
 from unittest import main
-import uuid
-
-from snowflake.core import Root
-from snowflake.snowpark import Session
-from trulens.core import Tru
 
 from tests.unit.utils import optional_test
+from tests.util.snowflake_test_case import SnowflakeTestCase
 
 
-class TestSnowflakeConnection(TestCase):
-    def setUp(self):
-        self._snowflake_connection_parameters = {
-            "account": os.environ["SNOWFLAKE_ACCOUNT"],
-            "user": os.environ["SNOWFLAKE_USER"],
-            "password": os.environ["SNOWFLAKE_USER_PASSWORD"],
-            "database": os.environ["SNOWFLAKE_DATABASE"],
-            "role": os.environ["SNOWFLAKE_ROLE"],
-            "warehouse": os.environ["SNOWFLAKE_WAREHOUSE"],
-        }
-        self._snowflake_session = Session.builder.configs(
-            self._snowflake_connection_parameters
-        ).create()
-        self._snowflake_root = Root(self._snowflake_session)
-
-    def tearDown(self):
-        self._snowflake_session.close()
-
-    def _list_schemas(self):
-        schemas = self._snowflake_root.databases[
-            self._snowflake_connection_parameters["database"]
-        ].schemas.iter()
-        return [curr.name for curr in schemas]
-
+class TestSnowflakeConnection(SnowflakeTestCase):
     @optional_test
     def test_basic_snowflake_connection(self):
         """
         Check that we can connect to a Snowflake backend and have created the required schema.
         """
-        app_name = str(uuid.uuid4()).replace("-", "_")
-        schema_name = Tru._validate_and_compute_schema_name(app_name)
-        try:
-            self.assertNotIn(schema_name, self._list_schemas())
-            Tru(
-                snowflake_connection_parameters=self._snowflake_connection_parameters,
-                name=app_name,
-            )
-            self.assertIn(schema_name, self._list_schemas())
-        finally:
-            if schema_name in self._list_schemas():
-                schema = self._snowflake_root.databases[
-                    self._snowflake_connection_parameters["database"]
-                ].schemas[schema_name]
-                schema.delete()
+        self.get_tru("test_basic_snowflake_connection")
 
 
 if __name__ == "__main__":

--- a/tests/e2e/test_snowflake_feedback_evaluation.py
+++ b/tests/e2e/test_snowflake_feedback_evaluation.py
@@ -1,0 +1,86 @@
+"""
+Tests server-side feedback evaluations in Snowflake.
+"""
+
+import time
+from unittest import main
+
+from trulens.core import Feedback
+from trulens.core import SnowflakeFeedback
+from trulens.core import Tru
+from trulens.core import TruBasicApp
+from trulens.core.schema.feedback import FeedbackMode
+from trulens.core.schema.feedback import FeedbackRunLocation
+
+from tests.unit.utils import optional_test
+from tests.util.snowflake_test_case import SnowflakeTestCase
+
+
+def silly_feedback_function(q: str) -> float:
+    return 0.1
+
+
+class TestSnowflakeFeedbackEvaluation(SnowflakeTestCase):
+    @optional_test
+    def test_local_deferred_mode(self) -> None:
+        tru = Tru()
+        tru.reset_database()
+        f = Feedback(silly_feedback_function).on_default()
+        tru_app = TruBasicApp(
+            text_to_text=lambda t: f"returning {t}",
+            feedbacks=[f],
+            feedback_mode=FeedbackMode.DEFERRED,
+        )
+        with tru_app:
+            tru_app.main_call("test_local_deferred_mode")
+        time.sleep(2)
+        records_and_feedback = tru.get_records_and_feedback()
+        self.assertEqual(len(records_and_feedback), 2)
+        self.assertEqual(len(records_and_feedback[1]), 0)
+        self.assertEqual(records_and_feedback[0].shape[0], 1)
+        tru.start_evaluator()
+        time.sleep(2)
+        tru.stop_evaluator()
+        records_and_feedback = tru.get_records_and_feedback()
+        self.assertEqual(len(records_and_feedback), 2)
+        self.assertEqual(records_and_feedback[1], ["silly_feedback_function"])
+        self.assertEqual(records_and_feedback[0].shape[0], 1)
+        self.assertEqual(
+            records_and_feedback[0]["silly_feedback_function"].iloc[0],
+            0.1,
+        )
+
+    @optional_test
+    def test_snowflake_deferred_mode(self) -> None:
+        # TODO(this_pr): refactor so that I'm not duplicating so much code between this test and the local one!
+        tru = self.get_tru("test_snowflake_deferred_mode")
+        f = SnowflakeFeedback(silly_feedback_function).on_default()
+        tru_app = TruBasicApp(
+            text_to_text=lambda t: f"returning {t}",
+            feedbacks=[f],
+            feedback_mode=FeedbackMode.DEFERRED,
+        )
+        with tru_app:
+            tru_app.main_call("test_snowflake_deferred_mode")
+        tru.start_evaluator()
+        time.sleep(2)
+        tru.stop_evaluator()
+        records_and_feedback = tru.get_records_and_feedback()
+        self.assertEqual(len(records_and_feedback), 2)
+        self.assertEqual(len(records_and_feedback[1]), 0)
+        self.assertEqual(records_and_feedback[0].shape[0], 1)
+        tru.start_evaluator(run_location=FeedbackRunLocation.SNOWFLAKE)
+        time.sleep(2)
+        tru.stop_evaluator()
+        records_and_feedback = tru.get_records_and_feedback()
+        self.assertEqual(len(records_and_feedback), 2)
+        self.assertEqual(records_and_feedback[1], ["silly_feedback_function"])
+        self.assertEqual(records_and_feedback[0].shape[0], 1)
+        self.assertEqual(
+            records_and_feedback[0]["silly_feedback_function"].iloc[0],
+            0.1,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/util/snowflake_test_case.py
+++ b/tests/util/snowflake_test_case.py
@@ -1,0 +1,76 @@
+"""
+Test class to use for Snowflake testing.
+"""
+
+import logging
+import os
+from unittest import TestCase
+from unittest import main
+import uuid
+
+from snowflake.core import Root
+from snowflake.snowpark import Session
+from trulens.core import Tru
+
+
+class SnowflakeTestCase(TestCase):
+    def setUp(self):
+        self._logger = logging.getLogger(__name__)
+        self._snowflake_connection_parameters = {
+            "account": os.environ["SNOWFLAKE_ACCOUNT"],
+            "user": os.environ["SNOWFLAKE_USER"],
+            "password": os.environ["SNOWFLAKE_USER_PASSWORD"],
+            "database": os.environ["SNOWFLAKE_DATABASE"],
+            "role": os.environ["SNOWFLAKE_ROLE"],
+            "warehouse": os.environ["SNOWFLAKE_WAREHOUSE"],
+        }
+        self._snowflake_session = Session.builder.configs(
+            self._snowflake_connection_parameters
+        ).create()
+        self._snowflake_root = Root(self._snowflake_session)
+        self._snowflake_schemas_to_delete = []
+
+    def tearDown(self):
+        # [HACK!] Clean up any instances of `Tru` so tests don't interfere with each other.
+        Tru._instances = {}
+        Tru._id_to_name_map = {}
+        # Clean up any Snowflake schemas.
+        schemas_not_deleted = []
+        for curr in self._snowflake_schemas_to_delete:
+            try:
+                schema = self._snowflake_root.databases[
+                    self._snowflake_connection_parameters["database"]
+                ].schemas[curr]
+                schema.delete()
+            except Exception:
+                schemas_not_deleted.append(curr)
+                self._logger.error(f"Failed to clean up schema {curr}!")
+        if schemas_not_deleted:
+            error_msg = "Failed to clean up the following schemas:\n"
+            error_msg += "\n".join(schemas_not_deleted)
+            raise ValueError(error_msg)
+        self._snowflake_session.close()
+
+    def list_schemas(self):
+        schemas = self._snowflake_root.databases[
+            self._snowflake_connection_parameters["database"]
+        ].schemas.iter()
+        return [curr.name for curr in schemas]
+
+    def get_tru(self, app_base_name: str) -> Tru:
+        app_name = app_base_name
+        app_name += "__"
+        app_name += str(uuid.uuid4()).replace("-", "_")
+        schema_name = Tru._validate_and_compute_schema_name(app_name)
+        self.assertNotIn(schema_name, self.list_schemas())
+        self._snowflake_schemas_to_delete.append(schema_name)
+        tru = Tru(
+            snowflake_connection_parameters=self._snowflake_connection_parameters,
+            app_name=app_name,
+        )
+        self.assertIn(schema_name, self.list_schemas())
+        return tru
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/util/snowflake_test_case.py
+++ b/tests/util/snowflake_test_case.py
@@ -32,8 +32,8 @@ class SnowflakeTestCase(TestCase):
 
     def tearDown(self):
         # [HACK!] Clean up any instances of `Tru` so tests don't interfere with each other.
-        Tru._instances = {}
-        Tru._id_to_name_map = {}
+        for key in [curr for curr in Tru._instances if curr[0] == "Tru"]:
+            del Tru._instances[key]
         # Clean up any Snowflake schemas.
         schemas_not_deleted = []
         for curr in self._snowflake_schemas_to_delete:


### PR DESCRIPTION
# Description
Set up a `run_location` that determines where a feedback function should be run if it's deferred.

## Other details good to know for developers
This does introduce schema changes. AFAICT the way `trulens` is written, this isn't a problem but someone can correct me if I'm wrong.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update
