### PR TITLE
Have Makefile upload target should first build packages.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,8 @@ build: $(POETRY_DIRS)
 	make build-dashboard
 
 ## Step: Upload wheels to pypi
-# Usage: TOKEN=... make upload-trulnes-instrument-langchain
-upload-%:
+# Usage: TOKEN=... make upload-trulens-instrument-langchain
+upload-%: build
 	poetry run twine upload -u __token__ -p $(TOKEN) dist/$*/*
 
 upload-all: build


### PR DESCRIPTION
# Description
Have Makefile upload target should first build packages.

## Other details good to know for developers


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
