### PR TITLE
Fix Groundedness by upgrading and fixing nltk version to >=3.8.2

### DIFF
--- a/src/feedback/pyproject.toml
+++ b/src/feedback/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.9"
 trulens-core = { version = "^1.0.0", allow-prereleases = true }
-nltk = "^3.8"
+nltk = "^3.8.2"
 pydantic = "^2"
 numpy = ">=1.23"
 scikit-learn = "^1.3.0"

--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -1397,7 +1397,7 @@ class LLMProvider(Provider):
         Returns:
             Tuple[float, dict]: A tuple containing a value between 0.0 (not grounded) and 1.0 (grounded) and a dictionary containing the reasons for the evaluation.
         """
-        nltk.download("punkt", quiet=True)
+        nltk.download("punkt_tab", quiet=True)
         groundedness_scores = {}
         reasons_str = ""
 
@@ -1484,7 +1484,7 @@ class LLMProvider(Provider):
         Returns:
             Tuple[float, dict]: A tuple containing a value between 0.0 (not grounded) and 1.0 (grounded) and a dictionary containing the reasons for the evaluation.
         """
-        nltk.download("punkt", quiet=True)
+        nltk.download("punkt_tab", quiet=True)
         groundedness_scores = {}
         reasons_str = ""
 

--- a/src/providers/huggingface/pyproject.toml
+++ b/src/providers/huggingface/pyproject.toml
@@ -32,7 +32,7 @@ trulens-core = { version = "^1.0.0", allow-prereleases = true }
 trulens-feedback = { version = "^1.0.0", allow-prereleases = true }
 requests = "^2.31"
 numpy = ">=1.23"
-nltk = "^3.8"
+nltk = "^3.8.2"
 # HuggingfaceLocal dependencies
 torch = "^2.1.2"
 transformers = "^4.38.1"

--- a/src/providers/huggingface/trulens/providers/huggingface/provider.py
+++ b/src/providers/huggingface/trulens/providers/huggingface/provider.py
@@ -219,7 +219,7 @@ class HuggingfaceBase(Provider):
         Returns:
             Tuple[float, str]: A tuple containing a value between 0.0 (not grounded) and 1.0 (grounded) and a string containing the reasons for the evaluation.
         """
-        nltk.download("punkt", quiet=True)
+        nltk.download("punkt_tab", quiet=True)
         groundedness_scores = {}
 
         reasons_str = ""

--- a/src/providers/litellm/poetry.lock
+++ b/src/providers/litellm/poetry.lock
@@ -2249,7 +2249,7 @@ files = []
 develop = false
 
 [package.dependencies]
-nltk = "^3.8"
+nltk = "^3.8.2"
 numpy = ">=1.23"
 pydantic = "^2"
 scikit-learn = "^1.3.0"

--- a/src/providers/openai/poetry.lock
+++ b/src/providers/openai/poetry.lock
@@ -2085,7 +2085,7 @@ files = []
 develop = false
 
 [package.dependencies]
-nltk = "^3.8"
+nltk = "^3.8.2"
 numpy = ">=1.23"
 pydantic = "^2"
 scikit-learn = "^1.3.0"


### PR DESCRIPTION
# Description

`punkt`, our sentence tokenizer library used in Groundedness feedback function, introduces a breaking change over 3.8.1 -> 3.8.2 and thus breaks groundedness feedback at the moment. 

The breaking change is to avoid the vulnerability in pickle and thus I'm leaning toward upgrading the version to be >= 3.8.2: 
https://github.com/nltk/nltk/issues/3266#issuecomment-2284001819
https://github.com/nltk/nltk/issues/3293
The change requires us to now download `punkt_tab` instead of `punkt`.  
## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.
![image](https://github.com/user-attachments/assets/61b81658-7520-4f77-9e4c-d32878a861fb)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
