### PR TITLE
Bump nltk version from 3.8.2 to 3.9.1

### DIFF
--- a/src/feedback/pyproject.toml
+++ b/src/feedback/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.9"
 trulens-core = { version = "^1.0.0", allow-prereleases = true }
-nltk = "^3.8.2"
+nltk = "^3.9.1"
 pydantic = "^2"
 numpy = ">=1.23"
 scikit-learn = "^1.3.0"

--- a/src/providers/huggingface/pyproject.toml
+++ b/src/providers/huggingface/pyproject.toml
@@ -32,7 +32,7 @@ trulens-core = { version = "^1.0.0", allow-prereleases = true }
 trulens-feedback = { version = "^1.0.0", allow-prereleases = true }
 requests = "^2.31"
 numpy = ">=1.23"
-nltk = "^3.8.2"
+nltk = "^3.9.1"
 # HuggingfaceLocal dependencies
 torch = "^2.1.2"
 transformers = "^4.38.1"

--- a/src/providers/litellm/poetry.lock
+++ b/src/providers/litellm/poetry.lock
@@ -2249,7 +2249,7 @@ files = []
 develop = false
 
 [package.dependencies]
-nltk = "^3.8.2"
+nltk = "^3.9.1"
 numpy = ">=1.23"
 pydantic = "^2"
 scikit-learn = "^1.3.0"

--- a/src/providers/openai/poetry.lock
+++ b/src/providers/openai/poetry.lock
@@ -2085,7 +2085,7 @@ files = []
 develop = false
 
 [package.dependencies]
-nltk = "^3.8.2"
+nltk = "^3.9.1"
 numpy = ">=1.23"
 pydantic = "^2"
 scikit-learn = "^1.3.0"


### PR DESCRIPTION
# Description

Because apparently the `3.8.2` patch is no longer available on Pypi and now we should just use `3.9.1`
https://github.com/nltk/nltk/issues/3266#issuecomment-2295883525
## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
