### PR TITLE
Stop using internal `pip` module (i.e. `pip._internal.parse_requirements`).

### DIFF
--- a/src/core/trulens/core/utils/imports.py
+++ b/src/core/trulens/core/utils/imports.py
@@ -25,7 +25,7 @@ from typing import (
 
 from packaging import requirements
 from packaging import version
-from pip._internal.req import parse_requirements
+import pkg_resources
 
 logger = logging.getLogger(__name__)
 pp = PrettyPrinter()
@@ -49,15 +49,15 @@ def _requirements_of_trulens_core_file(
     file in trulens.core."""
     _trulens_resources = resources.files("trulens.core")
     with resources.as_file(_trulens_resources / path) as _path:
-        pip_reqs = parse_requirements(str(_path), session=None)
+        with open(_path) as fh:
+            reqs = pkg_resources.parse_requirements(fh)
 
-        mapping = {}
+            mapping = {}
 
-        for pip_req in pip_reqs:
-            req = requirements.Requirement(pip_req.requirement)
-            mapping[req.name] = req
+            for req in reqs:
+                mapping[req.name] = req
 
-        return mapping
+            return mapping
 
 
 def static_resource(namespace: str, filepath: Union[Path, str]) -> Path:


### PR DESCRIPTION
# Description
Stop using internal `pip` module (i.e. `pip._internal.req.parse_requirements`). For whatever, reason the following fails on `pip` version `24.2`:
```python
import pydantic
from pip._internal.req import parse_requirements
from langchain.callbacks.openai_info import OpenAICallbackHandler
```
This has nothing to do with us, but if we stop using the `pip._internal` it seems to stop working. I briefly looked into why this is the case, and I got confused.

## Other details good to know for developers
This should fix https://github.com/truera/trulens/issues/1308

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
