### PR TITLE
[CP] Stop using internal pip module (i.e. pip._internal.parse_requirements).

### DIFF
--- a/trulens_eval/trulens_eval/utils/imports.py
+++ b/trulens_eval/trulens_eval/utils/imports.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, Iterable, Optional, Sequence, Type, Union
 
 from packaging import requirements
 from packaging import version
-from pip._internal.req import parse_requirements
+import pkg_resources
 
 from trulens_eval import __name__ as trulens_name
 
@@ -28,16 +28,9 @@ pp = PrettyPrinter()
 def requirements_of_file(path: Path) -> Dict[str, requirements.Requirement]:
     """Get a dictionary of package names to requirements from a requirements
     file."""
-
-    pip_reqs = parse_requirements(str(path), session=None)
-
-    mapping = {}
-
-    for pip_req in pip_reqs:
-        req = requirements.Requirement(pip_req.requirement)
-        mapping[req.name] = req
-
-    return mapping
+    with open(path) as fh:
+        reqs = pkg_resources.parse_requirements(fh)
+        return {req.name: req for req in reqs}
 
 
 if sys.version_info >= (3, 9):


### PR DESCRIPTION
# Description
[CP] Stop using internal pip module (i.e. pip._internal.parse_requirements).

This is, in some sense, a CP of https://github.com/truera/trulens/pull/1393

## Other details good to know for developers
I didn't test this out.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
