### PR TITLE
Groundedness with option to not use nltk punk sentence tokenizer

### DIFF
--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -1519,7 +1519,10 @@ class LLMProvider(Provider):
             nltk.download("punkt_tab", quiet=True)
             hypotheses = sent_tokenize(statement)
         else:
-            hypotheses = [statement]
+            hypotheses = self._create_chat_completion(
+                prompt=prompts.LLM_GROUNDEDNESS_SENTENCES_SPLITTER,
+                messages=[{"role": "user", "content": statement}],
+            ).split("\n")
 
         groundedness_scores = {}
         reasons_str = ""

--- a/src/feedback/trulens/feedback/prompts.py
+++ b/src/feedback/trulens/feedback/prompts.py
@@ -28,6 +28,7 @@ STATEMENT: {hypothesis}
 
 LLM_GROUNDEDNESS_SYSTEM = v2.Groundedness.system_prompt
 LLM_GROUNDEDNESS_USER = v2.Groundedness.user_prompt
+LLM_GROUNDEDNESS_SENTENCES_SPLITTER = v2.Groundedness.sentences_splitter_prompt
 
 LLM_ANSWERABILITY_SYSTEM = v2.Answerability.system_prompt
 LLM_ANSWERABILITY_USER = v2.Answerability.user_prompt

--- a/src/feedback/trulens/feedback/v2/feedback.py
+++ b/src/feedback/trulens/feedback/v2/feedback.py
@@ -224,6 +224,15 @@ class Groundedness(Semantics, WithPrompt):
         """
     )
 
+    sentences_splitter_prompt: ClassVar[str] = cleandoc(
+        """Split the following statement into individual sentences:
+
+        Statement: {statement}
+
+        Return each sentence on a new line.
+        """
+    )
+
 
 class Answerability(Semantics, WithPrompt):
     system_prompt: ClassVar[str] = cleandoc(


### PR DESCRIPTION
# Description

We currently are not able to download packages from the internet in server-side evaluation flow, so `punkt` is not an option there. 

Adding this quick parameter control to unblock @sfc-gh-dkurokawa  and @sfc-gh-jreini. 

In the longer term (like beyond this week),  this will require some benchmarking results to show whether we can fully migrate away from nltk / punkt 

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [x] This change requires a documentation update
