### PR TITLE
 Make styling more compatible with dark mode for feedback functions

### DIFF
--- a/src/dashboard/trulens/dashboard/ux/styles.py
+++ b/src/dashboard/trulens/dashboard/ux/styles.py
@@ -41,9 +41,9 @@ class CATEGORY:
     ]
 
     styling = {
-        "PASS": dict(color="#aaffaa", icon="✅"),
-        "WARNING": dict(color="#ffffaa", icon="⚠️"),
-        "FAIL": dict(color="#ffaaaa", icon="🛑"),
+        "PASS": dict(color="#aaffaa44", icon="✅"),
+        "WARNING": dict(color="#ffffaa44", icon="⚠️"),
+        "FAIL": dict(color="#ffaaaa44", icon="🛑"),
     }
 
     PASS: defaultdict = defaultdict(dict)
@@ -74,7 +74,7 @@ class CATEGORY:
         name="unknown",
         adjective="unknown",
         threshold=np.nan,
-        color="#aaaaaa",
+        color="#aaaaaa44",
         icon="?",
     )
 
@@ -125,7 +125,6 @@ cellstyle_jscode = {
         f"""
         if (v {">=" if k == "HIGHER_IS_BETTER" else "<="} {cat.threshold}) {{
             return {{
-                'color': 'black',
                 'backgroundColor': '{cat.color}'
             }};
         }}
@@ -135,7 +134,6 @@ cellstyle_jscode = {
     + f"""
         // i.e. not a number
         return {{
-            'color': 'black',
             'backgroundColor': '{CATEGORY.UNKNOWN.color}'
         }};
     }}"""


### PR DESCRIPTION
# Description

Test of a simple fix for feedback functions dark mode by reducing opacity of background colors


<img width="1728" alt="Screenshot 2024-09-03 at 2 47 33 PM" src="https://github.com/user-attachments/assets/a529f489-8771-4967-a5da-2dec9c175a83">

## Other details good to know for developers

Streamlit seems to be limited in dark mode detection at runtime, so trying out a preliminary solution to see if this could meet our needs first

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
