### PR TITLE
Support having a `Langchain` provider with a `BaseLLM` and not just `BaseChatModel`.

### DIFF
--- a/src/providers/langchain/trulens/providers/langchain/provider.py
+++ b/src/providers/langchain/trulens/providers/langchain/provider.py
@@ -66,7 +66,20 @@ class Langchain(LLMProvider):
 
         elif messages is not None:
             messages = [_convert_message(message) for message in messages]
-            predict = self.endpoint.chain.invoke(messages, **kwargs).content
+            predict = self.endpoint.chain.invoke(messages, **kwargs)
+            if isinstance(self.endpoint.chain, BaseChatModel):
+                if not isinstance(predict, BaseMessage):
+                    raise ValueError(
+                        "`chain.invoke` did not return a `langchain_core.messages.BaseMessage` as expected!"
+                    )
+                predict = predict.content
+            elif isinstance(self.endpoint.chain, BaseLLM):
+                if not isinstance(predict, str):
+                    raise ValueError(
+                        "`chain.invoke` did not return a `str` as expected!"
+                    )
+            else:
+                raise ValueError("Unexpected `chain` type!")
 
         else:
             raise ValueError("`prompt` or `messages` must be specified.")


### PR DESCRIPTION
# Description
Support having a `Langchain` provider with a `BaseLLM` and not just `BaseChatModel`.

This is for: https://github.com/truera/trulens/issues/1451

## Other details good to know for developers

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
