### PR TITLE
Move requests/Endpoint.post to huggingface provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ test-static:
 # are part of only the less frequently run release tests.
 
 # API tests.
-test-api:
+test-api: env-tests
 	TEST_OPTIONAL=1 $(PYTEST) tests/unit/static/test_api.py
 write-api: env-tests
 	TEST_OPTIONAL=1 WRITE_GOLDEN=1 $(PYTEST) tests/unit/static/test_api.py || true

--- a/src/core/trulens/core/utils/requirements.optional.txt
+++ b/src/core/trulens/core/utils/requirements.optional.txt
@@ -62,6 +62,8 @@ ipython    >= 8.12.0  # for notebooks
 ipywidgets >= 8.0.6  # for some example notebooks
 ipytree    >= 0.2.2 # for some example notebooks
 
+# Progress bars
+tqdm >= 4.2.0
 
 # Chunking/parsing
 sentencepiece  >= 0.1.97

--- a/src/providers/huggingface/trulens/providers/huggingface/endpoint.py
+++ b/src/providers/huggingface/trulens/providers/huggingface/endpoint.py
@@ -1,6 +1,14 @@
 import inspect
 import json
-from typing import Callable, Optional
+import logging
+from time import sleep
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Optional,
+    Sequence,
+)
 
 import requests
 from trulens.core.feedback import Endpoint
@@ -8,6 +16,10 @@ from trulens.core.feedback import EndpointCallback
 from trulens.core.utils.keys import _check_key
 from trulens.core.utils.keys import get_huggingface_headers
 from trulens.core.utils.python import safe_hasattr
+from trulens.core.utils.serial import JSON
+from trulens.core.utils.threading import DEFAULT_NETWORK_TIMEOUT
+
+logger = logging.getLogger(__name__)
 
 
 class HuggingfaceCallback(EndpointCallback):
@@ -32,6 +44,23 @@ class HuggingfaceEndpoint(Endpoint):
     Huggingface. Instruments the requests.post method for requests to
     "https://api-inference.huggingface.co".
     """
+
+    def __init__(self, *args, **kwargs):
+        if safe_hasattr(self, "name"):
+            # Already created with SingletonPerName mechanism
+            return
+
+        kwargs["name"] = "huggingface"
+        kwargs["callback_class"] = HuggingfaceCallback
+
+        # Returns true in "warn" mode to indicate that key is set. Does not
+        # print anything even if key not set.
+        if _check_key("HUGGINGFACE_API_KEY", silent=True, warn=True):
+            kwargs["post_headers"] = get_huggingface_headers()
+
+        super().__init__(*args, **kwargs)
+
+        self._instrument_class(requests, "post")
 
     def __new__(cls, *args, **kwargs):
         return super(Endpoint, cls).__new__(cls, name="huggingface")
@@ -61,19 +90,41 @@ class HuggingfaceEndpoint(Endpoint):
         if callback is not None:
             callback.handle_classification(response=response)
 
-    def __init__(self, *args, **kwargs):
-        if safe_hasattr(self, "name"):
-            # Already created with SingletonPerName mechanism
-            return
+    def post(
+        self, url: str, payload: JSON, timeout: float = DEFAULT_NETWORK_TIMEOUT
+    ) -> Any:
+        self.pace_me()
+        ret = requests.post(
+            url, json=payload, timeout=timeout, headers=self.post_headers
+        )
 
-        kwargs["name"] = "huggingface"
-        kwargs["callback_class"] = HuggingfaceCallback
+        j = ret.json()
 
-        # Returns true in "warn" mode to indicate that key is set. Does not
-        # print anything even if key not set.
-        if _check_key("HUGGINGFACE_API_KEY", silent=True, warn=True):
-            kwargs["post_headers"] = get_huggingface_headers()
+        # Huggingface public api sometimes tells us that a model is loading and
+        # how long to wait:
+        if "estimated_time" in j:
+            wait_time = j["estimated_time"]
+            logger.error("Waiting for %s (%s) second(s).", j, wait_time)
+            sleep(wait_time + 2)
+            return self.post(url, payload)
 
-        super().__init__(*args, **kwargs)
+        elif isinstance(j, Dict) and "error" in j:
+            error = j["error"]
+            logger.error("API error: %s.", j)
 
-        self._instrument_class(requests, "post")
+            if error == "overloaded":
+                logger.error("Waiting for overloaded API before trying again.")
+                sleep(10.0)
+                return self.post(url, payload)
+            else:
+                raise RuntimeError(error)
+
+        assert (
+            isinstance(j, Sequence) and len(j) > 0
+        ), f"Post did not return a sequence: {j}"
+
+        if len(j) == 1:
+            return j[0]
+
+        else:
+            return j

--- a/src/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py
+++ b/src/trulens_eval/trulens_eval/feedback/provider/endpoint/base.py
@@ -10,9 +10,9 @@ from trulens.core.utils import deprecation as deprecation_utils
 
 deprecation_utils.packages_dep_warn()
 
-from trulens.core.feedback.endpoint import DEFAULT_NETWORK_TIMEOUT
 from trulens.core.feedback.endpoint import DEFAULT_RPM
 from trulens.core.feedback.endpoint import INSTRUMENT
 from trulens.core.feedback.endpoint import Endpoint
 from trulens.core.feedback.endpoint import EndpointCallback
+from trulens.core.utils.threading import DEFAULT_NETWORK_TIMEOUT
 from trulens.feedback.dummy.endpoint import DummyEndpoint

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -495,7 +495,6 @@ trulens.core.feedback.endpoint.Endpoint:
     name: builtins.str
     pace: trulens.core.utils.pace.Pace
     pace_me: builtins.function
-    post: builtins.function
     post_headers: typing.Dict[builtins.str, builtins.str]
     print_instrumented: builtins.classmethod
     retries: builtins.int

--- a/tests/unit/static/golden/api.trulens_eval.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens_eval.3.11.yaml
@@ -696,7 +696,6 @@ trulens_eval.feedback.provider.endpoint.base.Endpoint:
     name: builtins.str
     pace: trulens_eval.utils.pace.Pace
     pace_me: builtins.function
-    post: builtins.function
     post_headers: typing.Dict[builtins.str, builtins.str]
     print_instrumented: builtins.classmethod
     retries: builtins.int

--- a/tests/unit/static/golden/api.trulens_eval.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens_eval.3.11.yaml
@@ -800,6 +800,7 @@ trulens_eval.feedback.provider.endpoint.hugs.HuggingfaceEndpoint:
     global_callback: trulens_eval.feedback.provider.endpoint.base.EndpointCallback
     name: builtins.str
     pace: trulens_eval.utils.pace.Pace
+    post: builtins.function
     post_headers: typing.Dict[builtins.str, builtins.str]
     retries: builtins.int
     rpm: builtins.float

--- a/tests/unit/static/golden/api.trulens_eval.3.12.yaml
+++ b/tests/unit/static/golden/api.trulens_eval.3.12.yaml
@@ -706,7 +706,6 @@ trulens_eval.feedback.provider.endpoint.base.Endpoint:
     name: builtins.str
     pace: trulens_eval.utils.pace.Pace
     pace_me: builtins.function
-    post: builtins.function
     post_headers: typing.Dict[builtins.str, builtins.str]
     print_instrumented: builtins.classmethod
     retries: builtins.int

--- a/tests/unit/static/golden/api.trulens_eval.3.12.yaml
+++ b/tests/unit/static/golden/api.trulens_eval.3.12.yaml
@@ -810,6 +810,7 @@ trulens_eval.feedback.provider.endpoint.hugs.HuggingfaceEndpoint:
     global_callback: trulens_eval.feedback.provider.endpoint.base.EndpointCallback
     name: builtins.str
     pace: trulens_eval.utils.pace.Pace
+    post: builtins.function
     post_headers: typing.Dict[builtins.str, builtins.str]
     retries: builtins.int
     rpm: builtins.float


### PR DESCRIPTION
# Description
Huggingface seems to be the only dependency that makes use of the Endpoint.post() method. Seeing as this depends on requests.post, this PR moves Endpoint.post() to HuggingFaceEndpoint.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
