### PR TITLE
init_server_side=False by default

### DIFF
--- a/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
@@ -41,7 +41,7 @@ class SnowflakeConnector(DBConnector):
         schema: str,
         warehouse: str,
         role: str,
-        init_server_side: bool = True,
+        init_server_side: bool = False,
         database_redact_keys: bool = False,
         database_prefix: Optional[str] = None,
         database_args: Optional[Dict[str, Any]] = None,


### PR DESCRIPTION
# Description
Making init of server-side artifacts opt-in. Avoids errors in cases where users do not have sufficient permissions to create tasks/streams/sprocs/etc. Or may be interested in local eval and unaware of other artifacts being created on their db.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
