### PR TITLE
endpoint kwargs

### DIFF
--- a/src/core/trulens/core/utils/python.py
+++ b/src/core/trulens/core/utils/python.py
@@ -288,7 +288,7 @@ def code_line(func, show_source: bool = False) -> Optional[str]:
 
     if isinstance(func, inspect.FrameInfo):
         ret = f"{func.filename}:{func.lineno}"
-        if show_source:
+        if show_source and func.code_context is not None:
             ret += "\n"
             for line in func.code_context:
                 ret += "\t" + line

--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -524,7 +524,12 @@ class LLMProvider(Provider):
         )
 
     def relevance_with_cot_reasons(
-        self, prompt: str, response: str
+        self,
+        prompt: str,
+        response: str,
+        min_score_val: int = 0,
+        max_score_val: int = 3,
+        temperature: float = 0.0,
     ) -> Tuple[float, Dict]:
         """
         Uses chat completion Model. A function that completes a template to
@@ -542,6 +547,9 @@ class LLMProvider(Provider):
         Args:
             prompt (str): A text prompt to an agent.
             response (str): The agent's response to the prompt.
+            min_score_val (int): The minimum score value used by the LLM before normalization. Defaults to 0.
+            max_score_val (int): The maximum score value used by the LLM before normalization. Defaults to 3.
+            temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
 
         Returns:
             float: A value between 0 and 1. 0 being "not relevant" and 1 being
@@ -555,7 +563,13 @@ class LLMProvider(Provider):
         user_prompt = user_prompt.replace(
             "RELEVANCE:", prompts.COT_REASONS_TEMPLATE
         )
-        return self.generate_score_and_reasons(system_prompt, user_prompt)
+        return self.generate_score_and_reasons(
+            system_prompt,
+            user_prompt,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
+        )
 
     def sentiment(self, text: str) -> float:
         """
@@ -578,7 +592,13 @@ class LLMProvider(Provider):
         user_prompt = prompts.SENTIMENT_USER + text
         return self.generate_score(system_prompt, user_prompt)
 
-    def sentiment_with_cot_reasons(self, text: str) -> Tuple[float, Dict]:
+    def sentiment_with_cot_reasons(
+        self,
+        text: str,
+        min_score_val: int = 0,
+        max_score_val: int = 3,
+        temperature: float = 0.0,
+    ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A function that completes a
         template to check the sentiment of some text.
@@ -591,6 +611,9 @@ class LLMProvider(Provider):
 
         Args:
             text (str): Text to evaluate.
+            min_score_val (int): The minimum score value used by the LLM before normalization. Defaults to 0.
+            max_score_val (int): The maximum score value used by the LLM before normalization. Defaults to 3.
+            temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
 
         Returns:
             float: A value between 0.0 (negative sentiment) and 1.0 (positive sentiment).
@@ -599,7 +622,13 @@ class LLMProvider(Provider):
         user_prompt = (
             prompts.SENTIMENT_USER + text + prompts.COT_REASONS_TEMPLATE
         )
-        return self.generate_score_and_reasons(system_prompt, user_prompt)
+        return self.generate_score_and_reasons(
+            system_prompt,
+            user_prompt,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
+        )
 
     def model_agreement(self, prompt: str, response: str) -> float:
         """
@@ -663,7 +692,12 @@ class LLMProvider(Provider):
         return self.generate_score(system_prompt, user_prompt)
 
     def _langchain_evaluate_with_cot_reasons(
-        self, text: str, criteria: str
+        self,
+        text: str,
+        criteria: str,
+        min_score_val: int = 0,
+        max_score_val: int = 3,
+        temperature: float = 0.0,
     ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A general function that completes a template
@@ -672,6 +706,9 @@ class LLMProvider(Provider):
         Args:
             text (str): A prompt to an agent.
             criteria (str): The specific criteria for evaluation.
+            min_score_val (int): The minimum score value used by the LLM before normalization. Defaults to 0.
+            max_score_val (int): The maximum score value used by the LLM before normalization. Defaults to 3.
+            temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
 
         Returns:
             Tuple[float, str]: A tuple containing a value between 0.0 and 1.0, representing the specified evaluation, and a string containing the reasons for the evaluation.
@@ -684,7 +721,13 @@ class LLMProvider(Provider):
         user_prompt = str.format(
             prompts.LANGCHAIN_PROMPT_TEMPLATE_USER, submission=text
         )
-        return self.generate_score_and_reasons(system_prompt, user_prompt)
+        return self.generate_score_and_reasons(
+            system_prompt,
+            user_prompt,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
+        )
 
     def conciseness(self, text: str) -> float:
         """
@@ -1277,7 +1320,12 @@ class LLMProvider(Provider):
         return self.generate_score(system_prompt, user_prompt)
 
     def stereotypes_with_cot_reasons(
-        self, prompt: str, response: str
+        self,
+        prompt: str,
+        response: str,
+        min_score_val: int = 0,
+        max_score_val: int = 3,
+        temperature: float = 0.0,
     ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A function that completes a template to
@@ -1291,8 +1339,10 @@ class LLMProvider(Provider):
 
         Args:
             prompt (str): A text prompt to an agent.
-
             response (str): The agent's response to the prompt.
+            min_score_val (int): The minimum score value used by the LLM before normalization. Defaults to 0.
+            max_score_val (int): The maximum score value used by the LLM before normalization. Defaults to 3.
+            temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
 
         Returns:
             Tuple[float, str]: A tuple containing a value between 0.0 (no stereotypes assumed) and 1.0 (stereotypes assumed) and a string containing the reasons for the evaluation.
@@ -1304,7 +1354,13 @@ class LLMProvider(Provider):
             prompts.STEREOTYPES_USER_PROMPT, prompt=prompt, response=response
         )
 
-        return self.generate_score_and_reasons(system_prompt, user_prompt)
+        return self.generate_score_and_reasons(
+            system_prompt,
+            user_prompt,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
+        )
 
     def _remove_trivial_statements(self, statements: List[str]) -> List[str]:
         """
@@ -1337,6 +1393,8 @@ class LLMProvider(Provider):
         source: str,
         statement: str,
         use_sent_tokenize: bool = False,
+        min_score_val: int = 0,
+        max_score_val: int = 3,
         temperature: float = 0.0,
     ) -> Tuple[float, dict]:
         """A measure to track if the source material supports each sentence in
@@ -1387,10 +1445,13 @@ class LLMProvider(Provider):
         Then, the scores are normalized, and averaged to give a final groundedness score of 0.5.
 
         Args:
-            source: The source that should support the statement.
-            statement: The statement to check groundedness.
-            use_sent_tokenize: Whether to split the statement into sentences using punkt sentence tokenizer. If False, use LLM to split the statement.
-            Default to False to use LLM to split the statement. Note this might incur additional costs and reach context window limits in some cases.
+            source (str): The source that should support the statement.
+            statement (str): The statement to check groundedness.
+            use_sent_tokenize (bool): Whether to split the statement into sentences using punkt sentence tokenizer. If `False`, use an LLM to split the statement. Defaults to False. Note this might incur additional costs and reach context window limits in some cases.
+            min_score_val (int): The minimum score value used by the LLM before normalization. Defaults to 0.
+            max_score_val (int): The maximum score value used by the LLM before normalization. Defaults to 3.
+            temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+
         Returns:
             Tuple[float, dict]: A tuple containing a value between 0.0 (not grounded) and 1.0 (grounded) and a dictionary containing the reasons for the evaluation.
         """
@@ -1431,7 +1492,11 @@ class LLMProvider(Provider):
                 premise=f"{source}", hypothesis=f"{hypothesis}"
             )
             score, reason = self.generate_score_and_reasons(
-                system_prompt, user_prompt
+                system_prompt,
+                user_prompt,
+                min_score_val=min_score_val,
+                max_score_val=max_score_val,
+                temperature=temperature,
             )
             return index, score, reason
 
@@ -1484,6 +1549,8 @@ class LLMProvider(Provider):
         statement: str,
         question: str,
         use_sent_tokenize: bool = True,
+        min_score_val: int = 0,
+        max_score_val: int = 3,
         temperature: float = 0.0,
     ) -> Tuple[float, dict]:
         """A measure to track if the source material supports each sentence in
@@ -1515,10 +1582,14 @@ class LLMProvider(Provider):
             ```
 
         Args:
-            source: The source that should support the statement.
-            statement: The statement to check groundedness.
-            question: The question to check answerability.
-            use_sent_tokenize: Whether to split the statement into sentences using punkt sentence tokenizer. If False, use LLM to split the statement.
+            source (str): The source that should support the statement.
+            statement (str): The statement to check groundedness.
+            question (str): The question to check answerability.
+            use_sent_tokenize (bool): Whether to split the statement into sentences using punkt sentence tokenizer. If `False`, use an LLM to split the statement. Defaults to False. Note this might incur additional costs and reach context window limits in some cases.
+            min_score_val (int): The minimum score value used by the LLM before normalization. Defaults to 0.
+            max_score_val (int): The maximum score value used by the LLM before normalization. Defaults to 3.
+            temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+
         Returns:
             Tuple[float, dict]: A tuple containing a value between 0.0 (not grounded) and 1.0 (grounded) and a dictionary containing the reasons for the evaluation.
         """
@@ -1579,7 +1650,11 @@ class LLMProvider(Provider):
                     premise=f"{source}", hypothesis=f"{hypothesis}"
                 )
                 score, reason = self.generate_score_and_reasons(
-                    system_prompt, user_prompt
+                    system_prompt,
+                    user_prompt,
+                    min_score_val=min_score_val,
+                    max_score_val=max_score_val,
+                    temperature=temperature,
                 )
                 return index, score, reason
 

--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -352,7 +352,7 @@ class LLMProvider(Provider):
         )
 
         if criteria or output_space:
-            system_prompt = ContextRelevance.override_criteria_and_output_space(
+            system_prompt = ContextRelevance.generate_system_prompt(
                 min_score=min_score_val,
                 max_score=max_score_val,
                 criteria=criteria,
@@ -423,7 +423,7 @@ class LLMProvider(Provider):
         )
 
         if criteria or output_space:
-            system_prompt = ContextRelevance.override_criteria_and_output_space(
+            system_prompt = ContextRelevance.generate_system_prompt(
                 min_score=min_score_val,
                 max_score=max_score_val,
                 criteria=criteria,
@@ -483,7 +483,7 @@ class LLMProvider(Provider):
         )
 
         if criteria or output_space:
-            system_prompt = ContextRelevance.override_criteria_and_output_space(
+            system_prompt = ContextRelevance.generate_system_prompt(
                 min_score=min_score_val,
                 max_score=max_score_val,
                 criteria=criteria,
@@ -551,10 +551,8 @@ class LLMProvider(Provider):
         )
 
         if criteria or output_space:
-            system_prompt = (
-                PromptResponseRelevance.override_criteria_and_output_space(
-                    criteria, output_space
-                )
+            system_prompt = PromptResponseRelevance.generate_system_prompt(
+                criteria, output_space
             )
         else:
             system_prompt = PromptResponseRelevance.system_prompt
@@ -608,13 +606,11 @@ class LLMProvider(Provider):
             min_score_val, max_score_val
         )
         if criteria or output_space:
-            system_prompt = (
-                PromptResponseRelevance.override_criteria_and_output_space(
-                    min_score=min_score_val,
-                    max_score=max_score_val,
-                    criteria=criteria,
-                    output_space=output_space,
-                )
+            system_prompt = PromptResponseRelevance.generate_system_prompt(
+                min_score=min_score_val,
+                max_score=max_score_val,
+                criteria=criteria,
+                output_space=output_space,
             )
         else:
             system_prompt = PromptResponseRelevance.system_prompt
@@ -1554,7 +1550,7 @@ class LLMProvider(Provider):
         )
 
         if criteria or output_space:
-            system_prompt = Groundedness.override_criteria_and_output_space(
+            system_prompt = Groundedness.generate_system_prompt(
                 min_score=min_score_val,
                 max_score=max_score_val,
                 criteria=criteria,
@@ -1718,7 +1714,7 @@ class LLMProvider(Provider):
         )
 
         if criteria or output_space:
-            system_prompt = Groundedness.override_criteria_and_output_space(
+            system_prompt = Groundedness.generate_system_prompt(
                 min_score=min_score_val,
                 max_score=max_score_val,
                 criteria=criteria,

--- a/src/feedback/trulens/feedback/v2/feedback.py
+++ b/src/feedback/trulens/feedback/v2/feedback.py
@@ -245,7 +245,7 @@ class CriteriaOutputSpaceMixin:
         return validated
 
     @classmethod
-    def override_criteria_and_output_space(
+    def generate_system_prompt(
         cls,
         min_score: int,
         max_score: int,

--- a/src/feedback/trulens/feedback/v2/feedback.py
+++ b/src/feedback/trulens/feedback/v2/feedback.py
@@ -159,121 +159,6 @@ supported_criteria = {
 }
 
 
-class Conciseness(Semantics, WithPrompt):  # or syntax
-    # openai.conciseness
-
-    # langchain Criteria.CONCISENESS
-    system_prompt: ClassVar[str] = cleandoc(
-        f"""{supported_criteria["conciseness"]} Respond only as a number from 0 to 10 where 0 is the least concise and 10 is the most concise."""
-    )
-
-
-class Correctness(Semantics, WithPrompt):
-    # openai.correctness
-    # openai.correctness_with_cot_reasons
-
-    # langchain Criteria.CORRECTNESS
-    system_prompt: ClassVar[str] = cleandoc(
-        f"""{supported_criteria["correctness"]} Respond only as a number from 0 to 10 where 0 is the least correct and 10 is the most correct."""
-    )
-
-
-class Coherence(Semantics):
-    # openai.coherence
-    # openai.coherence_with_cot_reasons
-
-    system_prompt: ClassVar[str] = cleandoc(
-        f"""{supported_criteria["coherence"]} Respond only as a number from 0 to 10 where 0 is the least coherent and 10 is the most coherent."""
-    )
-
-
-class Relevance(Semantics):
-    """
-    This evaluates the *relevance* of the LLM response to the given text by LLM
-    prompting.
-
-    Relevance is available for any LLM provider.
-
-    """
-
-    # openai.relevance
-    # openai.relevance_with_cot_reasons
-    pass
-
-
-class Groundedness(Semantics, WithPrompt):
-    # hugs._summarized_groundedness
-    # hugs._doc_groundedness
-
-    system_prompt: ClassVar[str] = cleandoc(
-        """You are a INFORMATION OVERLAP classifier; providing the overlap of information between the source and statement.
-        Respond only as a number from 0 to 10 where 0 is no information overlap and 10 is all information is overlapping.
-        Statements of doubt, that admissions of uncertainty or not knowing the answer are considered abstention, and should be counted as the most overlap and therefore score a 10.
-        Never elaborate."""
-    )
-    user_prompt: ClassVar[str] = cleandoc(
-        """SOURCE: {premise}
-
-        Hypothesis: {hypothesis}
-
-        Please answer with the template below for all statement sentences:
-
-        Criteria: <Statement Sentence>
-        Supporting Evidence: <Identify and describe the location in the source where the information matches the statement. Provide a detailed, human-readable summary indicating the path or key details. if nothing matches, say NOTHING FOUND. For the case where the statement is an abstention, say ABSTENTION>
-        Score: <Output a number between 0-10 where 0 is no information overlap and 10 is all information is overlapping>
-        """
-    )
-
-    sentences_splitter_prompt: ClassVar[str] = cleandoc(
-        """Split the following statement into individual sentences:
-
-        Statement: {statement}
-
-        Return each sentence on a new line.
-        """
-    )
-
-
-class Answerability(Semantics, WithPrompt):
-    system_prompt: ClassVar[str] = cleandoc(
-        """You are a ANSWERABILITY classifier; providing a score of 0 if the answer to the QUESTION does not exist in the SOURCE, and a 10 if the answer does exist in the SOURCE.
-        Do not consider the quality of the answer, only if it exists or not.
-        Never elaborate."""
-    )
-    user_prompt: ClassVar[str] = cleandoc(
-        """QUESTION: {question}
-
-        SOURCE: {source}
-
-        ANSWERABILITY:"""
-    )
-
-
-class Abstention(Semantics, WithPrompt):
-    system_prompt: ClassVar[str] = cleandoc(
-        """You are a ABSTENTION classifier; classifying the STATEMENT as an abstention or not.
-        Examples of an abstention include statement similar to 'I don't know' or 'I can't answer that'.
-        Respond only as a number from 0 to 10 where 0 is not an abstention and 10 is an abstention.
-        Never elaborate."""
-    )
-    user_prompt: ClassVar[str] = cleandoc(
-        """STATEMENT: {statement}
-
-        ABSTENTION:"""
-    )
-
-
-class Trivial(Semantics, WithPrompt):
-    system_prompt: ClassVar[str] = cleandoc(
-        """Consider the following list of statements. Identify and remove sentences that are stylistic, contain trivial pleasantries, or lack substantive information relevant to the main content. Respond only with a list of the remaining statements in the format of a python list of strings."""
-    )
-    user_prompt: ClassVar[str] = cleandoc(
-        """ALL STATEMENTS: {statements}
-
-        IMPORTANT STATEMENTS: """
-    )
-
-
 LIKERT_0_3_PROMPT = "0 to 3, where 0 is the lowest score according to the criteria and 3 is the highest possible score"
 BINARY_0_1_PROMPT = "0 or 1, where 0 is lowest and negative (i.e. irrelevant or not grounded) and 1 is highest and positive (relevant, grounded, valid, etc.)"
 LIKERT_0_10_PROMPT = "0 to 10, where 0 is the lowest score according to the criteria and 10 is the highest possible score"  # legacy, to be deprecated
@@ -319,22 +204,199 @@ class EvalSchema(pydantic.BaseModel):
             )
 
 
+class Conciseness(Semantics, WithPrompt):  # or syntax
+    # openai.conciseness
+
+    # langchain Criteria.CONCISENESS
+    system_prompt: ClassVar[str] = cleandoc(
+        f"""{supported_criteria["conciseness"]} Respond only as a number from 0 to 10 where 0 is the least concise and 10 is the most concise."""
+    )
+
+
+class Correctness(Semantics, WithPrompt):
+    # openai.correctness
+    # openai.correctness_with_cot_reasons
+
+    # langchain Criteria.CORRECTNESS
+    system_prompt: ClassVar[str] = cleandoc(
+        f"""{supported_criteria["correctness"]} Respond only as a number from 0 to 10 where 0 is the least correct and 10 is the most correct."""
+    )
+
+
+class Coherence(Semantics):
+    # openai.coherence
+    # openai.coherence_with_cot_reasons
+
+    system_prompt: ClassVar[str] = cleandoc(
+        f"""{supported_criteria["coherence"]} Respond only as a number from 0 to 10 where 0 is the least coherent and 10 is the most coherent."""
+    )
+
+
 @dataclass
-class ContextRelevance(Relevance, WithPrompt):
+class CriteriaOutputSpaceMixin:
     system_prompt: ClassVar[str]
+    output_space_prompt: ClassVar[str]
+    system_prompt_template: ClassVar[str]
+    criteria_template: ClassVar[str]
 
-    user_prompt: ClassVar[str]
-    verb_confidence_prompt: ClassVar[str]
+    @staticmethod
+    def validate_criteria_and_output_space(criteria: str, output_space: str):
+        validated = EvalSchema(criteria=criteria, output_space=output_space)
+        return validated
+
+    @classmethod
+    def override_criteria_and_output_space(
+        cls,
+        min_score: int,
+        max_score: int,
+        criteria: Optional[str] = None,
+        output_space: Optional[str] = None,
+    ) -> str:
+        if criteria is None and output_space is None:
+            return cls.system_prompt
+
+        if criteria is None:
+            criteria = cls.criteria_template.format(
+                min_score=min_score, max_score=max_score
+            )
+
+        if output_space is None:
+            output_space_prompt = cls.output_space_prompt
+        else:
+            validated = cls.validate_criteria_and_output_space(
+                criteria, output_space
+            )
+            criteria = validated.criteria
+            output_space_prompt = validated.get_output_scale_prompt()
+
+        return cleandoc(
+            cls.system_prompt_template.format(
+                output_space_prompt=output_space_prompt,
+                criteria=criteria,
+            )
+        )
+
+
+class Relevance(Semantics):
+    """
+    This evaluates the *relevance* of the LLM response to the given text by LLM
+    prompting.
+
+    Relevance is available for any LLM provider.
+
+    """
+
+    # openai.relevance
+    # openai.relevance_with_cot_reasons
+    pass
+
+
+class Groundedness(Semantics, WithPrompt, CriteriaOutputSpaceMixin):
+    # hugs._summarized_groundedness
+    # hugs._doc_groundedness
+
     output_space_prompt: ClassVar[str] = LIKERT_0_3_PROMPT
+    output_space: ClassVar[str] = OutputSpace.LIKERT_0_3.name
+    criteria_template: ClassVar[str] = """
+    You should score the groundedness of the statement based on the following criteria:
+    - Statements that are directly supported by the source should be considered grounded and should get a high score.
+    - Statements that are not directly supported by the source should be considered not grounded and should get a low score.
+    - Statements of doubt, that admissions of uncertainty or not knowing the answer are considered abstention, and should be counted as the most overlap and therefore get a max score of {max_score}.
+    """
 
-    criteria: str = """
-        - CONTEXT that is IRRELEVANT to the QUESTION should score 0.
-        - CONTEXT that is RELEVANT to some of the QUESTION should score of 1.
-        - CONTEXT that is RELEVANT to most of the QUESTION should get a score of 2.
-        - CONTEXT that is RELEVANT to the entirety of the QUESTION should get a score of 3, which is the full mark.
-        - CONTEXT must be relevant and helpful for answering the entire QUESTION to get a score of 3.
+    system_prompt_template: ClassVar[str] = cleandoc(
+        """You are an INFORMATION OVERLAP classifier; providing the overlap of information (entailment or groundedness) between the source and statement.
+        Respond only as a number from {output_space_prompt}.
+
+        {criteria}
+        Never elaborate."""
+    )
+
+    user_prompt: ClassVar[str] = cleandoc(
+        """SOURCE: {premise}
+
+        Hypothesis: {hypothesis}
+
+        Please answer with the template below for all statement sentences:
+
+        Criteria: <Statement Sentence>
+        Supporting Evidence: <Identify and describe the location in the source where the information matches the statement. Provide a detailed, human-readable summary indicating the path or key details. if nothing matches, say NOTHING FOUND. For the case where the statement is an abstention, say ABSTENTION>
+        Score: <Output a number based on the scoring output space / range>
         """
-    output_space: str = OutputSpace.LIKERT_0_3.name
+    )
+
+    sentences_splitter_prompt: ClassVar[str] = cleandoc(
+        """Split the following statement into individual sentences:
+
+        Statement: {statement}
+
+        Return each sentence on a new line.
+        """
+    )
+
+    criteria: ClassVar[str] = criteria_template.format(
+        min_score=OutputSpace.LIKERT_0_3.value[0],
+        max_score=OutputSpace.LIKERT_0_3.value[1],
+    )
+
+    system_prompt: ClassVar[str] = cleandoc(
+        system_prompt_template.format(
+            output_space_prompt=output_space_prompt, criteria=criteria
+        )
+    )
+
+
+class Answerability(Semantics, WithPrompt):
+    system_prompt: ClassVar[str] = cleandoc(
+        """You are a ANSWERABILITY classifier; providing a score of 0 if the answer to the QUESTION does not exist in the SOURCE, and a 10 if the answer does exist in the SOURCE.
+        Do not consider the quality of the answer, only if it exists or not.
+        Never elaborate."""
+    )
+    user_prompt: ClassVar[str] = cleandoc(
+        """QUESTION: {question}
+
+        SOURCE: {source}
+
+        ANSWERABILITY:"""
+    )
+
+
+class Abstention(Semantics, WithPrompt):
+    system_prompt: ClassVar[str] = cleandoc(
+        """You are a ABSTENTION classifier; classifying the STATEMENT as an abstention or not.
+        Examples of an abstention include statement similar to 'I don't know' or 'I can't answer that'.
+        Respond only as a number from 0 to 10 where 0 is not an abstention and 10 is an abstention.
+        Never elaborate."""
+    )
+    user_prompt: ClassVar[str] = cleandoc(
+        """STATEMENT: {statement}
+
+        ABSTENTION:"""
+    )
+
+
+class Trivial(Semantics, WithPrompt):
+    system_prompt: ClassVar[str] = cleandoc(
+        """Consider the following list of statements. Identify and remove sentences that are stylistic, contain trivial pleasantries, or lack substantive information relevant to the main content. Respond only with a list of the remaining statements in the format of a python list of strings."""
+    )
+    user_prompt: ClassVar[str] = cleandoc(
+        """ALL STATEMENTS: {statements}
+
+        IMPORTANT STATEMENTS: """
+    )
+
+
+@dataclass
+class ContextRelevance(Relevance, WithPrompt, CriteriaOutputSpaceMixin):
+    output_space_prompt: ClassVar[str] = LIKERT_0_3_PROMPT
+    output_space: ClassVar[str] = OutputSpace.LIKERT_0_3.name
+    criteria_template: ClassVar[str] = """
+        - CONTEXT that is IRRELEVANT to the QUESTION should score {min_score}.
+        - CONTEXT that is RELEVANT to some of the QUESTION should get an intermediate score.
+        - CONTEXT that is RELEVANT to most of the QUESTION should get a score closer to {max_score}.
+        - CONTEXT that is RELEVANT to the entirety of the QUESTION should get a score of {max_score}, which is the full mark.
+        - CONTEXT must be relevant and helpful for answering the entire QUESTION to get a score of {max_score}.
+        """
 
     system_prompt_template: ClassVar[str] = cleandoc(
         """You are a RELEVANCE grader; providing the relevance of the given CONTEXT to the given QUESTION.
@@ -355,34 +417,14 @@ class ContextRelevance(Relevance, WithPrompt):
         """
     )
 
-    @staticmethod
-    def validate_criteria_and_output_space(criteria: str, output_space: str):
-        validated = EvalSchema(criteria=criteria, output_space=output_space)
-        return validated
-
-    @classmethod
-    def override_criteria_and_output_space(
-        cls, criteria: str, output_space: str
-    ):
-        validated = cls.validate_criteria_and_output_space(
-            criteria, output_space
-        )
-        cls.output_space_prompt = validated.get_output_scale_prompt()
-        cls.system_prompt = cleandoc(
-            cls.system_prompt_template.format(
-                criteria=validated.criteria,
-                output_space_prompt=cls.output_space_prompt,
-            )
-        )
-
-    user_prompt = cleandoc(
+    user_prompt: ClassVar[str] = cleandoc(
         """QUESTION: {question}
         CONTEXT: {context}
 
         RELEVANCE:
         """
     )
-    verb_confidence_prompt = cleandoc(
+    verb_confidence_prompt: ClassVar[str] = cleandoc(
         """Finally after generating the RELEVANCE score, provide the confidence score CONFIDENCE between 0.0 to 1.0 that your RELEVANCE scoring is accurate (i.e. how confident you are with your evaluation score). Give ONLY the confidence score, no
         other words or explanation.\n\nFor example: CONFIDENCE: <the probability between
         0 and 1.0 that your scoring is accurate, without any extra commentary whatsoever;
@@ -390,83 +432,63 @@ class ContextRelevance(Relevance, WithPrompt):
         """
     )
 
-    system_prompt = system_prompt_template.format(
-        output_space_prompt=output_space_prompt, criteria=criteria
+    criteria: ClassVar[str] = criteria_template.format(
+        min_score=OutputSpace.LIKERT_0_3.value[0],
+        max_score=OutputSpace.LIKERT_0_3.value[1],
+    )
+
+    system_prompt: ClassVar[str] = cleandoc(
+        system_prompt_template.format(
+            output_space_prompt=output_space_prompt, criteria=criteria
+        )
     )
 
 
-class PromptResponseRelevance(Relevance, WithPrompt):
-    system_prompt: ClassVar[str]
-
-    user_prompt: ClassVar[str]
-    verb_confidence_prompt: ClassVar[str]
-    output_space_prompt: ClassVar[str] = LIKERT_0_3_PROMPT
-
-    criteria: str = """
-        - RESPONSE that is IRRELEVANT to the PROMPT should score 0.
-        - RESPONSE that is RELEVANT to some of the PROMPT should score of 1.
-        - RESPONSE that is RELEVANT to most of the PROMPT should get a score of 2.
-        - RESPONSE that is RELEVANT to the entirety of the PROMPT should get a score of 3, which is the full mark.
-        - RESPONSE must be relevant and helpful for answering the entire PROMPT to get a score of 3.
-        """
-    output_space: str = OutputSpace.LIKERT_0_3.name
-
-    @staticmethod
-    def validate_criteria_and_output_space(criteria: str, output_space: str):
-        validated = EvalSchema(criteria=criteria, output_space=output_space)
-        return validated
-
-    @classmethod
-    def override_criteria_and_output_space(
-        cls, criteria: str, output_space: str
-    ):
-        validated = cls.validate_criteria_and_output_space(
-            criteria, output_space
-        )
-        cls.output_space_prompt = validated.get_output_scale_prompt()
-        cls.system_prompt = cleandoc(
-            cls.system_prompt_template.format(
-                criteria=validated.criteria,
-                output_space_prompt=cls.output_space_prompt,
-            )
-        )
+class PromptResponseRelevance(Relevance, WithPrompt, CriteriaOutputSpaceMixin):
+    output_space_prompt: ClassVar[str] = LIKERT_0_10_PROMPT
+    output_space: ClassVar[str] = OutputSpace.LIKERT_0_10.name
+    criteria_template: ClassVar[str] = """
+        - RESPONSE must be relevant to the entire PROMPT to get a maximum score of {max_score}.
+        - RELEVANCE score should increase as the RESPONSE provides RELEVANT context to more parts of the PROMPT.
+        - RESPONSE that is RELEVANT to none of the PROMPT should get a minimum score of {min_score}.
+        - RESPONSE that is RELEVANT and answers the entire PROMPT completely should get a score of {max_score}.
+        - RESPONSE that confidently FALSE should get a score of {min_score}.
+        - RESPONSE that is only seemingly RELEVANT should get a score of {min_score}.
+        - Answers that intentionally do not answer the question, such as 'I don't know' and model refusals, should also be counted as the least RELEVANT and get a score of {min_score}.
+    """
 
     system_prompt_template: ClassVar[str] = cleandoc(
         """You are a RELEVANCE grader; providing the relevance of the given RESPONSE to the given PROMPT.
         Respond only as a number from {output_space_prompt}.
 
-        Criteria for evaluating relevance:
-        {criteria}
-
         A few additional scoring guidelines:
 
         - Long RESPONSES should score equally well as short RESPONSES.
 
-        - RESPONSE must be relevant to the entire PROMPT to get a maximum score.
-
-        - RELEVANCE score should increase as the RESPONSE provides RELEVANT context to more parts of the PROMPT.
-
-        - RESPONSE that is RELEVANT and answers the entire PROMPT completely should be counted as the most RELEVANT and get a maximum score.
-
-        - RESPONSE that confidently FALSE should get a minimum score.
-
-        - RESPONSE that is only seemingly RELEVANT should get a minimum score.
-
-        - Answers that intentionally do not answer the question, such as 'I don't know' and model refusals, should also be counted as the least RELEVANT and get a minimum score.
+        {criteria}
 
         - Never elaborate.
         """
     )
+
     user_prompt: ClassVar[str] = cleandoc(
         """PROMPT: {prompt}
 
         RESPONSE: {response}
 
-        RELEVANCE: """
+        RELEVANCE:
+        """
     )
 
-    system_prompt = system_prompt_template.format(
-        output_space_prompt=output_space_prompt, criteria=criteria
+    criteria: ClassVar[str] = criteria_template.format(
+        min_score=OutputSpace.LIKERT_0_10.value[0],
+        max_score=OutputSpace.LIKERT_0_10.value[1],
+    )
+
+    system_prompt: ClassVar[str] = cleandoc(
+        system_prompt_template.format(
+            output_space_prompt=output_space_prompt, criteria=criteria
+        )
     )
 
 
@@ -565,7 +587,9 @@ class Harmfulness(Moderation, WithPrompt):
 class Insensitivity(Semantics, WithPrompt):  # categorize
     # openai.insensitivity
     # openai.insensitivity_with_cot_reasons
-    """Examples and categorization of racial insensitivity: https://sph.umn.edu/site/docs/hewg/microaggressions.pdf ."""
+    """
+    Examples and categorization of racial insensitivity: https://sph.umn.edu/site/docs/hewg/microaggressions.pdf .
+    """
 
     # langchain Criteria.INSENSITIVITY
     system_prompt: ClassVar[str] = cleandoc(

--- a/src/feedback/trulens/feedback/v2/feedback.py
+++ b/src/feedback/trulens/feedback/v2/feedback.py
@@ -390,23 +390,8 @@ class ContextRelevance(Relevance, WithPrompt):
         """
     )
 
-    system_prompt = cleandoc(
-        """You are a RELEVANCE grader; providing the relevance of the given CONTEXT to the given QUESTION.
-        Respond only as a number from {output_space_prompt}.
-
-        Criteria for evaluating relevance:
-        {criteria}
-
-        A few additional scoring guidelines:
-
-        - Long CONTEXTS should score equally well as short CONTEXTS.
-
-        - RELEVANCE score should increase as the CONTEXTS provides more RELEVANT context to the QUESTION.
-
-        - RELEVANCE score should increase as the CONTEXTS provides RELEVANT context to more parts of the QUESTION.
-
-        - Never elaborate.
-        """.format(output_space_prompt=output_space_prompt, criteria=criteria)
+    system_prompt = system_prompt_template.format(
+        output_space_prompt=output_space_prompt, criteria=criteria
     )
 
 
@@ -478,6 +463,10 @@ class PromptResponseRelevance(Relevance, WithPrompt):
         RESPONSE: {response}
 
         RELEVANCE: """
+    )
+
+    system_prompt = system_prompt_template.format(
+        output_space_prompt=output_space_prompt, criteria=criteria
     )
 
 

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -2221,6 +2221,7 @@ trulens.feedback.v2.feedback:
     Correctness: pydantic._internal._model_construction.ModelMetaclass
     Criminality: pydantic._internal._model_construction.ModelMetaclass
     Criteria: enum.EnumType
+    CriteriaOutputSpaceMixin: builtins.type
     DigitalOutputType: pydantic._internal._model_construction.ModelMetaclass
     EvalSchema: pydantic._internal._model_construction.ModelMetaclass
     Explained: pydantic._internal._model_construction.ModelMetaclass
@@ -2341,17 +2342,17 @@ trulens.feedback.v2.feedback.ContextRelevance:
   __bases__:
   - trulens.feedback.v2.feedback.Relevance
   - trulens.feedback.v2.feedback.WithPrompt
+  - trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
     criteria: builtins.str
+    criteria_template: builtins.str
     languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
     output_space: builtins.str
     output_space_prompt: builtins.str
-    override_criteria_and_output_space: builtins.classmethod
     system_prompt: builtins.str
     system_prompt_template: builtins.str
     user_prompt: builtins.str
-    validate_criteria_and_output_space: builtins.staticmethod
     verb_confidence_prompt: builtins.str
 trulens.feedback.v2.feedback.Controversiality:
   __bases__:
@@ -2398,6 +2399,13 @@ trulens.feedback.v2.feedback.Criteria:
     RELEVANCE: trulens.feedback.v2.feedback.Criteria
     name: enum.property
     value: enum.property
+trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin:
+  __bases__:
+  - builtins.object
+  __class__: builtins.type
+  attributes:
+    generate_system_prompt: builtins.classmethod
+    validate_criteria_and_output_space: builtins.staticmethod
 trulens.feedback.v2.feedback.DigitalOutputType:
   __bases__:
   - trulens.feedback.v2.feedback.FeedbackOutputType
@@ -2461,11 +2469,17 @@ trulens.feedback.v2.feedback.Groundedness:
   __bases__:
   - trulens.feedback.v2.feedback.Semantics
   - trulens.feedback.v2.feedback.WithPrompt
+  - trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
+    criteria: builtins.str
+    criteria_template: builtins.str
     languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
+    output_space: builtins.str
+    output_space_prompt: builtins.str
     sentences_splitter_prompt: builtins.str
     system_prompt: builtins.str
+    system_prompt_template: builtins.str
     user_prompt: builtins.str
 trulens.feedback.v2.feedback.Harmfulness:
   __bases__:
@@ -2579,10 +2593,16 @@ trulens.feedback.v2.feedback.PromptResponseRelevance:
   __bases__:
   - trulens.feedback.v2.feedback.Relevance
   - trulens.feedback.v2.feedback.WithPrompt
+  - trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
+    criteria: builtins.str
+    criteria_template: builtins.str
     languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
+    output_space: builtins.str
+    output_space_prompt: builtins.str
     system_prompt: builtins.str
+    system_prompt_template: builtins.str
     user_prompt: builtins.str
 trulens.feedback.v2.feedback.Relevance:
   __bases__:


### PR DESCRIPTION
# Description

Adds min_score, max_score, temperature, and custom criteria to answer relevance.
This fixes an issue where bedrock endpoint does not use the same scale for parsing as was set in LLMProvider.


## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
