### PR TITLE
Revert default sentence splitter for groundedness back to use punkt

### DIFF
--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -1451,7 +1451,7 @@ class LLMProvider(Provider):
         source: str,
         statement: str,
         criteria: Optional[str] = None,
-        use_sent_tokenize: bool = False,
+        use_sent_tokenize: bool = True,
         min_score_val: int = 0,
         max_score_val: int = 3,
         temperature: float = 0.0,


### PR DESCRIPTION
# Description

Until we have confidence in using LLM to perform sentence splitting. 
## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts default sentence splitting in `groundedness_measure_with_cot_reasons` to use `punkt` tokenizer in `llm_provider.py`.
> 
>   - **Behavior**:
>     - Reverts default sentence splitting method in `groundedness_measure_with_cot_reasons` in `llm_provider.py` to use `punkt` tokenizer by setting `use_sent_tokenize` to `True`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for d9a6f9a5403def24e9e3c289950bc9a941788063. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->