### PR TITLE
Fix splitting key_points issue: generalize the solution for splitting key points in _assess_key_point_inclusion()

### DIFF
--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -1274,7 +1274,7 @@ class LLMProvider(Provider):
             List[str]: A list of strings indicating whether each key point is included in the summary.
         """
         assert self.endpoint is not None, "Endpoint is not set."
-        key_points_list = key_points.split("\n\n")
+        key_points_list = [point.strip() for point in key_points.split('\n') if point.strip()]
 
         system_prompt = prompts.COMPREHENSIVENESS_SYSTEM_PROMPT
         inclusion_assessments = []

--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -1274,7 +1274,7 @@ class LLMProvider(Provider):
             List[str]: A list of strings indicating whether each key point is included in the summary.
         """
         assert self.endpoint is not None, "Endpoint is not set."
-        key_points_list = [point.strip() for point in key_points.split('\n') if point.strip()]
+        key_points_list = [point.strip() for point in key_points.split("\n") if point.strip()]
 
         system_prompt = prompts.COMPREHENSIVENESS_SYSTEM_PROMPT
         inclusion_assessments = []

--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -1274,7 +1274,9 @@ class LLMProvider(Provider):
             List[str]: A list of strings indicating whether each key point is included in the summary.
         """
         assert self.endpoint is not None, "Endpoint is not set."
-        key_points_list = [point.strip() for point in key_points.split("\n") if point.strip()]
+        key_points_list = [
+            point.strip() for point in key_points.split("\n") if point.strip()
+        ]
 
         system_prompt = prompts.COMPREHENSIVENESS_SYSTEM_PROMPT
         inclusion_assessments = []


### PR DESCRIPTION
- key_points_list = [point.strip() for point in key_points.split('\n') if point.strip()]

I found that key_points sometimes include empty lines and sometimes don't, due to the probabilistic nature of LLM.
What I mean by that is key_points can be either

"Key Point 1:
Key Point 2:
Key Point 3:
"

or

"Key Point 1:

Key Point 2:

Key Point 3:
"

So both key_points.split('\n') and key_points.split('\n\n') could lead to a problem. I came up with a more generalized solution, as shown at the top.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix inconsistent newline handling in `_assess_key_point_inclusion` in `llm_provider.py` by splitting on single newlines and stripping whitespace.
> 
>   - **Behavior**:
>     - Modify `_assess_key_point_inclusion` in `llm_provider.py` to handle key points with inconsistent newline formatting by splitting on single newlines and stripping whitespace.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for ed681bf8562fd478eaca098c4767f8869ce00d96. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->