### PR TITLE
SQLAlchemy joinedload on record.app relationship

### DIFF
--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -756,6 +756,7 @@ class SQLAlchemyDB(DB):
                 )
 
             stmt = stmt.options(joinedload(self.orm.Record.feedback_results))
+            stmt = stmt.options(joinedload(self.orm.Record.app))
             # NOTE(piotrm): The joinedload here makes it so that the
             # feedback_results get loaded eagerly instead if lazily when
             # accessed later.

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -758,7 +758,7 @@ class SQLAlchemyDB(DB):
             stmt = stmt.options(joinedload(self.orm.Record.feedback_results))
             stmt = stmt.options(joinedload(self.orm.Record.app))
             # NOTE(piotrm): The joinedload here makes it so that the
-            # feedback_results get loaded eagerly instead if lazily when
+            # feedback_results and app definitions get loaded eagerly instead if lazily when
             # accessed later.
 
             # TODO(piotrm): The subsequent logic in helper methods end up


### PR DESCRIPTION
# Description

Perform joined load on app definitions table. Otherwise will lazy load app definitions and query for each app definition separately.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `joinedload` for `Record.app` in `get_records_and_feedback` to improve query efficiency by eagerly loading app definitions.
> 
>   - **Behavior**:
>     - Add `joinedload` for `Record.app` in `get_records_and_feedback` in `sqlalchemy.py` to eagerly load app definitions, preventing separate queries for each app definition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 072902e3292b5bae46abdaa4c392c24e1e86ce8b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->