### PR TITLE
Allow using Snowflake Connector for the actual DB Connector instead of the connection parameters.

### DIFF
--- a/docs/component_guides/logging/where_to_log/log_in_snowflake.md
+++ b/docs/component_guides/logging/where_to_log/log_in_snowflake.md
@@ -16,9 +16,32 @@ Here is a guide to logging in _Snowflake_.
 
 ## Connect TruLens to the Snowflake database
 
-Connecting TruLens to a Snowflake database for logging traces and evaluations only requires passing in Snowflake [connection parameters](https://docs.snowflake.com/developer-guide/python-connector/python-connector-api#connect).
+Connecting TruLens to a Snowflake database for logging traces and evaluations only requires passing in an existing [Snowpark session](https://docs.snowflake.com/en/developer-guide/snowpark/reference/python/latest/snowpark/api/snowflake.snowpark.Session#snowflake.snowpark.Session) or Snowflake [connection parameters](https://docs.snowflake.com/developer-guide/python-connector/python-connector-api#connect).
 
-!!! example "Connect TruLens to your Snowflake database"
+!!! example "Connect TruLens to your Snowflake database via Snowpark Session"
+
+    ```python
+    from snowflake.snowpark.Session
+    from trulens.connectors.snowflake import SnowflakeConnector
+    from trulens.core import TruSession
+    connnection_parameters = {
+        account: "<account>",
+        user: "<user>",
+        password: "<password>",
+        database_name: "<database>",
+        schema_name: "<schema>",
+        warehouse: "<warehouse>",
+        role: "<role>",
+    }
+    # Here we create a new Snowpark session, but if we already have one we can use that instead.
+    snowpark_session = Session.builder.configs(connection_parameters).create()
+    conn = SnowflakeConnector(
+        snowpark_session=snowpark_session
+    )
+    session = TruSession(connector=conn)
+    ```
+
+!!! example "Connect TruLens to your Snowflake database via connection parameters"
 
     ```python
     from trulens.core import TruSession

--- a/docs/component_guides/logging/where_to_log/log_in_snowflake.md
+++ b/docs/component_guides/logging/where_to_log/log_in_snowflake.md
@@ -21,7 +21,7 @@ Connecting TruLens to a Snowflake database for logging traces and evaluations on
 !!! example "Connect TruLens to your Snowflake database via Snowpark Session"
 
     ```python
-    from snowflake.snowpark.Session
+    from snowflake.snowpark import Session
     from trulens.connectors.snowflake import SnowflakeConnector
     from trulens.core import TruSession
     connnection_parameters = {

--- a/docs/reference/connectors/index.md
+++ b/docs/reference/connectors/index.md
@@ -9,7 +9,7 @@ Abstract interface: [DBConnector][trulens.core.database.connector.base.DBConnect
 ## Optional Implementations
 
 - 📦 [SnowflakeConnector][trulens.connectors.snowflake.connector.SnowflakeConnector] in
-  package `trulens-connectors-snowlake`.
+  package `trulens-connectors-snowflake`.
 
     ```bash
     pip install trulens-connectors-snowflake

--- a/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
@@ -34,30 +34,118 @@ class SnowflakeConnector(DBConnector):
 
     def __init__(
         self,
-        account: str,
-        user: str,
-        password: str,
-        database: str,
-        schema: str,
-        warehouse: str,
-        role: str,
+        account: Optional[str] = None,
+        user: Optional[str] = None,
+        password: Optional[str] = None,
+        database: Optional[str] = None,
+        schema: Optional[str] = None,
+        warehouse: Optional[str] = None,
+        role: Optional[str] = None,
+        snowpark_session: Optional[Session] = None,
         init_server_side: bool = False,
         database_redact_keys: bool = False,
         database_prefix: Optional[str] = None,
         database_args: Optional[Dict[str, Any]] = None,
         database_check_revision: bool = True,
     ):
-        database_args = database_args or {}
+        connection_parameters = {
+            "account": account,
+            "user": user,
+            "password": password,
+            "database": database,
+            "schema": schema,
+            "warehouse": warehouse,
+            "role": role,
+        }
+        if snowpark_session is None:
+            kwargs_to_set = []
+            for k, v in connection_parameters.items():
+                if v is None:
+                    kwargs_to_set.append(k)
+            if kwargs_to_set:
+                raise ValueError(
+                    f"If not supplying `snowpark_session` then must set `{kwargs_to_set}`!"
+                )
+            del connection_parameters["schema"]
+            snowpark_session = Session.builder.configs(
+                connection_parameters
+            ).create()
+            self._validate_schema_name(schema)
+            self._create_snowflake_schema_if_not_exists(
+                snowpark_session, database, schema
+            )
+            snowpark_session.use_schema(schema)
+            self._init_with_snowpark_session(
+                snowpark_session,
+                init_server_side,
+                database_redact_keys,
+                database_prefix,
+                database_args,
+                database_check_revision,
+            )
+        else:
+            kwargs_to_not_set = []
+            for k, v in connection_parameters.items():
+                if v is not None:
+                    kwargs_to_not_set.append(k)
+            if kwargs_to_not_set:
+                raise ValueError(
+                    f"Cannot supply both `snowpark_session` and `{kwargs_to_not_set}`!"
+                )
+            self._init_with_snowpark_session(
+                snowpark_session,
+                init_server_side,
+                database_redact_keys,
+                database_prefix,
+                database_args,
+                database_check_revision,
+            )
 
-        self._validate_schema_name(schema)
-        database_url = self._create_snowflake_database_url(
-            account=account,
-            user=user,
-            password=password,
-            database=database,
-            schema=schema,
-            warehouse=warehouse,
-            role=role,
+    def _init_with_snowpark_session(
+        self,
+        snowpark_session: Session,
+        init_server_side: bool,
+        database_redact_keys: bool,
+        database_prefix: Optional[str],
+        database_args: Optional[Dict[str, Any]],
+        database_check_revision: bool,
+    ):
+        database_args = database_args or {}
+        if "engine_params" not in database_args:
+            database_args["engine_params"] = {}
+        if "creator" in database_args["engine_params"]:
+            raise ValueError(
+                "Cannot set `database_args['engine_params']['creator']!"
+            )
+        database_args["engine_params"]["creator"] = (
+            lambda: snowpark_session.connection
+        )
+        if "paramstyle" in database_args["engine_params"]:
+            raise ValueError(
+                "Cannot set `database_args['engine_params']['paramstyle']!"
+            )
+        database_args["engine_params"]["paramstyle"] = "qmark"
+
+        required_settings = {
+            "account": snowpark_session.get_current_account(),
+            "user": snowpark_session.get_current_user(),
+            "database": snowpark_session.get_current_database(),
+            "schema": snowpark_session.get_current_schema(),
+            "warehouse": snowpark_session.get_current_warehouse(),
+            "role": snowpark_session.get_current_role(),
+        }
+        for k, v in required_settings.items():
+            if not v:
+                raise ValueError(f"`{k}` not set in `snowpark_session`!")
+
+        database_url = URL(
+            account=snowpark_session.get_current_account(),
+            user=snowpark_session.get_current_user(),
+            password="password",
+            database=snowpark_session.get_current_database(),
+            schema=snowpark_session.get_current_schema(),
+            warehouse=snowpark_session.get_current_warehouse(),
+            role=snowpark_session.get_current_role(),
         )
         database_args.update({
             k: v
@@ -82,47 +170,8 @@ class SnowflakeConnector(DBConnector):
                 self._db = OpaqueWrapper(obj=self._db, e=e)
 
         if init_server_side:
-            self._initialize_snowflake_server_side_feedback_evaluations(
-                account,
-                user,
-                password,
-                database,
-                schema,
-                warehouse,
-                role,
-                database_args["database_prefix"],
-            )
-
-    def _initialize_snowflake_server_side_feedback_evaluations(
-        self,
-        account: str,
-        user: str,
-        password: str,
-        database: str,
-        schema: str,
-        warehouse: str,
-        role: str,
-        database_prefix: str,
-    ):
-        connection_parameters = {
-            "account": account,
-            "user": user,
-            "password": password,
-            "database": database,
-            "schema": schema,
-            "warehouse": warehouse,
-            "role": role,
-        }
-        with Session.builder.configs(connection_parameters).create() as session:
             ServerSideEvaluationArtifacts(
-                session,
-                account,
-                user,
-                database,
-                schema,
-                warehouse,
-                role,
-                database_prefix,
+                snowpark_session, database_args["database_prefix"]
             ).set_up_all()
 
     @classmethod
@@ -133,28 +182,17 @@ class SnowflakeConnector(DBConnector):
             )
 
     @classmethod
-    def _create_snowflake_database_url(cls, **kwargs) -> str:
-        kwargs = {k: v for k, v in kwargs.items() if v}
-        cls._create_snowflake_schema_if_not_exists(kwargs)
-        return URL(**kwargs)
-
-    @classmethod
     def _create_snowflake_schema_if_not_exists(
-        cls, connection_parameters: Dict[str, str]
+        cls,
+        snowpark_session: Session,
+        database_name: str,
+        schema_name: str,
     ):
-        with Session.builder.configs(connection_parameters).create() as session:
-            root = Root(session)
-            schema_name = connection_parameters.get("schema", None)
-            if schema_name is None:
-                raise ValueError("Schema name must be provided.")
-
-            database_name = connection_parameters.get("database", None)
-            if database_name is None:
-                raise ValueError("Database name must be provided.")
-            schema = Schema(name=schema_name)
-            root.databases[database_name].schemas.create(
-                schema, mode=CreateMode.if_not_exists
-            )
+        root = Root(snowpark_session)
+        schema = Schema(name=schema_name)
+        root.databases[database_name].schemas.create(
+            schema, mode=CreateMode.if_not_exists
+        )
 
     @cached_property
     def db(self) -> DB:

--- a/src/connectors/snowflake/trulens/connectors/snowflake/utils/server_side_evaluation_artifacts.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/utils/server_side_evaluation_artifacts.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 from snowflake.snowpark import Session
 
@@ -29,32 +28,13 @@ class ServerSideEvaluationArtifacts:
     def __init__(
         self,
         session: Session,
-        account: str,
-        user: str,
-        database: str,
-        schema: str,
-        warehouse: str,
-        role: str,
         database_prefix: str,
     ) -> None:
         self._session = session
-        self._account = account
-        self._user = user
-        self._database = database
-        self._schema = schema
-        self._warehouse = warehouse
-        self._role = role
+        self._database = session.get_current_database()
+        self._schema = session.get_current_schema()
+        self._warehouse = session.get_current_warehouse()
         self._database_prefix = database_prefix
-        self._validate_name(database, "database")
-        self._validate_name(schema, "schema")
-        self._validate_name(warehouse, "warehouse")
-
-    @staticmethod
-    def _validate_name(name: str, error_message_variable_name: str) -> None:
-        if not re.match(r"^[A-Za-z0-9_]+$", name):
-            raise ValueError(
-                f"`{error_message_variable_name}` must contain only alphanumeric and underscore characters!"
-            )
 
     def set_up_all(self) -> None:
         self._set_up_stage()

--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -552,7 +552,7 @@ class LLMProvider(Provider):
 
         if criteria or output_space:
             system_prompt = PromptResponseRelevance.generate_system_prompt(
-                criteria, output_space
+                min_score_val, max_score_val, criteria, output_space
             )
         else:
             system_prompt = PromptResponseRelevance.system_prompt

--- a/tests/e2e/test_snowflake_feedback_evaluation.py
+++ b/tests/e2e/test_snowflake_feedback_evaluation.py
@@ -5,7 +5,6 @@ Tests server-side feedback evaluations in Snowflake.
 import time
 from unittest import main
 
-import snowflake.connector
 from trulens.apps.basic import TruBasicApp
 import trulens.connectors.snowflake.utils.server_side_evaluation_artifacts as ssea
 import trulens.connectors.snowflake.utils.server_side_evaluation_stored_procedure as ssesp
@@ -56,11 +55,7 @@ class TestSnowflakeFeedbackEvaluation(SnowflakeTestCase):
         self,
     ) -> SnowflakeFeedback:
         return SnowflakeFeedback(
-            Cortex(
-                snowflake.connector.connect(
-                    **self._snowflake_connection_parameters
-                )
-            ).relevance
+            Cortex(self._snowflake_session.connection).relevance
         ).on_input_output()
 
     def _start_evaluator_as_snowflake(self, session: TruSession):

--- a/tests/util/snowflake_test_case.py
+++ b/tests/util/snowflake_test_case.py
@@ -95,6 +95,7 @@ class SnowflakeTestCase(TestCase):
         connector = SnowflakeConnector(
             schema=self._schema,
             **self._snowflake_connection_parameters,
+            init_server_side=True,
         )
         session = TruSession(connector=connector)
         self.assertIn(self._schema, self.list_schemas())


### PR DESCRIPTION
# Description
Allow using Snowflake Connector for the actual DB Connector instead of the connection parameters.

## Other details good to know for developers


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for using a Snowflake Connector object in `SnowflakeConnector` instead of connection parameters, with updates to tests and documentation.
> 
>   - **Behavior**:
>     - `SnowflakeConnector` in `connector.py` now accepts `snowpark_session` as an optional parameter, allowing the use of an existing Snowflake session instead of connection parameters.
>     - Raises `ValueError` if both `snowpark_session` and connection parameters are provided or if required parameters are missing.
>     - Updates `relevance()` in `llm_provider.py` to include `min_score_val` and `max_score_val` in `generate_system_prompt()` call.
>   - **Internal Methods**:
>     - Adds `_init_with_snowpark_session()` in `connector.py` to initialize with a Snowflake session.
>     - Removes `_create_snowflake_database_url()` and `_initialize_snowflake_server_side_feedback_evaluations()` from `connector.py`.
>   - **Tests**:
>     - Updates `test_snowflake_feedback_evaluation.py` to use `snowpark_session` in tests.
>     - Modifies `get_session()` in `snowflake_test_case.py` to pass `init_server_side=True`.
>   - **Documentation**:
>     - Fixes typo in `index.md` from `trulens-connectors-snowlake` to `trulens-connectors-snowflake`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for f703f4f45cec0e0923f1d977a9de90ee5b9e2b20. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->