### PR TITLE
fix to sql query bug in dashboard

### DIFF
--- a/src/core/trulens/core/database/connector/base.py
+++ b/src/core/trulens/core/database/connector/base.py
@@ -369,9 +369,9 @@ class DBConnector(ABC, text_utils.WithIdentString):
 
             group_by_metadata_key: A key included in record metadata that you want to group results by.
 
-            limit: Limit on the number of records to return.
+            limit: Limit on the number of records to aggregate to produce the leaderboard.
 
-            offset: Record row offset.
+            offset: Record row offset to select which records to use to aggregate the leaderboard.
 
         Returns:
             DataFrame of apps with their feedback results aggregated.

--- a/src/core/trulens/core/database/connector/base.py
+++ b/src/core/trulens/core/database/connector/base.py
@@ -358,13 +358,20 @@ class DBConnector(ABC, text_utils.WithIdentString):
         self,
         app_ids: Optional[List[mod_types_schema.AppID]] = None,
         group_by_metadata_key: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> pandas.DataFrame:
         """Get a leaderboard for the given apps.
 
         Args:
             app_ids: A list of app ids to filter records by. If empty or not given, all
                 apps will be included in leaderboard.
+
             group_by_metadata_key: A key included in record metadata that you want to group results by.
+
+            limit: Limit on the number of records to return.
+
+            offset: Record row offset.
 
         Returns:
             DataFrame of apps with their feedback results aggregated.
@@ -374,7 +381,9 @@ class DBConnector(ABC, text_utils.WithIdentString):
         if app_ids is None:
             app_ids = []
 
-        df, feedback_cols = self.get_records_and_feedback(app_ids)
+        df, feedback_cols = self.get_records_and_feedback(
+            app_ids, limit=limit, offset=offset
+        )
         feedback_cols = sorted(feedback_cols)
 
         df["app_name"] = df["app_json"].apply(

--- a/src/core/trulens/core/database/orm.py
+++ b/src/core/trulens/core/database/orm.py
@@ -401,7 +401,7 @@ def new_orm(base: Type[T], prefix: str = "trulens_") -> Type[ORM[T]]:
     # Without the above, orm class attributes which are defined using backref
     # will not be visible, i.e. orm.AppDefinition.records.
 
-    base.registry.configure()
+    # base.registry.configure()
 
     return NewORM
 

--- a/src/core/trulens/core/database/orm.py
+++ b/src/core/trulens/core/database/orm.py
@@ -266,7 +266,9 @@ def new_orm(base: Type[T], prefix: str = "trulens_") -> Type[ORM[T]]:
             # Notice that trulens_records is in a subquery and named "anon_1"
             # but then it is used in the ORDER BY outside of the subquery
             # referred to by its non-aliased name that was never selected in the
-            # main query.
+            # main query. If one of the joinedloads in get_records_and_feedback
+            # is removed or if the limit is removed, the query does not use a
+            # subquery and no bug happens.
 
             @classmethod
             def parse(

--- a/src/core/trulens/core/database/orm.py
+++ b/src/core/trulens/core/database/orm.py
@@ -181,12 +181,8 @@ def new_orm(base: Type[T], prefix: str = "trulens_") -> Type[ORM[T]]:
                 )
 
         class FeedbackDefinition(base):
-            """ORM class for [FeedbackDefinition][trulens.core.schema.feedback.FeedbackDefinition].
-
-            Warning:
-                We don't use any of the typical ORM features and this class is only
-                used as a schema to interact with database through SQLAlchemy.
-            """
+            """ORM class for
+            [FeedbackDefinition][trulens.core.schema.feedback.FeedbackDefinition]."""
 
             _table_base_name = "feedback_defs"
 
@@ -213,12 +209,7 @@ def new_orm(base: Type[T], prefix: str = "trulens_") -> Type[ORM[T]]:
                 )
 
         class Record(base):
-            """ORM class for [Record][trulens.core.schema.record.Record].
-
-            Warning:
-                We don't use any of the typical ORM features and this class is only
-                used as a schema to interact with database through SQLAlchemy.
-            """
+            """ORM class for [Record][trulens.core.schema.record.Record]."""
 
             _table_base_name = "records"
 
@@ -240,35 +231,14 @@ def new_orm(base: Type[T], prefix: str = "trulens_") -> Type[ORM[T]]:
 
             app = relationship(
                 "AppDefinition",
-                backref=backref("records", cascade="all,delete"),
-                order_by=(ts, record_id),
+                backref=backref(
+                    "records", cascade="all,delete", order_by=(ts, record_id)
+                ),
             )
-            # NOTE(piotrm): order_by: Temporarily disabling all order_by inside
-            # relationships as it causes a bug in what I think is sqlalchemy
-            # when used in conjunction with 2 joinedloads and limit. The problem
-            # is that an SQL query is generated that uses these order_by fields
-            # without having selected from the table first due to the use of a
-            # subquery:
-            """
-            ```sql
-             SELECT anon_1..., trulens_apps_1..., trulens_feedbacks_1...,
-               FROM (
-                SELECT
-                 trulens_records.record_id AS record_id,
-                     ...
-                FROM trulens_records LIMIT :param_1
-             ) AS anon_1
-             LEFT OUTER JOIN trulens_apps AS trulens_apps_1 ...
-             LEFT OUTER JOIN trulens_feedbacks AS trulens_feedbacks_1 ...
-             ORDER BY trulens_records.ts, trulens_records.record_id
-            ```
-            """
-            # Notice that trulens_records is in a subquery and named "anon_1"
-            # but then it is used in the ORDER BY outside of the subquery
-            # referred to by its non-aliased name that was never selected in the
-            # main query. If one of the joinedloads in get_records_and_feedback
-            # is removed or if the limit is removed, the query does not use a
-            # subquery and no bug happens.
+            # NOTE(backref order_by): The order_by must be inside the backref as
+            # it refers to the ordering of AppDefinition.records, not of
+            # Record.app. Doing the opposite can produce SQL errors later on but
+            # no warning will be given at schema creation time.
 
             @classmethod
             def parse(
@@ -295,13 +265,8 @@ def new_orm(base: Type[T], prefix: str = "trulens_") -> Type[ORM[T]]:
                 )
 
         class FeedbackResult(base):
-            """
-            ORM class for [FeedbackResult][trulens.core.schema.feedback.FeedbackResult].
-
-            Warning:
-                We don't use any of the typical ORM features and this class is only
-                used as a schema to interact with database through SQLAlchemy.
-            """
+            """ORM class for
+            [FeedbackResult][trulens.core.schema.feedback.FeedbackResult]."""
 
             _table_base_name = "feedbacks"
 
@@ -329,17 +294,23 @@ def new_orm(base: Type[T], prefix: str = "trulens_") -> Type[ORM[T]]:
 
             record = relationship(
                 "Record",
-                backref=backref("feedback_results", cascade="all,delete"),
-                # order_by=(last_ts, feedback_result_id),
+                backref=backref(
+                    "feedback_results",
+                    cascade="all,delete",
+                    order_by=(last_ts, feedback_result_id),
+                ),
             )
-            # See NOTE(piotrm): order_by.
+            # See NOTE(backref order_by).
 
             feedback_definition = relationship(
                 "FeedbackDefinition",
-                backref=backref("feedback_results", cascade="all,delete"),
-                # order_by=(last_ts, feedback_result_id),
+                backref=backref(
+                    "feedback_results",
+                    cascade="all,delete",
+                    order_by=(last_ts, feedback_result_id),
+                ),
             )
-            # See NOTE(piotrm): order_by.
+            # See NOTE(backref order_by).
 
             @classmethod
             def parse(
@@ -366,13 +337,8 @@ def new_orm(base: Type[T], prefix: str = "trulens_") -> Type[ORM[T]]:
                 )
 
         class GroundTruth(base):
-            """
-            ORM class for [GroundTruth][trulens.core.schema.groundtruth.GroundTruth].
-
-            Warning:
-                We don't use any of the typical ORM features and this class is only
-                used as a schema to interact with database through SQLAlchemy.
-            """
+            """ORM class for
+            [GroundTruth][trulens.core.schema.groundtruth.GroundTruth]."""
 
             _table_base_name = "ground_truth"
 
@@ -384,10 +350,13 @@ def new_orm(base: Type[T], prefix: str = "trulens_") -> Type[ORM[T]]:
 
             dataset = relationship(
                 "Dataset",
-                backref=backref("ground_truths", cascade="all,delete"),
-                # order_by=ground_truth_id,
+                backref=backref(
+                    "ground_truths",
+                    cascade="all,delete",
+                    order_by=ground_truth_id,
+                ),
             )
-            # See NOTE(piotrm): order_by
+            # See NOTE(backref order_by).
 
             @classmethod
             def parse(

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -778,8 +778,6 @@ class SQLAlchemyDB(DB):
 
             stmt = stmt.limit(limit).offset(offset)
 
-            print("stmt=", stmt)
-
             ex = session.execute(stmt).unique()
             # unique needed for joinedload above.
 

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -761,9 +761,6 @@ class SQLAlchemyDB(DB):
             # feedback_results and app definitions get loaded eagerly instead if lazily when
             # accessed later.
 
-            # NOTE(piotrm): Strange issue in sqlalchemy if two joinedloads and a
-            # limit/offset are used. See orm.py "NOTE(piotrm): order_by".
-
             # TODO(piotrm): The subsequent logic in helper methods end up
             # reading all of the records and feedback_results in order to create
             # a DataFrame so there is no reason to not eagerly get all of this

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -778,6 +778,8 @@ class SQLAlchemyDB(DB):
 
             stmt = stmt.limit(limit).offset(offset)
 
+            print("stmt=", stmt)
+
             ex = session.execute(stmt).unique()
             # unique needed for joinedload above.
 

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -761,6 +761,9 @@ class SQLAlchemyDB(DB):
             # feedback_results and app definitions get loaded eagerly instead if lazily when
             # accessed later.
 
+            # NOTE(piotrm): Strange issue in sqlalchemy if two joinedloads and a
+            # limit/offset are used. See orm.py "NOTE(piotrm): order_by".
+
             # TODO(piotrm): The subsequent logic in helper methods end up
             # reading all of the records and feedback_results in order to create
             # a DataFrame so there is no reason to not eagerly get all of this

--- a/src/core/trulens/core/session.py
+++ b/src/core/trulens/core/session.py
@@ -729,20 +729,30 @@ class TruSession(
         self,
         app_ids: Optional[List[mod_types_schema.AppID]] = None,
         group_by_metadata_key: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> pandas.DataFrame:
         """Get a leaderboard for the given apps.
 
         Args:
             app_ids: A list of app ids to filter records by. If empty or not given, all
                 apps will be included in leaderboard.
+
             group_by_metadata_key: A key included in record metadata that you want to group results by.
+
+            limit: Limit on the number of records to return.
+
+            offset: Record row offset.
 
         Returns:
             Dataframe of apps with their feedback results aggregated.
             If group_by_metadata_key is provided, the dataframe will be grouped by the specified key.
         """
         return self.connector.get_leaderboard(
-            app_ids=app_ids, group_by_metadata_key=group_by_metadata_key
+            app_ids=app_ids,
+            group_by_metadata_key=group_by_metadata_key,
+            limit=limit,
+            offset=offset,
         )
 
     def add_ground_truth_to_dataset(

--- a/src/core/trulens/core/session.py
+++ b/src/core/trulens/core/session.py
@@ -740,9 +740,9 @@ class TruSession(
 
             group_by_metadata_key: A key included in record metadata that you want to group results by.
 
-            limit: Limit on the number of records to return.
+            limit: Limit on the number of records to aggregate to produce the leaderboard.
 
-            offset: Record row offset.
+            offset: Record row offset to select which records to use to aggregate the leaderboard.
 
         Returns:
             Dataframe of apps with their feedback results aggregated.


### PR DESCRIPTION
# Description

Changed what `order_by` applies to in the orm relationships to prevent an incorrect SQL bug.

Added limit and offset to `get_leaderboard`. The bug was occurring only in the dashboard because it was using `get_records_and_feedback` with a limit whereas the notebooks did not use a limit inside their `get_leaderboard`.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix SQL query bug in dashboard by disabling `order_by` in ORM relationships and adding `limit` and `offset` to `get_leaderboard`.
> 
>   - **Behavior**:
>     - Disable `order_by` in ORM relationships in `orm.py` to prevent SQLAlchemy query generation issues with `joinedload` and `limit`.
>     - Add `limit` and `offset` parameters to `get_leaderboard` in `base.py` and `session.py` to ensure consistent query behavior.
>   - **ORM Changes**:
>     - Modify `Record`, `FeedbackResult`, and `GroundTruth` classes in `orm.py` to remove `order_by` in relationships.
>   - **Misc**:
>     - Add `print` statement for debugging SQL statements in `sqlalchemy.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 28f555c1bdea115a89e485d5eb638f04b2a8bf4b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->