### PR TITLE
use 0-3 output scaling for relevance by default

### DIFF
--- a/src/feedback/trulens/feedback/v2/feedback.py
+++ b/src/feedback/trulens/feedback/v2/feedback.py
@@ -445,8 +445,8 @@ class ContextRelevance(Relevance, WithPrompt, CriteriaOutputSpaceMixin):
 
 
 class PromptResponseRelevance(Relevance, WithPrompt, CriteriaOutputSpaceMixin):
-    output_space_prompt: ClassVar[str] = LIKERT_0_10_PROMPT
-    output_space: ClassVar[str] = OutputSpace.LIKERT_0_10.name
+    output_space_prompt: ClassVar[str] = LIKERT_0_3_PROMPT
+    output_space: ClassVar[str] = OutputSpace.LIKERT_0_3.name
     criteria_template: ClassVar[str] = """
         - RESPONSE must be relevant to the entire PROMPT to get a maximum score of {max_score}.
         - RELEVANCE score should increase as the RESPONSE provides RELEVANT context to more parts of the PROMPT.
@@ -481,8 +481,8 @@ class PromptResponseRelevance(Relevance, WithPrompt, CriteriaOutputSpaceMixin):
     )
 
     criteria: ClassVar[str] = criteria_template.format(
-        min_score=OutputSpace.LIKERT_0_10.value[0],
-        max_score=OutputSpace.LIKERT_0_10.value[1],
+        min_score=OutputSpace.LIKERT_0_3.value[0],
+        max_score=OutputSpace.LIKERT_0_3.value[1],
     )
 
     system_prompt: ClassVar[str] = cleandoc(


### PR DESCRIPTION
# Description

Fix context relevance output scaling

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change default output scaling from 0-10 to 0-3 in `PromptResponseRelevance` class.
> 
>   - **Behavior**:
>     - Change default output scaling from 0-10 to 0-3 in `PromptResponseRelevance` class.
>     - Update `output_space_prompt` to `LIKERT_0_3_PROMPT`.
>     - Update `output_space` to `OutputSpace.LIKERT_0_3.name`.
>     - Update `criteria` to use `OutputSpace.LIKERT_0_3` values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for b2e2d1719fb738a1f3c7ec6018068249f9a44007. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->