### PR TITLE
Fix Selector AttributeError

### DIFF
--- a/src/core/trulens/core/schema/select.py
+++ b/src/core/trulens/core/schema/select.py
@@ -108,9 +108,7 @@ class Select:
         if len(lens.path) == 0:
             return lens
 
-        if Select.Record.path.is_prefix_of(
-            lens
-        ) or Select.App.path.is_prefix_of(lens):
+        if Select.Record.is_prefix_of(lens) or Select.App.is_prefix_of(lens):
             return Select.Lens(path=lens.path[len(Select.Record) :])
 
         return lens

--- a/src/feedback/trulens/feedback/v2/feedback.py
+++ b/src/feedback/trulens/feedback/v2/feedback.py
@@ -445,8 +445,8 @@ class ContextRelevance(Relevance, WithPrompt, CriteriaOutputSpaceMixin):
 
 
 class PromptResponseRelevance(Relevance, WithPrompt, CriteriaOutputSpaceMixin):
-    output_space_prompt: ClassVar[str] = LIKERT_0_10_PROMPT
-    output_space: ClassVar[str] = OutputSpace.LIKERT_0_10.name
+    output_space_prompt: ClassVar[str] = LIKERT_0_3_PROMPT
+    output_space: ClassVar[str] = OutputSpace.LIKERT_0_3.name
     criteria_template: ClassVar[str] = """
         - RESPONSE must be relevant to the entire PROMPT to get a maximum score of {max_score}.
         - RELEVANCE score should increase as the RESPONSE provides RELEVANT context to more parts of the PROMPT.
@@ -481,8 +481,8 @@ class PromptResponseRelevance(Relevance, WithPrompt, CriteriaOutputSpaceMixin):
     )
 
     criteria: ClassVar[str] = criteria_template.format(
-        min_score=OutputSpace.LIKERT_0_10.value[0],
-        max_score=OutputSpace.LIKERT_0_10.value[1],
+        min_score=OutputSpace.LIKERT_0_3.value[0],
+        max_score=OutputSpace.LIKERT_0_3.value[1],
     )
 
     system_prompt: ClassVar[str] = cleandoc(


### PR DESCRIPTION
# Description

`AttributeError: 'tuple' object has no attribute 'is_prefix_of`

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `AttributeError` in `dequalify` and update scoring prompts in `PromptResponseRelevance`.
> 
>   - **Bug Fix**:
>     - Fix `AttributeError` in `dequalify` function in `select.py` by removing incorrect tuple access.
>   - **Scoring Update**:
>     - Change `output_space_prompt` and `output_space` from `LIKERT_0_10` to `LIKERT_0_3` in `PromptResponseRelevance` class in `feedback.py`.
>     - Update `criteria_template` and `criteria` to reflect new scoring range in `PromptResponseRelevance`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for b09dafcf2ff2d92f059925f7d3f993dbd9dda9bc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->