### PR TITLE
Fix Selector AttributeError

### DIFF
--- a/src/core/trulens/core/schema/select.py
+++ b/src/core/trulens/core/schema/select.py
@@ -108,9 +108,7 @@ class Select:
         if len(lens.path) == 0:
             return lens
 
-        if Select.Record.path.is_prefix_of(
-            lens
-        ) or Select.App.path.is_prefix_of(lens):
+        if Select.Record.is_prefix_of(lens) or Select.App.is_prefix_of(lens):
             return Select.Lens(path=lens.path[len(Select.Record) :])
 
         return lens


### PR DESCRIPTION
# Description

`AttributeError: 'tuple' object has no attribute 'is_prefix_of`

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `AttributeError` in `dequalify` function by correcting method calls on `Select.Record` and `Select.App`.
> 
>   - **Bug Fix**:
>     - Fix `AttributeError` in `dequalify` function in `select.py` by calling `is_prefix_of` on `Select.Record` and `Select.App` instead of their `path` attributes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 33dd74569a64c09e2fcef8ad9062cf0e2194c883. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->