### PR TITLE
Simplify system prompt generation conditions with output space and criteria

### DIFF
--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -351,15 +351,12 @@ class LLMProvider(Provider):
             min_score_val, max_score_val
         )
 
-        if criteria or output_space:
-            system_prompt = ContextRelevance.generate_system_prompt(
-                min_score=min_score_val,
-                max_score=max_score_val,
-                criteria=criteria,
-                output_space=output_space,
-            )
-        else:
-            system_prompt = ContextRelevance.system_prompt
+        system_prompt = ContextRelevance.generate_system_prompt(
+            min_score=min_score_val,
+            max_score=max_score_val,
+            criteria=criteria,
+            output_space=output_space,
+        )
 
         return self.generate_score(
             system_prompt=system_prompt,
@@ -422,15 +419,12 @@ class LLMProvider(Provider):
             min_score_val, max_score_val
         )
 
-        if criteria or output_space:
-            system_prompt = ContextRelevance.generate_system_prompt(
-                min_score=min_score_val,
-                max_score=max_score_val,
-                criteria=criteria,
-                output_space=output_space,
-            )
-        else:
-            system_prompt = ContextRelevance.system_prompt
+        system_prompt = ContextRelevance.generate_system_prompt(
+            min_score=min_score_val,
+            max_score=max_score_val,
+            criteria=criteria,
+            output_space=output_space,
+        )
 
         return self.generate_score_and_reasons(
             system_prompt=system_prompt,
@@ -482,15 +476,12 @@ class LLMProvider(Provider):
             min_score_val, max_score_val
         )
 
-        if criteria or output_space:
-            system_prompt = ContextRelevance.generate_system_prompt(
-                min_score=min_score_val,
-                max_score=max_score_val,
-                criteria=criteria,
-                output_space=output_space,
-            )
-        else:
-            system_prompt = ContextRelevance.system_prompt
+        system_prompt = ContextRelevance.generate_system_prompt(
+            min_score=min_score_val,
+            max_score=max_score_val,
+            criteria=criteria,
+            output_space=output_space,
+        )
 
         try:
             return self.generate_confidence_score(
@@ -550,12 +541,9 @@ class LLMProvider(Provider):
             min_score_val, max_score_val
         )
 
-        if criteria or output_space:
-            system_prompt = PromptResponseRelevance.generate_system_prompt(
-                min_score_val, max_score_val, criteria, output_space
-            )
-        else:
-            system_prompt = PromptResponseRelevance.system_prompt
+        system_prompt = PromptResponseRelevance.generate_system_prompt(
+            min_score_val, max_score_val, criteria, output_space
+        )
 
         return self.generate_score(
             system_prompt=system_prompt,
@@ -605,15 +593,13 @@ class LLMProvider(Provider):
         output_space = self._determine_output_space(
             min_score_val, max_score_val
         )
-        if criteria or output_space:
-            system_prompt = PromptResponseRelevance.generate_system_prompt(
-                min_score=min_score_val,
-                max_score=max_score_val,
-                criteria=criteria,
-                output_space=output_space,
-            )
-        else:
-            system_prompt = PromptResponseRelevance.system_prompt
+
+        system_prompt = PromptResponseRelevance.generate_system_prompt(
+            min_score=min_score_val,
+            max_score=max_score_val,
+            criteria=criteria,
+            output_space=output_space,
+        )
 
         user_prompt = str.format(
             prompts.ANSWER_RELEVANCE_USER, prompt=prompt, response=response
@@ -1601,15 +1587,12 @@ class LLMProvider(Provider):
             min_score_val, max_score_val
         )
 
-        if criteria or output_space:
-            system_prompt = Groundedness.generate_system_prompt(
-                min_score=min_score_val,
-                max_score=max_score_val,
-                criteria=criteria,
-                output_space=output_space,
-            )
-        else:
-            system_prompt = Groundedness.system_prompt
+        system_prompt = Groundedness.generate_system_prompt(
+            min_score=min_score_val,
+            max_score=max_score_val,
+            criteria=criteria,
+            output_space=output_space,
+        )
 
         def evaluate_hypothesis(index, hypothesis):
             user_prompt = prompts.LLM_GROUNDEDNESS_USER.format(
@@ -1799,15 +1782,12 @@ class LLMProvider(Provider):
             min_score_val, max_score_val
         )
 
-        if criteria or output_space:
-            system_prompt = Groundedness.generate_system_prompt(
-                min_score=min_score_val,
-                max_score=max_score_val,
-                criteria=criteria,
-                output_space=output_space,
-            )
-        else:
-            system_prompt = Groundedness.system_prompt
+        system_prompt = Groundedness.generate_system_prompt(
+            min_score=min_score_val,
+            max_score=max_score_val,
+            criteria=criteria,
+            output_space=output_space,
+        )
 
         def evaluate_hypothesis(index, hypothesis):
             abstention_score = evaluate_abstention(hypothesis)


### PR DESCRIPTION
# Description

Removing redundant conditional checks, as all logics are already encapsulated in the updated `generate_system_prompt` function

```
def generate_system_prompt(
        cls,
        min_score: int,
        max_score: int,
        criteria: Optional[str] = None,
        output_space: Optional[str] = None,
    ) -> str:
        if criteria is None and output_space is None:
            return cls.system_prompt

        if criteria is None:
            criteria = cls.criteria_template.format(
                min_score=min_score, max_score=max_score
            )

        if output_space is None:
            output_space_prompt = cls.output_space_prompt
        else:
            validated = cls.validate_criteria_and_output_space(
                criteria, output_space
            )
            criteria = validated.criteria
            output_space_prompt = validated.get_output_scale_prompt()

        return cleandoc(
            cls.system_prompt_template.format(
                output_space_prompt=output_space_prompt,
                criteria=criteria,
            )
        )
```

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies system prompt generation in `llm_provider.py` by removing conditional checks and ensuring consistent use of `generate_system_prompt`.
> 
>   - **Behavior**:
>     - Simplifies system prompt generation by removing conditional checks for `criteria` or `output_space` in `context_relevance`, `context_relevance_with_cot_reasons`, `context_relevance_verb_confidence`, `relevance`, `relevance_with_cot_reasons`, `groundedness_measure_with_cot_reasons`, and `evaluate_answerability`.
>     - Ensures `generate_system_prompt` is always called with `min_score`, `max_score`, `criteria`, and `output_space`.
>   - **Functions**:
>     - Updates `context_relevance`, `context_relevance_with_cot_reasons`, `context_relevance_verb_confidence`, `relevance`, `relevance_with_cot_reasons`, `groundedness_measure_with_cot_reasons`, and `evaluate_answerability` to use the simplified prompt generation logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for a82af2a41ccf31e7c2993ec922b45376870ee8c0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->