### PR TITLE
bumping conda package build to 1.1.0

### DIFF
--- a/src/connectors/snowflake/meta.yaml
+++ b/src/connectors/snowflake/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trulens-connectors-snowflake" %}
-{% set version = "1.0.6" %}
+{% set version = "1.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 965d6827aad110ee352d87cd9191011a56ceae17eb3bfe57c7f1e7a450971013
+  sha256: a7aa5eb9a1ffa98e2301952473a958f4bd143d2723339bc926f0a675e6d48ade
 
 build:
   noarch: python

--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trulens-core" %}
-{% set version = "1.0.6" %}
+{% set version = "1.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 25b912b067c578912c75f16da7c5654e6ba08876c233c4682b0ed91e9f593166
+  sha256: 739ca935c4945f8859e1d16ee8ac518cca820bbe26e5273b506b4705d618942f
 
 build:
   noarch: python

--- a/src/feedback/meta.yaml
+++ b/src/feedback/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trulens-feedback" %}
-{% set version = "1.0.6" %}
+{% set version = "1.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: dd3aa09e87ace00825903bedc4e075d562471461e525ac82ed9df7da7a730cda
+  sha256: cbc4a949c5effaedbb556983d70897e45f888305eb665cd56e88d84bdf25d2f6
 
 build:
   noarch: python

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trulens-providers-cortex" %}
-{% set version = "1.0.6" %}
+{% set version = "1.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: fe5b9bb8e1042183baadf366e8410356acd331901112a272c2961f7af0352ace
+  sha256: 3d586521351f7a710850465e9970372bb5d3fd7c490f35576a9fcbd72993ae1d
 
 build:
   noarch: python


### PR DESCRIPTION
# Description
Conda packaga build 1.1.0 version


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump conda package versions to 1.1.0 and update source hashes in `meta.yaml` files.
> 
>   - **Version Update**:
>     - Bump version to `1.1.0` in `meta.yaml` for `trulens-connectors-snowflake`, `trulens-core`, `trulens-feedback`, and `trulens-providers-cortex`.
>   - **Source Hash Update**:
>     - Update `sha256` hash in `meta.yaml` for the new version in the same files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 601d3994e59ae6313b31c7253ff4a0404611302e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->