### PR TITLE
import rename listings

### DIFF
--- a/docs/contributing/standards.md
+++ b/docs/contributing/standards.md
@@ -61,7 +61,7 @@ apply when referring to things like package names, classes, methods.
     This is especially important for module names which might cause name
     collisions with other things such as variables named `record`.
 
-- Keep module renames consistent using the following patterns:
+- Keep module renames consistent using the following patterns (see `src/core/trulens/_mods.py` for the full list):
 
     ```python
     # schema

--- a/src/core/trulens/_mods.py
+++ b/src/core/trulens/_mods.py
@@ -1,0 +1,132 @@
+# ruff: noqa: E402, F401
+"""Import renames for TruLens modules as per code standards.
+
+This is intentionally a python file to be analyzed by static tools. Do not
+import this module otherwise.
+
+"""
+
+from trulens.apps import basic as basic_app
+from trulens.apps import custom as custom_app
+from trulens.apps import virtual as virtual_app
+from trulens.apps.langchain import guardrails as langchain_guardrails
+from trulens.apps.langchain import langchain as langchain_app
+from trulens.apps.langchain import tru_chain as mod_tru_chain  # not a good name
+from trulens.apps.llamaindex import guardrails as llama_guardrails
+from trulens.apps.llamaindex import llama as llama_app
+from trulens.apps.llamaindex import (
+    tru_llama as mod_tru_llama,  # not a good name
+)
+from trulens.apps.nemo import tru_rails as nemo_app  # not a good name
+from trulens.connectors.snowflake import connector as snowflake_connector
+from trulens.core import app as core_app
+from trulens.core import instruments as core_instruments
+from trulens.core import session as core_session
+from trulens.core._utils import debug as debug_utils
+from trulens.core._utils import optional as optional_utils
+from trulens.core._utils import pycompat as pycompat_utils
+from trulens.core.database import base as core_db
+from trulens.core.database import exceptions as db_exceptions
+from trulens.core.database import migrations as db_migrations
+from trulens.core.database import orm as db_orm
+from trulens.core.database import sqlalchemy as db_sqlalchemy
+from trulens.core.database import utils as database_utils
+from trulens.core.database.connector import base as core_connector
+from trulens.core.database.connector import default as default_connector
+from trulens.core.database.legacy import migration as db_legacy_migrations
+from trulens.core.database.migrations import data as db_data_migrations
+from trulens.core.feedback import endpoint as core_endpoint
+from trulens.core.feedback import feedback as core_feedback
+from trulens.core.feedback import provider as core_provider
+from trulens.core.guardrails import base as core_guardrails
+from trulens.core.schema import app as app_schema
+from trulens.core.schema import base as base_schema
+from trulens.core.schema import dataset as dataset_schema
+from trulens.core.schema import feedback as feedback_schema
+from trulens.core.schema import groundtruth as groundtruth_schema
+from trulens.core.schema import record as record_schema
+from trulens.core.schema import select as select_schema
+from trulens.core.schema import types as types_schema
+from trulens.core.utils import asynchro as asynchro_utils
+from trulens.core.utils import constants as constant_utils
+from trulens.core.utils import containers as container_utils
+from trulens.core.utils import deprecation as deprecation_utils
+from trulens.core.utils import imports as import_utils
+from trulens.core.utils import json as json_utils
+from trulens.core.utils import keys as keys_utils
+from trulens.core.utils import pace as pace_utils
+from trulens.core.utils import pyschema as pyschema_utils
+from trulens.core.utils import python as python_utils
+from trulens.core.utils import serial as serial_utils
+from trulens.core.utils import text as text_utils
+from trulens.core.utils import threading as threading_utils
+from trulens.core.utils import trulens as trulens_utils
+from trulens.dashboard import (
+    Leaderboard as Leaderboard_page,  # not a good location
+)
+from trulens.dashboard import appui as dashboard_appui
+from trulens.dashboard import constants as dashboard_constants
+from trulens.dashboard import display as dashboard_display
+from trulens.dashboard import run as dashboard_run
+from trulens.dashboard import streamlit as dashboard_streamlit
+from trulens.dashboard.pages import Compare as Compare_page
+from trulens.dashboard.pages import Records as Records_page
+from trulens.dashboard.utils import dashboard_utils
+from trulens.dashboard.utils import metadata_utils
+from trulens.dashboard.utils import notebook_utils
+from trulens.dashboard.utils import records_utils
+from trulens.dashboard.ux import components as dashboard_components
+from trulens.dashboard.ux import styles as dashboard_styles
+from trulens.experimental.otel_tracing.core import otel as core_otel
+from trulens.experimental.otel_tracing.core import trace as core_trace
+from trulens.experimental.otel_tracing.core._utils import wrap as wrap_utils
+from trulens.feedback import embeddings as feedback_embeddings
+from trulens.feedback import feedback as mod_feedback
+from trulens.feedback import generated as feedback_generated
+from trulens.feedback import groundtruth as feedback_groundtruth
+from trulens.feedback import llm_provider
+from trulens.feedback import prompts as feedback_prompts
+from trulens.feedback.dummy import endpoint as dummy_endpoint
+from trulens.feedback.dummy import provider as dummy_provider
+from trulens.feedback.v2 import feedback as mod_feedback_v2  # not a good name
+from trulens.feedback.v2.provider import (
+    base as core_v2_provider,  # not a good name
+)
+from trulens.providers.bedrock import endpoint as bedrock_endpoint
+from trulens.providers.bedrock import provider as bedrock_provider
+from trulens.providers.cortext import endpoint as cortex_endpoint
+from trulens.providers.cortext import provider as cortex_provider
+from trulens.providers.huggingface import endpoint as huggingface_endpoint
+from trulens.providers.huggingface import provider as huggingface_provider
+from trulens.providers.langchain import endpoint as langchain_endpoint
+from trulens.providers.langchain import provider as langchain_provider
+from trulens.providers.litellm import endpoint as litellm_endpoint
+from trulens.providers.litellm import provider as litellm_provider
+from trulens.providers.openai import endpoint as openai_endpoint
+from trulens.providers.openai import provider as openai_provider
+
+# modules without renames that can be imported:
+"""
+./benchmark/trulens/benchmark/benchmark_frameworks/dataset/beir_loader.py
+./benchmark/trulens/benchmark/benchmark_frameworks/experiments/dataset_preprocessing.py
+./benchmark/trulens/benchmark/benchmark_frameworks/tru_benchmark_experiment.py
+./benchmark/trulens/benchmark/generate/generate_test_set.py
+./benchmark/trulens/benchmark/test_cases.py
+./connectors/snowflake/trulens/connectors/snowflake/utils/server_side_evaluation_stored_procedure.py
+./connectors/snowflake/trulens/connectors/snowflake/utils/server_side_evaluation_artifacts.py
+"""
+
+# modules that should not be imported at all
+"""
+./trulens/_mods.py
+./core/trulens/core/database/migrations/env.py
+./core/trulens/core/database/migrations/versions/2_add_run_location_column_to_feedback_defs_table.py
+./core/trulens/core/database/migrations/versions/9_update_app_json.py
+./core/trulens/core/database/migrations/versions/5_add_app_name_and_version_fields.py
+./core/trulens/core/database/migrations/versions/3_add_groundtruth_and_dataset_tables.py
+./core/trulens/core/database/migrations/versions/8_update_records_app_id.py
+./core/trulens/core/database/migrations/versions/4_set_ff_id_not_null.py
+./core/trulens/core/database/migrations/versions/7_app_name_version_not_null.py
+./core/trulens/core/database/migrations/versions/6_populate_app_name_and_version_data.py
+./core/trulens/core/database/migrations/versions/1_first_revision.py
+"""

--- a/src/dashboard/trulens/dashboard/Leaderboard.py
+++ b/src/dashboard/trulens/dashboard/Leaderboard.py
@@ -12,7 +12,7 @@ from trulens.apps import virtual as virtual_app
 from trulens.core.schema import feedback as feedback_schema
 from trulens.core.utils import text as text_utils
 from trulens.dashboard import constants as dashboard_constants
-from trulens.dashboard.pages import Compare as compare_page
+from trulens.dashboard.pages import Compare as Compare_page
 from trulens.dashboard.utils import dashboard_utils
 from trulens.dashboard.utils import metadata_utils
 from trulens.dashboard.ux import components as dashboard_components
@@ -524,18 +524,18 @@ def _render_grid_tab(
         )
         st.switch_page("pages/Records.py")
     # Compare App Versions
-    if len(selected_app_ids) < compare_page.MIN_COMPARATORS:
+    if len(selected_app_ids) < Compare_page.MIN_COMPARATORS:
         _compare_button_label = (
-            f"Min {compare_page.MIN_COMPARATORS} App Versions"
+            f"Min {Compare_page.MIN_COMPARATORS} App Versions"
         )
         _compare_button_disabled = True
-        help_msg = f"Select at least {compare_page.MIN_COMPARATORS} app versions to compare."
-    elif len(selected_app_ids) > compare_page.MAX_COMPARATORS:
+        help_msg = f"Select at least {Compare_page.MIN_COMPARATORS} app versions to compare."
+    elif len(selected_app_ids) > Compare_page.MAX_COMPARATORS:
         _compare_button_label = (
-            f"Max {compare_page.MAX_COMPARATORS} App Versions"
+            f"Max {Compare_page.MAX_COMPARATORS} App Versions"
         )
         _compare_button_disabled = True
-        help_msg = f"Deselect to at most {compare_page.MAX_COMPARATORS} app versions to compare."
+        help_msg = f"Deselect to at most {Compare_page.MAX_COMPARATORS} app versions to compare."
     else:
         _compare_button_label = "Compare"
         _compare_button_disabled = False

--- a/src/trulens_eval/trulens_eval/Leaderboard.py
+++ b/src/trulens_eval/trulens_eval/Leaderboard.py
@@ -1,7 +1,8 @@
 # ruff: noqa: E402, F401
 """
 !!! warning
-    This module is deprecated and will be removed. Use `trulens.dashboard.pages.Leaderboard` instead.
+    This module is deprecated and will be removed. Use
+    `trulens.dashboard.Leaderboard` instead.
 """
 
 from trulens.core.utils import deprecation as deprecation_utils

--- a/tests/_mods.py
+++ b/tests/_mods.py
@@ -1,0 +1,40 @@
+# ruff: noqa: E402, F401
+
+"""Import renames for TruLens test modules as per code standards.
+
+This is intentionally a python file to be analyzed by static tools. Do not
+import this module otherwise.
+"""
+
+from tests import test as mod_test  # not a good name
+from tests import utils as test_utils
+from tests.unit import feedbacks as test_feedbacks
+
+# Modules that should not be imported at all:
+"""
+./docs_notebooks/test_notebooks.py
+./unit/test_feedback.py
+./unit/test_tru_basic_app.py
+./unit/core/utils/test_json_utils.py
+./unit/core/utils/test_text_utils.py
+./unit/test_lens.py
+./unit/test_feedback_score_generation.py
+./unit/static/test_deprecation.py
+./unit/static/test_static.py
+./unit/static/test_api.py
+./unit/test_app.py
+./unit/test_tru_custom.py
+./util/snowflake_test_case.py
+./integration/test_database.py
+./legacy/test_trulens_eval_notebooks.py
+./e2e/test_serial.py
+./e2e/test_providers.py
+./e2e/test_tru_chain.py
+./e2e/test_endpoints.py
+./e2e/test_dummy.py
+./e2e/test_tru_llama.py
+./e2e/test_embedding_feedback.py
+./e2e/test_tru_session.py
+./e2e/test_snowflake_connection.py
+./e2e/test_snowflake_feedback_evaluation.py
+"""

--- a/tests/e2e/test_tru_chain.py
+++ b/tests/e2e/test_tru_chain.py
@@ -56,7 +56,7 @@ class TestTruChain(mod_test.TruTestCase):
 
         # Note that without WITH_APP mode, there might be a delay between return
         # of a with_record and the record appearing in the db.
-        tc = mod_tru_chain.TruBasicApp(
+        tc = mod_tru_chain.TruChain(
             chain,
             app_name=app_name,
             feedback_mode=feedback_schema.FeedbackMode.WITH_APP,

--- a/tests/unit/static/test_static.py
+++ b/tests/unit/static/test_static.py
@@ -69,6 +69,7 @@ all_trulens_mods = list(get_submodule_names(trulens))
 # Things which should not be imported at all.
 not_mods = [
     "trulens.core.database.migrations.env",  # can only be executed by alembic
+    "trulens._mods",  # for static tools only
 ]
 
 if sys.version_info >= (3, 12):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -110,7 +110,11 @@ def get_submodule_names(mod: ModuleType) -> Iterable[str]:
     Args:
         mod: The base module over which to look.
     """
+
     if isinstance(mod, str):
+        if mod == "_mods":
+            # Not meant to be imported.
+            return
         try:
             mod = importlib.import_module(mod)
         except Exception:
@@ -121,12 +125,17 @@ def get_submodule_names(mod: ModuleType) -> Iterable[str]:
     yield mod.__name__
 
     for modname in get_module_names_of_path(path, prefix=mod.__name__ + "."):
-        if modname.endswith("._bundle") or modname.startswith(
-            "trulens.dashboard.pages"
+        if (
+            modname.endswith("._bundle")
+            or modname.startswith("trulens.dashboard.pages")
+            or modname.endswith("_mods")
         ):
             # Skip _bundle this as it is not a real module/package.
 
             # Skip trulens.dashboard.pages* because importing them executes a lot of stuff.
+
+            # Skip _mods because it is a special module for static tools is not
+            # meant to be imported.
 
             # TODO: figure out how to prevent it from being installed to begin with.
             continue


### PR DESCRIPTION
# Description

Adds `src/core/_mods.py` and `tests/_mods.py` with listing of all importable modules and the names with which they should be imported. These are for static analysis tools to read so they can offer refactoring and code completion based on import standards.

Fixed a few places where import style was not being followed.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces import renaming standards, updates imports for consistency, marks a module as deprecated, and updates documentation.
> 
>   - **New Files**:
>     - Adds `src/core/_mods.py` and `tests/_mods.py` for listing importable modules and their standard import names.
>   - **Import Renames**:
>     - Renames `Compare` to `Compare_page` in `Leaderboard.py`.
>     - Renames `tru_chain` to `mod_tru_chain` in `test_tru_chain.py`.
>     - Renames `basic` to `basic_app` in `test_feedback.py`.
>   - **Deprecation**:
>     - Marks `trulens_eval/Leaderboard.py` as deprecated, suggesting `trulens.dashboard.Leaderboard` instead.
>   - **Documentation**:
>     - Updates `standards.md` to reference the new `_mods.py` file for module renaming patterns.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for be1b044cb8d9d3b31e9dff10d635d12ff716e186. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->