### PR TITLE
Use ggshield for local secret scanning

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -86,6 +86,27 @@ pre-commit install
 
 For more information on pre-commit, see [pre-commit.com](https://pre-commit.com/).
 
+## Install ggshield
+
+TruLens developers use ggshield to scan for secrets locally in addition to gitguardian in CLI. Install and authenticate to ggshield with the following commands:
+
+```bash
+brew install gitguardian/tap/ggshield
+ggshield auth login
+```
+
+Then, ggshield can be run with the following command from trulens root directory to scan the full repository:
+
+```bash
+ggshield secret scan repo ./
+```
+
+It can also be run with smaller scope, such as only for docs with the following as included in `make docs-upload`
+
+```bash
+ggshield secret scan repo ./docs/
+```
+
 ## Helpful commands
 
 ### Formatting

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ docs-serve-dirty: env-docs
 	poetry run mkdocs serve --dirty -a 127.0.0.1:8000
 
 docs-upload: env-docs $(shell find docs -type f) mkdocs.yml
-	poetry run ggshield secret scan repo ./docs || exit 1
+	poetry run ggshield secret scan repo ./docs
 	poetry run mkdocs gh-deploy
 
 # Check that links in the documentation are valid. Requires the lychee tool.

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ docs-serve-dirty: env-docs
 	poetry run mkdocs serve --dirty -a 127.0.0.1:8000
 
 docs-upload: env-docs $(shell find docs -type f) mkdocs.yml
+	poetry run ggshield secret scan repo ./docs || exit 1
 	poetry run mkdocs gh-deploy
 
 # Check that links in the documentation are valid. Requires the lychee tool.


### PR DESCRIPTION
# Description

Use ggshield for local secret scanning to prevent secrets from being published in docs.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Integrate ggshield for local secret scanning to prevent secret leaks in documentation.
> 
>   - **New Feature**:
>     - Integrate `ggshield` for local secret scanning to prevent secret leaks in documentation.
>   - **Documentation**:
>     - Update `DEVELOPMENT.md` with installation and usage instructions for `ggshield`.
>   - **Makefile**:
>     - Add `ggshield secret scan repo ./docs` to `docs-upload` target to scan for secrets before deploying docs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 760539643c53216d098b0baa387bc83598b82f8d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->