### PR TITLE
Always ensure endpoint context variable is cleaned up.

### DIFF
--- a/src/core/trulens/core/feedback/endpoint.py
+++ b/src/core/trulens/core/feedback/endpoint.py
@@ -603,29 +603,30 @@ class Endpoint(
         # following call to retrieve.
         endpoints_token = Endpoint._context_endpoints.set(endpoints)  # noqa: F841
 
-        # context_vars = contextvars.copy_context()
-        context_vars = {
-            Endpoint._context_endpoints: Endpoint._context_endpoints.get()
-        }
+        try:
+            # context_vars = contextvars.copy_context()
+            context_vars = {
+                Endpoint._context_endpoints: Endpoint._context_endpoints.get()
+            }
 
-        # Call the function.
-        result: T = __func(*args, **kwargs)
+            # Call the function.
+            result: T = __func(*args, **kwargs)
 
-        def rewrap(result):
-            if python_utils.is_lazy(result):
-                return python_utils.wrap_lazy(
-                    result,
-                    wrap=rewrap,
-                    context_vars=context_vars,
-                )
+            def rewrap(result):
+                if python_utils.is_lazy(result):
+                    return python_utils.wrap_lazy(
+                        result,
+                        wrap=rewrap,
+                        context_vars=context_vars,
+                    )
 
-            return result
+                return result
 
-        result = rewrap(result)
-
-        # Pop the endpoints from the contextvars.
-        # Optionally disable to debug context issues. See App._set_context_vars.
-        Endpoint._context_endpoints.reset(endpoints_token)
+            result = rewrap(result)
+        finally:
+            # Pop the endpoints from the contextvars.
+            # Optionally disable to debug context issues. See App._set_context_vars.
+            Endpoint._context_endpoints.reset(endpoints_token)
 
         # Return result and only the callbacks created here. Outer thunks might
         # return others.

--- a/tests/e2e/test_context_variables.py
+++ b/tests/e2e/test_context_variables.py
@@ -1,0 +1,78 @@
+"""
+Tests for context variable issues.
+"""
+
+import os
+import unittest
+
+import openai
+from snowflake.snowpark import Session
+from trulens.apps.custom import TruCustomApp
+from trulens.apps.custom import instrument
+from trulens.connectors.snowflake import SnowflakeConnector
+from trulens.core import TruSession
+
+from tests.test import optional_test
+
+
+class TestContextVariables(unittest.TestCase):
+    def setUp(self):
+        connection_parameters = {
+            "account": os.environ["SNOWFLAKE_ACCOUNT"],
+            "user": os.environ["SNOWFLAKE_USER"],
+            "password": os.environ["SNOWFLAKE_USER_PASSWORD"],
+            "database": os.environ["SNOWFLAKE_DATABASE"],
+            "role": os.environ["SNOWFLAKE_ROLE"],
+            "warehouse": os.environ["SNOWFLAKE_WAREHOUSE"],
+            "schema": "TestContextVariables",
+        }
+        self._snowpark_session = Session.builder.configs(
+            connection_parameters
+        ).create()
+        connector = SnowflakeConnector(
+            **connection_parameters, init_server_side=True
+        )
+        self._session = TruSession(connector=connector)
+
+    @optional_test
+    def test_endpoint_contextvar_always_cleaned(self):
+        class FailingRAG:
+            oai_client = openai.OpenAI()
+
+            @instrument
+            def retrieve(self, query: str) -> list:
+                return ["A", "B", "C"]
+
+            @instrument
+            def generate_completion(self, query: str, context_str: list) -> str:
+                raise ValueError()
+
+            @instrument
+            def query(self, query: str) -> str:
+                context_str = self.retrieve(query=query)
+                completion = self.generate_completion(
+                    query=query, context_str=context_str
+                )
+                return completion
+
+        # Set up trulens.
+        rag = FailingRAG()
+        tru_rag = TruCustomApp(
+            rag,
+            app_name="FailingRAG",
+            app_version="base",
+        )
+
+        with tru_rag:
+            self.assertRaises(ValueError, rag.query, "X")
+        # During app invocation, the endpoint context variable is set to track
+        # costs, but because in this test it fails prematurely, we must make
+        # sure the context variable is cleaned up properly. When it's set,
+        # the snowflake.snowpark.Session.sql function is handled differently
+        # in such a way that the following call will fail.
+        # TODO: find a better way to check if the context variable is cleaned.
+        self._snowpark_session.sql("SELECT 1").collect()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Description
Always ensure endpoint context variable is cleaned up.

Previously, if we failed during app invocation the endpoint context variable remained set. This was a problem because there is different behaviors for when it's set (as to allow cost tracking). This ensures this doesn't happen.

## Other details good to know for developers
There's two changes here:
1. I just put the context variable reset in a `finally` block.
2. A test to make sure this doesn't happen again.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure endpoint context variable is always reset in `_track_costs` and add a test to verify cleanup.
> 
>   - **Behavior**:
>     - Ensure endpoint context variable is reset in `_track_costs` in `endpoint.py` using a `finally` block.
>     - Prevents leftover context variables when app invocation fails.
>   - **Tests**:
>     - Add `test_context_variables.py` to verify context variable cleanup.
>     - Includes a test case `test_endpoint_contextvar_always_cleaned` that simulates a failure and checks cleanup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 3a4c02e3820b357189dc9524a6df162991a19229. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->