### PR TITLE
use float nan in place of numpy for skipped evals

### DIFF
--- a/src/core/trulens/core/feedback/feedback.py
+++ b/src/core/trulens/core/feedback/feedback.py
@@ -956,10 +956,10 @@ Feedback function signature:
                 feedback_calls.append(feedback_call)
 
             # Warn that there were some skipped evals.
-            if len(skipped_exceptions) > 0:
-                num_skipped = len(skipped_exceptions)
-                num_evaled = len(result_vals)
-                num_total = num_skipped + num_evaled
+            num_skipped = len(skipped_exceptions)
+            num_eval = len(result_vals)
+            num_total = num_skipped + num_eval
+            if num_skipped > 0 and num_total > 0:
                 warnings.warn(
                     (
                         f"{num_skipped}/{num_total}={100.0 * num_skipped / num_total:0.1f}"
@@ -970,15 +970,13 @@ Feedback function signature:
                     stacklevel=1,
                 )
 
-            if len(result_vals) == 0:
+            if num_eval == 0:
                 warnings.warn(
                     f"Feedback function {self.supplied_name if self.supplied_name is not None else self.name} with aggregation {self.agg} had no inputs.",
                     UserWarning,
                     stacklevel=1,
                 )
-
-                result = np.nan
-
+                result = float("nan")
             else:
                 if isinstance(result_vals[0], float):
                     result_vals = np.array(result_vals)


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue that can be
included in the release announcement. Please also include relevant motivation
and context.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `numpy` with native `float` for skipped evaluations in `run()` in `feedback.py`.
> 
>   - **Behavior**:
>     - Replace `np.nan` with `float('nan')` for skipped evaluations in `run()` in `feedback.py`.
>     - Update variable names: `num_evaled` to `num_eval` for clarity in `run()`.
>   - **Misc**:
>     - Remove unnecessary `numpy` dependency for handling skipped evaluations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 1f937c4d64e905e8c91e30bb77a26d666fc7fa70. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->