### PR TITLE
Don't check for user and account in snowpark sessions because Streamlit apps might hide them.

### DIFF
--- a/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
@@ -119,6 +119,12 @@ class SnowflakeConnector(DBConnector):
         missing_snowpark_session_parameters = []
         mismatched_parameters = []
         for k, v in snowpark_session_connection_parameters.items():
+            if k in ["account", "user"] and not v:
+                # Streamlit apps may hide these values so we don't check them.
+                # They are required for a Snowpark Session anyway so this isn't
+                # a problem (though we can't check consistency with
+                # `connection_parameters`).
+                continue
             if not v:
                 missing_snowpark_session_parameters.append(k)
             elif connection_parameters[k] not in [None, v]:


### PR DESCRIPTION
# Description
Don't check for user and account in snowpark sessions because Streamlit apps might hide them.

Some users are running the snowflake connector in Streamlit and running into an issue where the user isn't set (in reality it is set, it's just not visible).

## Other details good to know for developers

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Skip checking 'account' and 'user' in Snowpark sessions for Streamlit apps in `connector.py`.
> 
>   - **Behavior**:
>     - In `connector.py`, `_validate_snowpark_session_with_connection_parameters` now skips checking `account` and `user` if they are not visible, addressing issues in Streamlit apps.
>     - Ensures Snowpark sessions can proceed without visible `account` and `user` values, assuming they are set but hidden.
>   - **Misc**:
>     - Adds comments explaining the rationale for skipping these checks in Streamlit environments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for c31e623467399b3700605f3f9203fb96535b08f6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->