### PR TITLE
Fix the misspelled trulens-providers-openai package in examples

### DIFF
--- a/examples/quickstart/groundtruth_dataset_persistence.ipynb
+++ b/examples/quickstart/groundtruth_dataset_persistence.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !pip install trulens trulens-provider-openai openai"
+    "# !pip install trulens trulens-providers-openai openai"
    ]
   },
   {

--- a/examples/quickstart/groundtruth_evals.ipynb
+++ b/examples/quickstart/groundtruth_evals.ipynb
@@ -29,7 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !pip install trulens trulens-provider-openai openai"
+    "# !pip install trulens trulens-providers-openai openai"
    ]
   },
   {

--- a/examples/quickstart/groundtruth_evals_for_retrieval_systems.ipynb
+++ b/examples/quickstart/groundtruth_evals_for_retrieval_systems.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !pip install trulens trulens-provider-openai openai"
+    "# !pip install trulens trulens-providers-openai openai"
    ]
   },
   {


### PR DESCRIPTION
# Description

This PR fixes a misspelling in the `trulens-providers-openai` package name within the quickstart examples, which was causing installation errors when running examples in Colab or Jupyter Notebook. 

## Other details good to know for developers

No functional changes are introduced, and the core functionality of TruLens remains unaffected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
