### PR TITLE
Use snowflake connector over snowpark session in trulens Snowflake DB connector as snowpark session isn't thread-safe.

### DIFF
--- a/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
@@ -6,6 +6,7 @@ import re
 from typing import (
     Any,
     Dict,
+    List,
     Optional,
     Union,
 )
@@ -26,6 +27,10 @@ from snowflake.sqlalchemy import URL
 logger = logging.getLogger(__name__)
 
 
+# TODO(this_pr): get rid of snowpark_session.sql uses.
+# TODO(this_pr): get rid of snowpark_session.use_* uses.
+# TODO(this_pr): get rid of these things in notebooks.
+# TODO(this_pr): get rid of these things in tests.
 class SnowflakeConnector(DBConnector):
     """Connector to snowflake databases."""
 
@@ -74,7 +79,7 @@ class SnowflakeConnector(DBConnector):
             database_prefix,
             database_args,
             database_check_revision,
-            URL(**connection_parameters),
+            connection_parameters,
         )
 
     def _create_snowpark_session(
@@ -109,12 +114,12 @@ class SnowflakeConnector(DBConnector):
     ) -> Dict[str, Optional[str]]:
         # Validate.
         snowpark_session_connection_parameters = {
-            "account": snowpark_session.get_current_account(),
-            "user": snowpark_session.get_current_user(),
-            "database": snowpark_session.get_current_database(),
-            "schema": snowpark_session.get_current_schema(),
-            "warehouse": snowpark_session.get_current_warehouse(),
-            "role": snowpark_session.get_current_role(),
+            "account": snowpark_session.get_current_account(),  # TODO(this_pr): get rid of this!
+            "user": snowpark_session.get_current_user(),  # TODO(this_pr): get rid of this!
+            "database": snowpark_session.get_current_database(),  # TODO(this_pr): get rid of this!
+            "schema": snowpark_session.get_current_schema(),  # TODO(this_pr): get rid of this!
+            "warehouse": snowpark_session.get_current_warehouse(),  # TODO(this_pr): get rid of this!
+            "role": snowpark_session.get_current_role(),  # TODO(this_pr): get rid of this!
         }
         missing_snowpark_session_parameters = []
         mismatched_parameters = []
@@ -163,7 +168,7 @@ class SnowflakeConnector(DBConnector):
         database_prefix: Optional[str],
         database_args: Optional[Dict[str, Any]],
         database_check_revision: bool,
-        database_url: str,
+        connection_parameters: Dict[str, str],
     ):
         database_args = database_args or {}
         if "engine_params" not in database_args:
@@ -184,7 +189,7 @@ class SnowflakeConnector(DBConnector):
         database_args.update({
             k: v
             for k, v in {
-                "database_url": database_url,
+                "database_url": URL(**connection_parameters),
                 "database_redact_keys": database_redact_keys,
             }.items()
             if v is not None
@@ -206,28 +211,44 @@ class SnowflakeConnector(DBConnector):
         if init_server_side:
             ServerSideEvaluationArtifacts(
                 snowpark_session,
+                connection_parameters["database"],
+                connection_parameters["schema"],
+                connection_parameters["warehouse"],
                 database_args["database_prefix"],
                 init_server_side_with_staged_packages,
             ).set_up_all()
 
         # Add "trulens_workspace_version" tag to the current schema
-        schema = snowpark_session.get_current_schema()
-        db = snowpark_session.get_current_database()
         TRULENS_WORKSPACE_VERSION_TAG = "trulens_workspace_version"
 
-        res = snowpark_session.sql(
-            f"create tag if not exists {TRULENS_WORKSPACE_VERSION_TAG}"
-        ).collect()
-        res = snowpark_session.sql(
-            "ALTER schema {}.{} SET TAG {}='{}'".format(
-                db,
-                schema,
+        self._run_query(
+            snowpark_session,
+            f"CREATE TAG IF NOT EXISTS {TRULENS_WORKSPACE_VERSION_TAG}",
+        )
+        res = self._run_query(
+            snowpark_session,
+            "ALTER SCHEMA {}.{} SET TAG {}='{}'".format(
+                connection_parameters["database"],
+                connection_parameters["schema"],
                 TRULENS_WORKSPACE_VERSION_TAG,
                 self.db.get_db_revision(),
-            )
-        ).collect()
+            ),
+        )
 
         print(f"Set TruLens workspace version tag: {res}")
+
+    @staticmethod
+    def _run_query(
+        snowpark_session: Session,
+        q: str,
+        bindings: Optional[List[Any]] = None,
+    ) -> List[Any]:
+        cursor = snowpark_session.connection.cursor()
+        if bindings:
+            cursor.execute(q, bindings)
+        else:
+            cursor.execute(q)
+        return cursor.fetchall()
 
     @classmethod
     def _validate_schema_name(cls, name: str) -> None:
@@ -242,9 +263,11 @@ class SnowflakeConnector(DBConnector):
         snowpark_session: Session,
         schema_name: str,
     ):
-        snowpark_session.sql(
-            "CREATE SCHEMA IF NOT EXISTS IDENTIFIER(?)", [schema_name]
-        ).collect()
+        SnowflakeConnector._run_query(
+            snowpark_session,
+            "CREATE SCHEMA IF NOT EXISTS IDENTIFIER(?)",
+            [schema_name],
+        )
         snowpark_session.use_schema(schema_name)
 
     @cached_property

--- a/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
@@ -27,10 +27,6 @@ from snowflake.sqlalchemy import URL
 logger = logging.getLogger(__name__)
 
 
-# TODO(this_pr): get rid of snowpark_session.sql uses.
-# TODO(this_pr): get rid of snowpark_session.use_* uses.
-# TODO(this_pr): get rid of these things in notebooks.
-# TODO(this_pr): get rid of these things in tests.
 class SnowflakeConnector(DBConnector):
     """Connector to snowflake databases."""
 
@@ -114,12 +110,12 @@ class SnowflakeConnector(DBConnector):
     ) -> Dict[str, Optional[str]]:
         # Validate.
         snowpark_session_connection_parameters = {
-            "account": snowpark_session.get_current_account(),  # TODO(this_pr): get rid of this!
-            "user": snowpark_session.get_current_user(),  # TODO(this_pr): get rid of this!
-            "database": snowpark_session.get_current_database(),  # TODO(this_pr): get rid of this!
-            "schema": snowpark_session.get_current_schema(),  # TODO(this_pr): get rid of this!
-            "warehouse": snowpark_session.get_current_warehouse(),  # TODO(this_pr): get rid of this!
-            "role": snowpark_session.get_current_role(),  # TODO(this_pr): get rid of this!
+            "account": snowpark_session.get_current_account(),
+            "user": snowpark_session.get_current_user(),
+            "database": snowpark_session.get_current_database(),
+            "schema": snowpark_session.get_current_schema(),
+            "warehouse": snowpark_session.get_current_warehouse(),
+            "role": snowpark_session.get_current_role(),
         }
         missing_snowpark_session_parameters = []
         mismatched_parameters = []


### PR DESCRIPTION
# Description
Use snowflake connector over snowpark session in trulens Snowflake DB connector as snowpark session isn't thread-safe.

It's unlikely, but while setting up the server if someone else uses the snowpark session it could be problematic. The bigger issue is making sure users don't use it in their app (which we can mitigate by saying this in the notebook examples).

## Other details good to know for developers
Future work to do still:
1. Remove from notebook examples.
2. Remove from tests? This isn't really necessary since this is a controlled environment but might want to do this later.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch from Snowpark session to Snowflake connector for thread safety, updating query execution and connection handling in `connector.py` and `server_side_evaluation_artifacts.py`.
> 
>   - **Behavior**:
>     - Switch from Snowpark session to Snowflake connector in `connector.py` for thread safety.
>     - Modify `_init_with_snowpark_session` to use `connection_parameters` instead of `URL`.
>     - Introduce `_run_query` method in `connector.py` and `server_side_evaluation_artifacts.py` for executing queries.
>   - **Parameters**:
>     - Pass `database`, `schema`, and `warehouse` directly to `ServerSideEvaluationArtifacts` instead of using Snowpark session methods.
>   - **Misc**:
>     - Update `ServerSideEvaluationArtifacts` to use `_run_query` for executing SQL commands.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for bdd4adb0173a35185720a4eac22191cf2f502ea0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->