### PR TITLE
Don't open extra Snowflake connections and don't recycle connections as quickly.

### DIFF
--- a/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
@@ -226,6 +226,13 @@ class SnowflakeConnector(DBConnector):
         default_engine_params = {
             "creator": lambda: snowpark_session.connection,
             "paramstyle": "qmark",
+            # The following parameters ensure the pool does not allocate new
+            # connections that it will close. This is a problem because the
+            # "creator" does not create new connections, it only passes around
+            # the single one it has.
+            "max_overflow": 0,
+            "pool_recycle": -1,
+            "pool_timeout": 120,
         }
         if "engine_params" not in database_args:
             database_args["engine_params"] = default_engine_params

--- a/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
@@ -166,32 +166,12 @@ class SnowflakeConnector(DBConnector):
         database_check_revision: bool,
         connection_parameters: Dict[str, str],
     ):
-        database_args = database_args or {}
-        if "engine_params" not in database_args:
-            database_args["engine_params"] = {}
-        if "creator" in database_args["engine_params"]:
-            raise ValueError(
-                "Cannot set `database_args['engine_params']['creator']!"
-            )
-        database_args["engine_params"]["creator"] = (
-            lambda: snowpark_session.connection
-        )
-        if "paramstyle" in database_args["engine_params"]:
-            raise ValueError(
-                "Cannot set `database_args['engine_params']['paramstyle']!"
-            )
-        database_args["engine_params"]["paramstyle"] = "qmark"
-
-        database_args.update({
-            k: v
-            for k, v in {
-                "database_url": URL(**connection_parameters),
-                "database_redact_keys": database_redact_keys,
-            }.items()
-            if v is not None
-        })
-        database_args["database_prefix"] = (
-            database_prefix or core_db.DEFAULT_DATABASE_PREFIX
+        database_args = self._set_up_database_args(
+            database_args,
+            snowpark_session,
+            connection_parameters,
+            database_redact_keys,
+            database_prefix,
         )
         self._db: Union[SQLAlchemyDB, python_utils.OpaqueWrapper] = (
             SQLAlchemyDB.from_tru_args(**database_args)
@@ -232,6 +212,42 @@ class SnowflakeConnector(DBConnector):
         )
 
         print(f"Set TruLens workspace version tag: {res}")
+
+    def _set_up_database_args(
+        self,
+        database_args: Dict[str, Any],
+        snowpark_session: Session,
+        connection_parameters: Dict[str, str],
+        database_redact_keys: bool,
+        database_prefix: Optional[str],
+    ) -> Dict[str, Any]:
+        database_args = database_args or {}
+        # Set engine_params.
+        default_engine_params = {
+            "creator": lambda: snowpark_session.connection,
+            "paramstyle": "qmark",
+        }
+        if "engine_params" not in database_args:
+            database_args["engine_params"] = default_engine_params
+        else:
+            for k, v in default_engine_params.items():
+                if k in database_args["engine_params"]:
+                    raise ValueError(
+                        f"Cannot set `database_args['engine_params']['{k}']!"
+                    )
+        # Set remaining parameters.
+        database_args.update({
+            k: v
+            for k, v in {
+                "database_url": URL(**connection_parameters),
+                "database_redact_keys": database_redact_keys,
+            }.items()
+            if v is not None
+        })
+        database_args["database_prefix"] = (
+            database_prefix or core_db.DEFAULT_DATABASE_PREFIX
+        )
+        return database_args
 
     @staticmethod
     def _run_query(


### PR DESCRIPTION
# Description
Don't open extra Snowflake connections and don't recycle connections as quickly.

## Other details good to know for developers
Most of this is just refactoring but the crux of the logic is here:
https://github.com/truera/trulens/compare/davidkurokawa/dont_close_connections_easily?expand=1#diff-58cf82783e0a280f95f2085f29603382620208b15a0a5ae54cc4da0b0cb079caR229-R235
where I add some parameters to make the connection pool not close connections as much.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `SnowflakeConnector` to optimize connection management by introducing `_set_up_database_args()` to handle database argument setup and prevent unnecessary connections.
> 
>   - **Behavior**:
>     - Refactor `SnowflakeConnector` to prevent unnecessary Snowflake connections by setting `max_overflow` to 0, `pool_recycle` to -1, and `pool_timeout` to 120 in `_set_up_database_args()`.
>     - Move database argument setup logic to `_set_up_database_args()` from `_init_with_snowpark_session()`.
>   - **Functions**:
>     - Add `_set_up_database_args()` to encapsulate database argument setup logic.
>     - Update `_init_with_snowpark_session()` to use `_set_up_database_args()` for setting up database arguments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 22e7aa7c8ad2442474be0b227358b36b07ac0556. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->