### PR TITLE
Allow Cortex provider to only take a connection object.

### DIFF
--- a/examples/expositional/frameworks/cortexchat/cortex_chat_quickstart.ipynb
+++ b/examples/expositional/frameworks/cortexchat/cortex_chat_quickstart.ipynb
@@ -229,7 +229,7 @@
     "\n",
     "snowpark_session = Session.builder.configs(connection_params).create()\n",
     "\n",
-    "provider = Cortex(snowpark_session, \"llama3.1-8b\")\n",
+    "provider = Cortex(snowpark_session.connection, \"llama3.1-8b\")\n",
     "\n",
     "# Question/answer relevance between overall question and answer.\n",
     "f_answer_relevance = (\n",

--- a/src/providers/cortex/trulens/providers/cortex/provider.py
+++ b/src/providers/cortex/trulens/providers/cortex/provider.py
@@ -77,7 +77,7 @@ class Cortex(
             ```
 
     Args:
-        snowflake_conn (Any): Snowflake connection.
+        snowflake_conn (Any): Snowflake connection. Note: This is not a snowflake session.
 
         model_engine (str, optional): Model engine to use. Defaults to `snowflake-arctic`.
 
@@ -104,7 +104,10 @@ class Cortex(
         self_kwargs["snowflake_conn"] = _SNOWFLAKE_STORED_PROCEDURE_CONNECTION
         if _SNOWFLAKE_STORED_PROCEDURE_CONNECTION is None:
             self_kwargs["snowflake_conn"] = snowflake_conn
-
+        if not callable(getattr(self_kwargs["snowflake_conn"], "cursor", None)):
+            raise ValueError(
+                "Invalid snowflake_conn: Expected a Snowflake connection object with a 'cursor' method. Please ensure you are not passing a session object."
+            )
         super().__init__(**self_kwargs)
 
     def _exec_snowsql_complete_command(


### PR DESCRIPTION
# Description

Cortex provider will not accept a session object, and we have seen this as an accidental thing many users are doing.


## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure `Cortex` only accepts a Snowflake connection object by checking for a `cursor` method in `provider.py`.
> 
>   - **Behavior**:
>     - In `Cortex.__init__`, added a check to ensure `snowflake_conn` has a `cursor` method, raising `ValueError` if not.
>     - Updated docstring for `snowflake_conn` to clarify it should not be a session object.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for d5bf12b8eb3c4433ec1e560966c4d5365795698b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->