### PR TITLE
Don't check if Cortex providers can be deserialized for deferred feedback functions.

### DIFF
--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -628,12 +628,17 @@ class App(
         for f in self.feedbacks:
             if (
                 self.feedback_mode == feedback_schema.FeedbackMode.DEFERRED
-                or f.run_location
-                == feedback_schema.FeedbackRunLocation.SNOWFLAKE
+                and f.run_location
+                != feedback_schema.FeedbackRunLocation.SNOWFLAKE
             ):
                 # Try to load each of the feedback implementations. Deferred
                 # mode will do this but we want to fail earlier at app
                 # constructor here.
+                # If we're running on Snowflake, the Cortex provider (which is
+                # the only allowed provider) will receive its Snowflake
+                # connection from trulens.providers.cortex.provider._SNOWFLAKE_STORED_PROCEDURE_CONNECTION
+                # so it cannot be hydrated correctly here and so we skip the
+                # following check.
                 try:
                     f.implementation.load()
                 except Exception as e:

--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -628,17 +628,24 @@ class App(
         for f in self.feedbacks:
             if (
                 self.feedback_mode == feedback_schema.FeedbackMode.DEFERRED
-                and f.run_location
-                != feedback_schema.FeedbackRunLocation.SNOWFLAKE
+                or f.run_location
+                == feedback_schema.FeedbackRunLocation.SNOWFLAKE
             ):
+                # To correctly deserialize a Cortex provider, we assume that
+                # trulens.providers.cortex.provider._SNOWFLAKE_STORED_PROCEDURE_CONNECTION
+                # is set (as in a Snowflake stored procedure). So we don't check
+                # it here as there are other ways to initialize the Cortex
+                # provider out of convenience.
+                if (
+                    isinstance(f.implementation, pyschema_utils.Method)
+                    and f.implementation.obj.cls.module.module_name
+                    == "trulens.providers.cortex.provider"
+                    and f.implementation.obj.cls.name == "Cortex"
+                ):
+                    continue
                 # Try to load each of the feedback implementations. Deferred
                 # mode will do this but we want to fail earlier at app
                 # constructor here.
-                # If we're running on Snowflake, the Cortex provider (which is
-                # the only allowed provider) will receive its Snowflake
-                # connection from trulens.providers.cortex.provider._SNOWFLAKE_STORED_PROCEDURE_CONNECTION
-                # so it cannot be hydrated correctly here and so we skip the
-                # following check.
                 try:
                     f.implementation.load()
                 except Exception as e:


### PR DESCRIPTION
# Description
Don't check if Cortex providers can be deserialized for deferred feedback functions.

This is because the snowflake connection passed to the Cortex provider constructor is not serializable and so will fail. However, the way to get around this is by setting a module level variable (i.e. `trulens.providers.cortex.provider._SNOWFLAKE_STORED_PROCEDURE_CONNECTION`) as stored procedures in Snowflake do.

## Other details good to know for developers
Currently main is broken without this change as we're now checking if the snowflake connection passed to the Cortex provider has the attribute `cursor` which when deserialized during a check for deferred feedback functions fails.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Skip deserialization check for Cortex providers in deferred feedback functions to fix Snowflake connection issue in `app.py`.
> 
>   - **Behavior**:
>     - Skip deserialization check for Cortex providers in deferred feedback functions in `_tru_post_init` in `app.py`.
>     - Assumes `trulens.providers.cortex.provider._SNOWFLAKE_STORED_PROCEDURE_CONNECTION` is set for correct deserialization.
>   - **Bug Fix**:
>     - Fixes issue where Snowflake connection in Cortex provider caused deserialization failure during deferred feedback function checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 9fbab98a7920f50e54761c4537d3989b2c95f631. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->