### PR TITLE
Ensure `make clean` does indeed clean or it will fail out.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ env-tests-optional: env env-tests
 		llama-index-embeddings-openai \
 		langchain-openai \
 		unstructured \
-		chromadb \
+		chromadb
 
 env-tests-db: env-tests
 	poetry run pip install \

--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,9 @@ clean:
 	echo
 	if [[ $$REPLY =~ ^[Yy]$$ ]]; then \
 		git clean -fxd; \
+	else \
+		echo "Did not clean!"; \
+		exit 1; \
 	fi;
 
 ## Step: Build wheels

--- a/tests/e2e/test_context_variables.py
+++ b/tests/e2e/test_context_variables.py
@@ -5,7 +5,6 @@ Tests for context variable issues.
 import os
 import unittest
 
-import openai
 from snowflake.snowpark import Session
 from trulens.apps.custom import TruCustomApp
 from trulens.apps.custom import instrument
@@ -37,8 +36,6 @@ class TestContextVariables(unittest.TestCase):
     @optional_test
     def test_endpoint_contextvar_always_cleaned(self):
         class FailingRAG:
-            oai_client = openai.OpenAI()
-
             @instrument
             def retrieve(self, query: str) -> list:
                 return ["A", "B", "C"]


### PR DESCRIPTION
# Description
Ensure `make clean` does indeed clean or it will fail out.

Also removed an extra dependency to `openai` in a test that wasn't necessary.

## Other details good to know for developers
During a release, I noticed you could get away without cleaning things which we probably shouldn't allow. Also there was some issue with the test environment (hence my removing of the `openai` thing).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure `make clean` in `Makefile` performs a clean operation and remove unnecessary `openai` import from `test_context_variables.py`.
> 
>   - **Makefile**:
>     - Modify `clean` target to exit with a message if the user chooses not to clean.
>   - **Tests**:
>     - Remove unnecessary `openai` import from `test_context_variables.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 34a8cb5077ba943df57e890d190d7e3d41a63f47. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->