### PR TITLE
Move print message up to not invoke error when we can't create a tag.

### DIFF
--- a/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
@@ -211,12 +211,11 @@ class SnowflakeConnector(DBConnector):
                     self.db.get_db_revision(),
                 ),
             )
+            print(f"Set TruLens workspace version tag: {res}")
         except Exception as e:
             print(
                 f"Error setting TruLens workspace version tag: {e}, check if you have enterprise version of Snowflake."
             )
-
-        print(f"Set TruLens workspace version tag: {res}")
 
     def _set_up_database_args(
         self,


### PR DESCRIPTION
# Description
Move print message up to not invoke error when we can't create a tag.

## Other details good to know for developers
This was put into the 1.2.4 but it wasn't put it in main due to the time crunch.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move print statement in `_init_with_snowpark_session` to prevent error when setting tag fails.
> 
>   - **Behavior**:
>     - Move print statement in `_init_with_snowpark_session` in `connector.py` to execute before potential exception.
>     - Prevents error when setting TruLens workspace version tag fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for e15b105defb8a02b498f5773ec05e8319b38855e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->