### PR TITLE
Bump version to 1.2.6.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens"
-version = "1.2.5"
+version = "1.2.6"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/langchain/pyproject.toml
+++ b/src/apps/langchain/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-langchain"
-version = "1.2.5"
+version = "1.2.6"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/llamaindex/pyproject.toml
+++ b/src/apps/llamaindex/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-llamaindex"
-version = "1.2.5"
+version = "1.2.6"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/nemo/pyproject.toml
+++ b/src/apps/nemo/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-nemo"
-version = "1.2.5"
+version = "1.2.6"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/benchmark/pyproject.toml
+++ b/src/benchmark/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-benchmark"
-version = "1.2.5"
+version = "1.2.6"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/connectors/snowflake/meta.yaml
+++ b/src/connectors/snowflake/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trulens-connectors-snowflake" %}
-{% set version = "1.2.5" %}
+{% set version = "1.2.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 0c9c5661e860608a39d68b7fab0f6ed18b62b71454139e6d3498dc3077a451e7
+  sha256: 60dd891cfdf9c5cfc7a39d74ad9f875336e163dadbf64ba2448bd7e062bbecd7
 
 build:
   noarch: python

--- a/src/connectors/snowflake/pyproject.toml
+++ b/src/connectors/snowflake/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-connectors-snowflake"
-version = "1.2.5"
+version = "1.2.6"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trulens-core" %}
-{% set version = "1.2.5" %}
+{% set version = "1.2.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 880cf7feceef82c631b04a5be2be019e76ce04eba508e6c8814b119430ca5705
+  sha256: 60ef731365def0f4a05439776b6be57635a4ebd5f6261265a15793ba2a6ddc89
 
 build:
   noarch: python

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-core"
-version = "1.2.5"
+version = "1.2.6"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/dashboard/pyproject.toml
+++ b/src/dashboard/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-dashboard"
-version = "1.2.5"
+version = "1.2.6"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/feedback/meta.yaml
+++ b/src/feedback/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trulens-feedback" %}
-{% set version = "1.2.5" %}
+{% set version = "1.2.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 631aea2a5257a62ac2396362cb992d683aaaaad518385219c366e480a4fa6285
+  sha256: 54a41bf58fe821a78f9405098de3259be9d3327003a4bc93e44c6befe9f51646
 
 build:
   noarch: python

--- a/src/feedback/pyproject.toml
+++ b/src/feedback/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-feedback"
-version = "1.2.5"
+version = "1.2.6"
 description = "A TruLens extension package implementing feedback functions for LLM App evaluation."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/bedrock/pyproject.toml
+++ b/src/providers/bedrock/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-bedrock"
-version = "1.2.5"
+version = "1.2.6"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trulens-providers-cortex" %}
-{% set version = "1.2.5" %}
+{% set version = "1.2.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 985c6ff994e509df977cabcc3ab4b408b9d2f9bbea82450f8fdeff65274607fc
+  sha256: 735144708a181ae110abbe445f7674885899cf7acc7440992c15d3d453013749
 
 build:
   noarch: python

--- a/src/providers/cortex/pyproject.toml
+++ b/src/providers/cortex/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-cortex"
-version = "1.2.5"
+version = "1.2.6"
 description = "A TruLens extension package adding Snowflake Cortex support for LLM App evaluation."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/huggingface/pyproject.toml
+++ b/src/providers/huggingface/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-huggingface"
-version = "1.2.5"
+version = "1.2.6"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/langchain/pyproject.toml
+++ b/src/providers/langchain/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-langchain"
-version = "1.2.5"
+version = "1.2.6"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/litellm/pyproject.toml
+++ b/src/providers/litellm/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-litellm"
-version = "1.2.5"
+version = "1.2.6"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/openai/pyproject.toml
+++ b/src/providers/openai/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-openai"
-version = "1.2.5"
+version = "1.2.6"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/trulens_eval/pyproject.toml
+++ b/src/trulens_eval/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens_eval"
-version = "1.2.5"
+version = "1.2.6"
 description = "Backwards-compatibility package for API of trulens_eval<1.0.0 using API of trulens-*>=1.0.0."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",


### PR DESCRIPTION
# Description
Bump version to 1.2.6.

## Other details good to know for developers
I forgot there was a change we only had in the releases/rc-trulens-1.2.4 branch for a TAG fix so I had to incorporate that into main and re-release.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump version from 1.2.5 to 1.2.6 across multiple `pyproject.toml` and `meta.yaml` files for release management.
> 
>   - **Version Update**:
>     - Bump version from `1.2.5` to `1.2.6` in `pyproject.toml` files for `trulens`, `trulens-apps-langchain`, `trulens-apps-llamaindex`, `trulens-apps-nemo`, `trulens-benchmark`, `trulens-connectors-snowflake`, `trulens-core`, `trulens-dashboard`, `trulens-feedback`, `trulens-providers-bedrock`, `trulens-providers-cortex`, `trulens-providers-huggingface`, `trulens-providers-langchain`, `trulens-providers-litellm`, `trulens-providers-openai`, and `trulens_eval`.
>     - Update version in `meta.yaml` files for `trulens-connectors-snowflake`, `trulens-core`, `trulens-feedback`, and `trulens-providers-cortex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for fbd769144df575d9ddb6117ad6e155f24c515d53. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->