### PR TITLE
Add Datec logo to homepage

### DIFF
--- a/docs/assets/images/logos/datec.png
+++ b/docs/assets/images/logos/datec.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:041321c77c472efb3d323b69d271ce55f37ca6b11b304700e0baf27e4519416b
+size 159056

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -262,7 +262,7 @@
                         <a href="https://www.cubeserv.com/" target="_blank">
                             <img src="/assets/images/logos/cubeserv.svg" alt="CubeServ" style="width: 100px; height: auto;" />
                         </a>
-                        <a href="https://datecinc.net/" target="_blank">
+                        <a href="https://www.datec.com.bo/" target="_blank">
                             <img src="/assets/images/logos/datec.png" alt="Datec" style="width: 100px; height: auto;" />
                         </a>
                     </div>

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -262,6 +262,9 @@
                         <a href="https://www.cubeserv.com/" target="_blank">
                             <img src="/assets/images/logos/cubeserv.svg" alt="CubeServ" style="width: 100px; height: auto;" />
                         </a>
+                        <a href="https://datecinc.net/" target="_blank">
+                            <img src="/assets/images/logos/datec.png" alt="Datec" style="width: 100px; height: auto;" />
+                        </a>
                     </div>
                 </div>
 


### PR DESCRIPTION
# Description

Add [datec](https://datecinc.net/) logo section on the homepage

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [x] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Datec logo to the 'Trusted by' section on the homepage.
> 
>   - **UI Update**:
>     - Add Datec logo to the 'Trusted by' section in `home.html`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 45eb6c6edbd631f125cfba202d98b39aa4bba68c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->