### PR TITLE
change instrumentation arg `self` -> `_self`

### DIFF
--- a/src/core/trulens/core/instruments.py
+++ b/src/core/trulens/core/instruments.py
@@ -1241,5 +1241,6 @@ class instrument(AddInstruments):
         # list of filters.
         self.method(cls, name)
 
-    def __call__(self, *args, **kwargs):
-        return self.func(*args, **kwargs)
+    def __call__(_self, *args, **kwargs):
+        # _self is used to avoid conflicts where `self` may be passed from the callee
+        return _self.func(*args, **kwargs)

--- a/src/core/trulens/core/instruments.py
+++ b/src/core/trulens/core/instruments.py
@@ -1242,5 +1242,5 @@ class instrument(AddInstruments):
         self.method(cls, name)
 
     def __call__(_self, *args, **kwargs):
-        # _self is used to avoid conflicts where `self` may be passed from the callee
+        # `_self` is used to avoid conflicts where `self` may be passed from the caller method
         return _self.func(*args, **kwargs)


### PR DESCRIPTION
# Description
An issue occurs when an instrumented method takes in a self argument that is passed by the caller.

```python
Class.instrumented_instance_method(self=self, **kwargs)
```

This may raise an Runtime error where `self` is provided twice, once by the caller and once in the instrument wrapper code.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Change `self` to `_self` in `instrument.__call__` to prevent argument conflict when `self` is passed by the callee.
> 
>   - **Behavior**:
>     - Change `self` to `_self` in `__call__` method of `instrument` class in `instruments.py` to avoid conflict when `self` is passed by the callee.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for d03730418b7c724ff5127875c2a10c0fb073aaf3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->