### PR TITLE
relax snowflake-ml-python version

### DIFF
--- a/src/providers/cortex/pyproject.toml
+++ b/src/providers/cortex/pyproject.toml
@@ -31,7 +31,7 @@ python = "^3.8.1,<3.12"
 trulens-core = { version = "^1.0.0" }
 trulens-feedback = { version = "^1.0.0" }
 snowflake-connector-python = "^3.11"
-snowflake-ml-python = "^1.4"
+snowflake-ml-python = "^1.6.4"
 snowflake-snowpark-python = "^1.18.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/src/providers/cortex/pyproject.toml
+++ b/src/providers/cortex/pyproject.toml
@@ -31,7 +31,7 @@ python = "^3.8.1,<3.12"
 trulens-core = { version = "^1.0.0" }
 trulens-feedback = { version = "^1.0.0" }
 snowflake-connector-python = "^3.11"
-snowflake-ml-python = "^1.7.1"
+snowflake-ml-python = "^1.4"
 snowflake-snowpark-python = "^1.18.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description

snowflake-ml-python>=1.7.1 doesn't support python 3.8, which conflicts with trulens

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Relax `snowflake-ml-python` version from `^1.7.1` to `^1.4` in `pyproject.toml`.
> 
>   - **Dependencies**:
>     - Relax `snowflake-ml-python` version from `^1.7.1` to `^1.4` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for a1e09ccfe094bdcef59d10af0919118dca0777f5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->