### PR TITLE
Fix Cortex provider for tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,18 @@ write-golden-%: tests/e2e/test_%.py
 	WRITE_GOLDEN=1 $(PYTEST) tests/e2e/test_$*.py || true
 write-golden: write-golden-dummy write-golden-serial
 
+# Snowflake-specific tests.
+test-snowflake:
+	rm -rf ./dist \
+		&& rm -rf ./src/core/trulens/data/snowflake_stage_zips \
+		&& make build \
+		&& make zip-wheels \
+		&& make build \
+		&& make env \
+		&& TEST_OPTIONAL=1 ALLOW_OPTIONALS=1 $(PYTEST) \
+			./tests/e2e/test_context_variables.py \
+			./tests/e2e/test_snowflake_*
+
 # Run the tests for a specific file.
 test-file-%: tests/e2e/%
 	$(PYTEST) tests/e2e/$*

--- a/tests/e2e/data/staged_packages.ipynb
+++ b/tests/e2e/data/staged_packages.ipynb
@@ -164,7 +164,7 @@
     "tru_session = TruSession(connector=connector)\n",
     "\n",
     "# Set up feedback functions.\n",
-    "relevance = Cortex(snowpark_session.connection).relevance\n",
+    "relevance = Cortex(snowpark_session).relevance\n",
     "f_regular = Feedback(relevance).on_input_output()\n",
     "f_snowflake = SnowflakeFeedback(relevance).on_input_output()\n",
     "feedbacks = [\n",

--- a/tests/util/snowflake_test_case.py
+++ b/tests/util/snowflake_test_case.py
@@ -13,6 +13,7 @@ from snowflake.snowpark import Session
 from snowflake.snowpark.row import Row
 from trulens.connectors import snowflake as snowflake_connector
 from trulens.core import session as core_session
+from trulens.providers.cortex.provider import Cortex
 
 
 class SnowflakeTestCase(TestCase):
@@ -31,6 +32,7 @@ class SnowflakeTestCase(TestCase):
             self._snowflake_connection_parameters
         ).create()
         self._snowflake_schemas_to_delete = set()
+        Cortex.DEFAULT_SNOWPARK_SESSION = self._snowpark_session
 
     def tearDown(self):
         # [HACK!] Clean up any instances of `TruSession` so tests don't interfere with each other.


### PR DESCRIPTION
# Description
Fix Cortex provider for tests.

## Other details good to know for developers

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Cortex provider's Snowflake session handling by introducing a default session and updating test setup.
> 
>   - **Cortex Provider**:
>     - Adds `DEFAULT_SNOWPARK_SESSION` to `Cortex` class in `provider.py` for default session handling.
>     - Updates session initialization to use `DEFAULT_SNOWPARK_SESSION` if no session is provided or if `pyschema_utils.is_noserio()` returns true.
>     - Raises `ValueError` if session inference fails, suggesting setting `DEFAULT_SNOWPARK_SESSION`.
>   - **Testing**:
>     - Sets `Cortex.DEFAULT_SNOWPARK_SESSION` in `setUp()` of `SnowflakeTestCase` in `snowflake_test_case.py` to ensure consistent session usage across tests.
>   - **Makefile**:
>     - Adds `test-snowflake` target for running Snowflake-specific tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 0e17bc19a1c2500b37e9ed5b44fe3d3b7bee54ac. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->