### PR TITLE
strip quotes from connection params

### DIFF
--- a/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
@@ -127,9 +127,9 @@ class SnowflakeConnector(DBConnector):
             "role": snowpark_session.get_current_role(),
         }
 
-        for k, v in connection_parameters.items():
+        for k, v in snowpark_session_connection_parameters.items():
             if v and v.startswith('"') and v.endswith('"'):
-                connection_parameters[k] = v.strip('"')
+                snowpark_session_connection_parameters[k] = v.strip('"')
 
         missing_snowpark_session_parameters = []
         mismatched_parameters = []

--- a/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
@@ -126,6 +126,11 @@ class SnowflakeConnector(DBConnector):
             "warehouse": snowpark_session.get_current_warehouse(),
             "role": snowpark_session.get_current_role(),
         }
+
+        for k, v in connection_parameters.items():
+            if v and v.startswith('"') and v.endswith('"'):
+                connection_parameters[k] = v.strip('"')
+
         missing_snowpark_session_parameters = []
         mismatched_parameters = []
         for k, v in snowpark_session_connection_parameters.items():


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue that can be
included in the release announcement. Please also include relevant motivation
and context.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Strips quotes from connection parameters in `_validate_snowpark_session_with_connection_parameters()` in `connector.py`.
> 
>   - **Behavior**:
>     - Strips quotes from connection parameters in `_validate_snowpark_session_with_connection_parameters()` in `connector.py`.
>     - Handles cases where parameters are enclosed in double quotes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 78438cb3c87a0bcb7fa4810e212db3e463f06e41. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->