### PR TITLE
reset_database only drops trulens tables

### DIFF
--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -26,6 +26,7 @@ import pandas as pd
 import pydantic
 from pydantic import Field
 import sqlalchemy as sa
+from sqlalchemy import Table
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql import text as sql_text
@@ -350,6 +351,8 @@ class SQLAlchemyDB(core_db.DB):
         meta = self.orm.metadata
 
         tables = [
+            Table(f"{self.table_prefix}alembic_version", self.orm.metadata)
+        ] + [
             c.__table__
             for c in self.orm.registry.values()
             if hasattr(c, "__table__")

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -26,7 +26,6 @@ import pandas as pd
 import pydantic
 from pydantic import Field
 import sqlalchemy as sa
-from sqlalchemy import Table
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql import text as sql_text
@@ -351,8 +350,6 @@ class SQLAlchemyDB(core_db.DB):
         meta = self.orm.metadata
 
         tables = [
-            Table(f"{self.table_prefix}alembic_version", self.orm.metadata)
-        ] + [
             c.__table__
             for c in self.orm.registry.values()
             if hasattr(c, "__table__")


### PR DESCRIPTION
# Description

reset_database() would previously drop all tables in a given database/schema. This fix would only drop trulens-related tables

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> `reset_database()` in `sqlalchemy.py` now drops only `trulens`-related tables, enhancing data safety.
> 
>   - **Behavior**:
>     - `reset_database()` in `sqlalchemy.py` now drops only `trulens`-related tables instead of all tables in the database.
>     - Collects tables from `self.orm.registry` and drops them using `meta.drop_all`.
>   - **Misc**:
>     - Removed commented-out code in `reset_database()` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for e770f153557bece50a6c5ce469c0228d0debfd31. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->