### PR TITLE
trulens-dashboard: handle selected_rows is None and fix fallback to st.dataframe in SiS 

### DIFF
--- a/src/dashboard/trulens/dashboard/Leaderboard.py
+++ b/src/dashboard/trulens/dashboard/Leaderboard.py
@@ -518,7 +518,7 @@ def _render_grid_tab(
         grid_key=grid_key,
     )
 
-    if selected_rows.empty:
+    if selected_rows is None or selected_rows.empty:
         selected_app_ids = []
     else:
         selected_app_ids = list(selected_rows.app_id.unique())

--- a/src/dashboard/trulens/dashboard/pages/Compare.py
+++ b/src/dashboard/trulens/dashboard/pages/Compare.py
@@ -502,7 +502,7 @@ def _render_shared_records(
         grid_key="compare_grid",
     )
 
-    if selected_rows.empty:
+    if selected_rows is None or selected_rows.empty:
         return None
     return selected_rows[record_id_cols]
 

--- a/src/dashboard/trulens/dashboard/pages/Compare.py
+++ b/src/dashboard/trulens/dashboard/pages/Compare.py
@@ -245,7 +245,9 @@ def _render_advanced_filters(
 
         for i in range(n_clauses):
             clause_container = st.container()
-            st_cols = clause_container.columns(5, vertical_alignment="center")
+            st_cols = st_columns(
+                5, vertical_alignment="center", container=clause_container
+            )
             clause_fields = render_clause(st_cols, idx=i)
             if clause_fields is None:
                 # TODO: test this

--- a/src/dashboard/trulens/dashboard/pages/Compare.py
+++ b/src/dashboard/trulens/dashboard/pages/Compare.py
@@ -401,17 +401,17 @@ def _render_grid(
             # Fallback to st.dataframe if st_aggrid is not installed
             pass
 
-        column_order = ["input", *diff_cols, *agg_diff_col]
-        column_order = [col for col in column_order if col in df.columns]
-        event = st.dataframe(
-            df[column_order],
-            column_order=column_order,
-            selection_mode="single-row",
-            on_select="rerun",
-            hide_index=True,
-            use_container_width=True,
-        )
-        return df.iloc[event.selection["rows"]]
+    column_order = ["input", *diff_cols, *agg_diff_col]
+    column_order = [col for col in column_order if col in df.columns]
+    event = st.dataframe(
+        df[column_order],
+        column_order=column_order,
+        selection_mode="single-row",
+        on_select="rerun",
+        hide_index=True,
+        use_container_width=True,
+    )
+    return df.iloc[event.selection["rows"]]
 
 
 def _render_shared_records(


### PR DESCRIPTION
# Description

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Handle `None` `selected_rows` and fix `st.dataframe` fallback in `Leaderboard.py` and `Compare.py`.
> 
>   - **Behavior**:
>     - Handle `selected_rows` being `None` in `_render_grid_tab` in `Leaderboard.py` and `_render_shared_records` in `Compare.py`.
>     - Fix fallback to `st.dataframe` in `_render_grid` in `Compare.py` when `st_aggrid` is not installed.
>   - **Misc**:
>     - Minor indentation fix in `_render_grid` in `Compare.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 4c10530ff1799c9eebe9a526272ee00cfd299ac0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->