### PR TITLE
Have `Pace` create an event loop if it doesn't exist.

### DIFF
--- a/src/core/trulens/core/utils/pace.py
+++ b/src/core/trulens/core/utils/pace.py
@@ -101,6 +101,8 @@ class Pace(BaseModel):
                 "Increase `seconds_per_period` or `marks_per_second` (or both)."
             )
 
+        self._ensure_event_loop_exists()
+
         super().__init__(
             *args,
             seconds_per_period=seconds_per_period,
@@ -109,6 +111,14 @@ class Pace(BaseModel):
             max_marks=max_marks,
             **kwargs,
         )
+
+    @staticmethod
+    def _ensure_event_loop_exists():
+        try:
+            asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
 
     async def amark(self) -> float:
         """Return in appropriate pace.


### PR DESCRIPTION
# Description
Have `Pace` create an event loop if it doesn't exist.

The async lock that was introduced in https://github.com/truera/trulens/pull/1654 doesn't work in Python 3.9 because it doesn't create an event loop if one doesn't exist for w/e reason. So we check if there is one now, and if not we create one. The approach to check if there is one is a bit hacky, but it's what was recommended in Stack Overflow so I went with that.

## Other details good to know for developers

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
