### PR TITLE
Set langchain version for crewai example

### DIFF
--- a/examples/expositional/frameworks/crewai/surprise_trip/pyproject.toml
+++ b/examples/expositional/frameworks/crewai/surprise_trip/pyproject.toml
@@ -21,10 +21,8 @@ crewai-tools = "^0.4.6"
 pip = "^24.1.1"
 langchain = ">=0.3.9"
 langchain-core = ">=0.3.21"
+trulens-core = "^1.2.0"
 
 [tool.poetry.scripts]
 surprise_travel = "surprise_travel.main:run"
 train = "surprise_travel.main:train"
-
-[trulens]
-trulens-core = "1.2.0"

--- a/examples/expositional/frameworks/crewai/surprise_trip/pyproject.toml
+++ b/examples/expositional/frameworks/crewai/surprise_trip/pyproject.toml
@@ -22,6 +22,7 @@ pip = "^24.1.1"
 langchain = ">=0.3.9"
 langchain-core = ">=0.3.21"
 trulens-core = "^1.2.0"
+trulens-dashboard = "^1.2.0"
 
 [tool.poetry.scripts]
 surprise_travel = "surprise_travel.main:run"

--- a/examples/expositional/frameworks/crewai/surprise_trip/pyproject.toml
+++ b/examples/expositional/frameworks/crewai/surprise_trip/pyproject.toml
@@ -19,6 +19,8 @@ crewai = { extras = [
 ], version = "^0.35.8" }
 crewai-tools = "^0.4.6"
 pip = "^24.1.1"
+langchain = ">=0.3.9"
+langchain-core = ">=0.3.21"
 
 [tool.poetry.scripts]
 surprise_travel = "surprise_travel.main:run"

--- a/snowflake_buffered_ingestion_100.png
+++ b/snowflake_buffered_ingestion_100.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:87a01152bcaccab8fdd6896d78784cdff87046f3f9621da5a06883c29f31c49f
-size 1916201

--- a/src/apps/langchain/pyproject.toml
+++ b/src/apps/langchain/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.8.1"
 trulens-core = { version = "^1.0.0" }
-langchain = ">=0.3.9"
-langchain-core = ">=0.3.21"
+langchain = ">=0.2.10"
+langchain-core = ">=0.2.0"
 pydantic = "^2.4.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description

Resets langchain versions in trulens-apps-langchain and defines constraints in the CrewAI example

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set specific `langchain` and `langchain-core` version constraints for CrewAI example and trulens-apps-langchain.
> 
>   - **Dependencies**:
>     - Update `langchain` to ">=0.3.9" and `langchain-core` to ">=0.3.21" in `examples/expositional/frameworks/crewai/surprise_trip/pyproject.toml`.
>     - Downgrade `langchain` to ">=0.2.10" and `langchain-core` to ">=0.2.0" in `src/apps/langchain/pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 0779a98eec0ac8b04858920ebda51feb284802c1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->