### PR TITLE
Update docs to use postgres + psycopg in order to avoid known issues with psycopg2

### DIFF
--- a/docs/blog/posts/release_blog_1dot.md
+++ b/docs/blog/posts/release_blog_1dot.md
@@ -4,7 +4,6 @@ categories:
 date: 2024-08-30
 ---
 
-
 # Moving to TruLens v1: Reliable and Modular Logging and Evaluation
 
 It has always been our goal to make it easy to build trustworthy LLM applications. Since we launched last May, the package has grown up before our eyes, morphing from a hacked-together addition to an existing project (`trulens-explain`) to a thriving, agnostic standard for tracking and evaluating LLM apps. Along the way, we’ve experienced growing pains and discovered inefficiencies in the way TruLens was built. We’ve also heard that the reasons people use TruLens today are diverse, and many of its use cases do not require its full footprint.
@@ -23,12 +22,12 @@ Split off `trulens-eval` from `trulens-explain`, and let `trulens-eval` take ove
 
 Next, we modularized _TruLens_ into a family of different packages, described below. This change is designed to minimize the overhead required for _TruLens_ developers to use the capabilities they need. For example, you can now install instrumentation packages in production without the additional dependencies required to run the dashboard.
 
-* `trulens-core` holds core abstractions for database operations, app instrumentation, guardrails and evaluation.
-* `trulens-dashboard` gives you the required capabilities to run and operate the TruLens dashboard.
-* `trulens-apps-` prefixed packages give you tools for interacting with LLM apps built with other frameworks, giving you capabilities including tracing, logging and guardrailing. These include `trulens-apps-langchain` and `trulens-apps-llamaindex` which hold our popular `TruChain` and `TruLlama` wrappers that seamlessly instrument _LangChain_ and _Llama-Index_ apps.
-* `trulens-feedback` gives you access to out of the box feedback functions required for running feedback functions. Feedback function implementations must be combined with a selected provider integration.
-* `trulens-providers-` prefixed package describes a set of integrations with other libraries for running feedback functions. Today, we offer an extensive set of integrations that allow you to run feedback functions on top of virtually any LLM. These integrations can be installed as standalone packages, and include: `trulens-providers-openai`, `trulens-providers-huggingface`, `trulens-providers-litellm`, `trulens-providers-langchain`, `trulens-providers-bedrock`, `trulens-providers-cortex`.
-* `trulens-connectors-` provide ways to log _TruLens_ traces and evaluations to other databases. In addition to connect to any `sqlalchemy` database with `trulens-core`, we've added with `trulens-connectors-snowflake` tailored specifically to connecting to Snowflake. We plan to add more connectors over time.
+- `trulens-core` holds core abstractions for database operations, app instrumentation, guardrails and evaluation.
+- `trulens-dashboard` gives you the required capabilities to run and operate the TruLens dashboard.
+- `trulens-apps-` prefixed packages give you tools for interacting with LLM apps built with other frameworks, giving you capabilities including tracing, logging and guardrailing. These include `trulens-apps-langchain` and `trulens-apps-llamaindex` which hold our popular `TruChain` and `TruLlama` wrappers that seamlessly instrument _LangChain_ and _Llama-Index_ apps.
+- `trulens-feedback` gives you access to out of the box feedback functions required for running feedback functions. Feedback function implementations must be combined with a selected provider integration.
+- `trulens-providers-` prefixed package describes a set of integrations with other libraries for running feedback functions. Today, we offer an extensive set of integrations that allow you to run feedback functions on top of virtually any LLM. These integrations can be installed as standalone packages, and include: `trulens-providers-openai`, `trulens-providers-huggingface`, `trulens-providers-litellm`, `trulens-providers-langchain`, `trulens-providers-bedrock`, `trulens-providers-cortex`.
+- `trulens-connectors-` provide ways to log _TruLens_ traces and evaluations to other databases. In addition to connect to any `sqlalchemy` database with `trulens-core`, we've added with `trulens-connectors-snowflake` tailored specifically to connecting to Snowflake. We plan to add more connectors over time.
 
 ![TruLens 1.0 Release Graphics](../../assets/images/trulens_1_release_graphic_modular.png)
 
@@ -249,7 +248,7 @@ You can see how to start a TruLens session logging to a postgres database below:
     from trulens.core import TruSession
     from trulens.core.database.connector import DefaultDBConnector
 
-    connector = DefaultDBConnector(database_url="postgresql://trulensuser:password@localhost/trulens")
+    connector = DefaultDBConnector(database_url="postgresql+psycopg://trulensuser:password@localhost/trulens")
     session = TruSession(connector=connector)
     ```
 

--- a/docs/component_guides/logging/where_to_log/index.md
+++ b/docs/component_guides/logging/where_to_log/index.md
@@ -15,14 +15,14 @@ For example, for Postgres database `trulens` running on `localhost` with usernam
     ```python
     from trulens.core.session import TruSession
     from trulens.core.database.connector.default import DefaultDBConnector
-    connector = DefaultDBConnector(database_url = "postgresql://trulensuser:password@localhost/trulens")
+    connector = DefaultDBConnector(database_url = "postgresql+psycopg://trulensuser:password@localhost/trulens")
     session = TruSession(connector = connector)
     ```
 
 After which you should receive the following message:
 
 ```
-🦑 TruSession initialized with db url postgresql://trulensuser:password@localhost/trulens.
+🦑 TruSession initialized with db url postgresql+psycopg://trulensuser:password@localhost/trulens.
 ```
 
 ## Connecting to a Database Engine
@@ -38,7 +38,7 @@ See [this article](https://docs.sqlalchemy.org/en/20/core/engines.html#database-
     from sqlalchemy import create_engine
 
     database_engine = create_engine(
-        "postgresql://trulensuser:password@localhost/trulens",
+        "postgresql+psycopg://trulensuser:password@localhost/trulens",
         connect_args={"connection_factory": MyConnectionFactory},
     )
     connector = DefaultDBConnector(database_engine = database_engine)
@@ -50,4 +50,5 @@ See [this article](https://docs.sqlalchemy.org/en/20/core/engines.html#database-
 After which you should receive the following message:
 
 ```
-🦑 TruSession initialized with db url postgresql://trulensuser:password@localhost/trulens.
+🦑 TruSession initialized with db url postgresql+psycopg://trulensuser:password@localhost/trulens.
+```

--- a/examples/expositional/use_cases/summarization_eval.ipynb
+++ b/examples/expositional/use_cases/summarization_eval.ipynb
@@ -197,7 +197,7 @@
     "session = TruSession()\n",
     "session.reset_database()\n",
     "# If you have a database you can connect to, use a URL. For example:\n",
-    "# session = TruSession(database_url=\"postgresql://hostname/database?user=username&password=password\")"
+    "# session = TruSession(database_url=\"postgresql+psycopg://hostname/database?user=username&password=password\")"
    ]
   },
   {

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -304,7 +304,7 @@ def clean_db(
             # NOTE: Sqlalchemy docs say this should be written
             # "sqlite://:memory:" but that gives an error on mac at least.
             "sqlite_file": f"sqlite:///{Path(tmp) / 'test.sqlite'}",
-            "postgres": "postgresql+psycopg2://pg-test-user:pg-test-pswd@localhost/pg-test-db",
+            "postgres": "postgresql+psycopg://pg-test-user:pg-test-pswd@localhost/pg-test-db",
             "mysql": "mysql+pymysql://mysql-test-user:mysql-test-pswd@localhost/mysql-test-db",
         }[alias]
 


### PR DESCRIPTION
# Description

#1685 raises a known issue where SQLalchemy postgres + psycopg2 has issues due to `psycopg2` not converting np floats to a storable format by default - see https://github.com/sqlalchemy/sqlalchemy/discussions/11712. This is fixed out of the box with `psycopg >= 3.2` (and demonstrated to be working in https://github.com/truera/trulens/issues/1685), so this PR aims to update the docs to guide users down this smoother path instead.



## Other details good to know for developers

It doesn't look like we're directly depending on `psycopg2`, so no package updates were made

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [x] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update documentation and tests to use `psycopg` for PostgreSQL connections, replacing `psycopg2`.
> 
>   - **Documentation**:
>     - Update PostgreSQL connection examples to use `psycopg` instead of `psycopg2` in `release_blog_1dot.md` and `index.md`.
>     - Modify example connection strings to `postgresql+psycopg://` format.
>   - **Tests**:
>     - Update test database connection string to use `psycopg` in `test_database.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for a9266180b2a513e7bd1263daa3e7b4551c035ea4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->