### PR TITLE
Custom criteria for feedback

### DIFF
--- a/docs/component_guides/evaluation/feedback_implementations/custom_feedback_functions.ipynb
+++ b/docs/component_guides/evaluation/feedback_implementations/custom_feedback_functions.ipynb
@@ -152,7 +152,7 @@
    "id": "bb804240",
    "metadata": {},
    "source": [
-    "## Groundedness configurations\n",
+    "### Groundedness configurations\n",
     "\n",
     "Groundedness has its own specific configurations that can be set with the `GroundednessConfigurations` class."
    ]
@@ -200,12 +200,72 @@
   },
   {
    "cell_type": "markdown",
+   "id": "140c9429",
+   "metadata": {},
+   "source": [
+    "## Custom Criteria\n",
+    "\n",
+    "To customize the LLM-judge prompting, you can override standard criteria with your own custom criteria.\n",
+    "\n",
+    "This can be useful to tailor LLM-judge prompting to your domain and improve alignment with human evaluations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f795de1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom_criteria = \"\"\"\n",
+    "Does the answer fully address the question? Respond 1 if yes, 0 if no.\n",
+    "\"\"\"\n",
+    "\n",
+    "provider.relevance(\n",
+    "    \"What are the key considerations when starting a small business?\",\n",
+    "    \"Find a mentor who can guide you through the early stages and help you navigate common challenges.\",\n",
+    "    criteria=custom_criteria,\n",
+    "    min_score_val=0,\n",
+    "    max_score_val=1,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "feacc998",
+   "metadata": {},
+   "source": [
+    "Custom criteria can also utilize the {min_score} and {max_score} variables to remain consistent with the output space."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bfdf4f64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom_criteria = \"\"\"\n",
+    "Does the answer fully address the question? Respond {max_score} if yes, {min_score} if no.\n",
+    "\"\"\"\n",
+    "\n",
+    "provider.relevance(\n",
+    "    \"What are the key considerations when starting a small business?\",\n",
+    "    \"Find a mentor who can guide you through the early stages and help you navigate common challenges.\",\n",
+    "    criteria=custom_criteria,\n",
+    "    min_score_val=0,\n",
+    "    max_score_val=10,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "aefe7bd1",
    "metadata": {},
    "source": [
     "### Few-shot examples\n",
     "\n",
-    "Last, you can also provide examples to customize feedback scoring to your domain.\n",
+    "You can also provide examples to customize feedback scoring to your domain.\n",
     "\n",
     "This is currently available only for the RAG triad feedback functions (answer relevance, context relevance and groundedness)."
    ]

--- a/docs/component_guides/evaluation/feedback_implementations/custom_feedback_functions.ipynb
+++ b/docs/component_guides/evaluation/feedback_implementations/custom_feedback_functions.ipynb
@@ -218,7 +218,7 @@
    "outputs": [],
    "source": [
     "custom_criteria = \"\"\"\n",
-    "Does the answer fully address the question? Respond 1 if yes, 0 if no.\n",
+    "A relevant response should provide a clear and concise answer to the question.\n",
     "\"\"\"\n",
     "\n",
     "provider.relevance(\n",
@@ -231,30 +231,19 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "feacc998",
-   "metadata": {},
-   "source": [
-    "Custom criteria can also utilize the {min_score} and {max_score} variables to remain consistent with the output space."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bfdf4f64",
+   "id": "6ce721b6",
    "metadata": {},
    "outputs": [],
    "source": [
     "custom_criteria = \"\"\"\n",
-    "Does the answer fully address the question? Respond {max_score} if yes, {min_score} if no.\n",
+    "A positive sentiment should be expressed with an extremely encouraging and enthusiastic tone.\n",
     "\"\"\"\n",
     "\n",
-    "provider.relevance(\n",
-    "    \"What are the key considerations when starting a small business?\",\n",
-    "    \"Find a mentor who can guide you through the early stages and help you navigate common challenges.\",\n",
+    "provider.sentiment(\n",
+    "    \"When you're ready to start your business, you'll be amazed at how much you can achieve!\",\n",
     "    criteria=custom_criteria,\n",
-    "    min_score_val=0,\n",
-    "    max_score_val=10,\n",
     ")"
    ]
   },
@@ -340,6 +329,7 @@
     "        provider.relevance_with_cot_reasons,\n",
     "        name=\"Answer Relevance\",\n",
     "        examples=fewshot_relevance_examples_list,\n",
+    "        criteria=custom_criteria,\n",
     "        min_score_val=0,\n",
     "        max_score_val=1,\n",
     "        temperature=0.9,\n",

--- a/docs/component_guides/evaluation/feedback_implementations/custom_feedback_functions.ipynb
+++ b/docs/component_guides/evaluation/feedback_implementations/custom_feedback_functions.ipynb
@@ -326,7 +326,7 @@
     "# Question/answer relevance between overall question and answer.\n",
     "f_answer_relevance = (\n",
     "    Feedback(\n",
-    "        provider.relevance_with_cot_reasons,\n",
+    "        provider.groundedness_measure_with_cot_reasons,\n",
     "        name=\"Answer Relevance\",\n",
     "        examples=fewshot_relevance_examples_list,\n",
     "        criteria=custom_criteria,\n",

--- a/docs/component_guides/evaluation/feedback_implementations/custom_feedback_functions.ipynb
+++ b/docs/component_guides/evaluation/feedback_implementations/custom_feedback_functions.ipynb
@@ -294,47 +294,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9a0546d5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "provider.helpfulness(\n",
-    "    \"Find a mentor who can guide you through the early stages and help you navigate common challenges.\",\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dd01b249",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "custom_criteria = \"\"\"\n",
-    "A helpful response is super enthusiastic and provides a clear and concise answer to the question.\n",
-    "\"\"\"\n",
-    "\n",
-    "provider.helpfulness(\n",
-    "    \"Find a mentor who can guide you through the early stages and help you navigate common challenges.\",\n",
-    "    criteria=custom_criteria,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5a830bd8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "provider.controversiality_with_cot_reasons(\n",
-    "    \"Find a mentor who can guide you through the early stages and help you navigate common challenges.\"\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "42d69109",
    "metadata": {},

--- a/docs/component_guides/evaluation/feedback_implementations/custom_feedback_functions.ipynb
+++ b/docs/component_guides/evaluation/feedback_implementations/custom_feedback_functions.ipynb
@@ -326,7 +326,7 @@
     "# Question/answer relevance between overall question and answer.\n",
     "f_answer_relevance = (\n",
     "    Feedback(\n",
-    "        provider.groundedness_measure_with_cot_reasons,\n",
+    "        provider.relevance_with_cot_reasons,\n",
     "        name=\"Answer Relevance\",\n",
     "        examples=fewshot_relevance_examples_list,\n",
     "        criteria=custom_criteria,\n",

--- a/docs/component_guides/evaluation/feedback_implementations/custom_feedback_functions.ipynb
+++ b/docs/component_guides/evaluation/feedback_implementations/custom_feedback_functions.ipynb
@@ -294,6 +294,47 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a0546d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "provider.helpfulness(\n",
+    "    \"Find a mentor who can guide you through the early stages and help you navigate common challenges.\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd01b249",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom_criteria = \"\"\"\n",
+    "A helpful response is super enthusiastic and provides a clear and concise answer to the question.\n",
+    "\"\"\"\n",
+    "\n",
+    "provider.helpfulness(\n",
+    "    \"Find a mentor who can guide you through the early stages and help you navigate common challenges.\",\n",
+    "    criteria=custom_criteria,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a830bd8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "provider.controversiality_with_cot_reasons(\n",
+    "    \"Find a mentor who can guide you through the early stages and help you navigate common challenges.\"\n",
+    ")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "42d69109",
    "metadata": {},

--- a/src/core/trulens/core/feedback/feedback.py
+++ b/src/core/trulens/core/feedback/feedback.py
@@ -161,6 +161,9 @@ class Feedback(feedback_schema.FeedbackDefinition):
     examples: Optional[List[Tuple]] = pydantic.Field(None, exclude=True)
     """Examples to use when evaluating the feedback function."""
 
+    criteria: Optional[str] = pydantic.Field(None, exclude=True)
+    """Criteria for the feedback function."""
+
     min_score_val: Optional[int] = pydantic.Field(None, exclude=True)
     """Minimum score value for the feedback function."""
 
@@ -180,6 +183,7 @@ class Feedback(feedback_schema.FeedbackDefinition):
         imp: Optional[Callable] = None,
         agg: Optional[Callable] = None,
         examples: Optional[List[Tuple]] = None,
+        criteria: Optional[str] = None,
         min_score_val: Optional[int] = 0,
         max_score_val: Optional[int] = 3,
         temperature: Optional[float] = 0.0,
@@ -267,6 +271,7 @@ class Feedback(feedback_schema.FeedbackDefinition):
         self.imp = imp
         self.agg = agg
         self.examples = examples
+        self.criteria = criteria
         self.min_score_val = min_score_val
         self.max_score_val = max_score_val
         self.temperature = temperature
@@ -485,6 +490,8 @@ class Feedback(feedback_schema.FeedbackDefinition):
         ), "Feedback definition needs an implementation to call."
         if self.examples is not None:
             kwargs["examples"] = self.examples
+        if self.criteria is not None:
+            kwargs["criteria"] = self.criteria
         if self.min_score_val is not None:
             kwargs["min_score_val"] = self.min_score_val
         if self.max_score_val is not None:

--- a/src/core/trulens/core/schema/feedback.py
+++ b/src/core/trulens/core/schema/feedback.py
@@ -338,6 +338,9 @@ class FeedbackDefinition(
     examples: Optional[List[Tuple]] = None
     """User supplied examples for this feedback function."""
 
+    criteria: Optional[str] = None
+    """Criteria for the feedback function."""
+
     combinations: Optional[FeedbackCombinations] = FeedbackCombinations.PRODUCT
     """Mode of combining selected values to produce arguments to each feedback
     function call."""
@@ -382,6 +385,7 @@ class FeedbackDefinition(
             Union[pyschema_utils.Function, pyschema_utils.Method]
         ] = None,
         examples: Optional[List[Tuple]] = None,
+        criteria: Optional[str] = None,
         if_exists: Optional[serial_utils.Lens] = None,
         if_missing: FeedbackOnMissingParameters = FeedbackOnMissingParameters.ERROR,
         selectors: Optional[Dict[str, serial_utils.Lens]] = None,
@@ -400,6 +404,7 @@ class FeedbackDefinition(
             implementation=implementation,
             aggregator=aggregator,
             examples=examples,
+            criteria=criteria,
             selectors=selectors,
             if_exists=if_exists,
             if_missing=if_missing,

--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -637,7 +637,11 @@ class LLMProvider(core_provider.Provider):
         )
 
     def sentiment(
-        self, text: str, min_score_val: int = 0, max_score_val: int = 3
+        self,
+        text: str,
+        min_score_val: int = 0,
+        max_score_val: int = 3,
+        criteria: str = None,
     ) -> float:
         """
         Uses chat completion model. A function that completes a template to
@@ -657,9 +661,18 @@ class LLMProvider(core_provider.Provider):
             A value between 0 and 1. 0 being "negative sentiment" and 1
                 being "positive sentiment".
         """
-        system_prompt = feedback_prompts.SENTIMENT_SYSTEM.format(
-            min_score=min_score_val, max_score=max_score_val
+
+        output_space = self._determine_output_space(
+            min_score_val=min_score_val, max_score_val=max_score_val
         )
+
+        system_prompt = feedback_v2.Sentiment.generate_system_prompt(
+            min_score=min_score_val,
+            max_score=max_score_val,
+            criteria=criteria,
+            output_space=output_space,
+        )
+
         user_prompt = feedback_prompts.SENTIMENT_USER + text
         return self.generate_score(
             system_prompt,

--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -354,8 +354,8 @@ class LLMProvider(core_provider.Provider):
             min_score=min_score_val,
             max_score=max_score_val,
             criteria=criteria,
-            output_space=output_space,
             examples=examples,
+            output_space=output_space,
         )
 
         return self.generate_score(
@@ -553,8 +553,8 @@ class LLMProvider(core_provider.Provider):
                 min_score=min_score_val,
                 max_score=max_score_val,
                 criteria=criteria,
-                output_space=output_space,
                 examples=examples,
+                output_space=output_space,
             )
         )
 
@@ -639,9 +639,11 @@ class LLMProvider(core_provider.Provider):
     def sentiment(
         self,
         text: str,
+        criteria: str = None,
+        examples: Optional[List[str]] = None,
         min_score_val: int = 0,
         max_score_val: int = 3,
-        criteria: str = None,
+        temperature: float = 0.0,
     ) -> float:
         """
         Uses chat completion model. A function that completes a template to
@@ -670,6 +672,7 @@ class LLMProvider(core_provider.Provider):
             min_score=min_score_val,
             max_score=max_score_val,
             criteria=criteria,
+            examples=examples,
             output_space=output_space,
         )
 
@@ -679,11 +682,14 @@ class LLMProvider(core_provider.Provider):
             user_prompt,
             min_score_val=min_score_val,
             max_score_val=max_score_val,
+            temperature=temperature,
         )
 
     def sentiment_with_cot_reasons(
         self,
         text: str,
+        criteria: str = None,
+        examples: Optional[List[str]] = None,
         min_score_val: int = 0,
         max_score_val: int = 3,
         temperature: float = 0.0,
@@ -707,7 +713,17 @@ class LLMProvider(core_provider.Provider):
         Returns:
             float: A value between 0.0 (negative sentiment) and 1.0 (positive sentiment).
         """
-        system_prompt = feedback_prompts.SENTIMENT_SYSTEM
+        output_space = self._determine_output_space(
+            min_score_val=min_score_val, max_score_val=max_score_val
+        )
+
+        system_prompt = feedback_v2.Sentiment.generate_system_prompt(
+            min_score=min_score_val,
+            max_score=max_score_val,
+            criteria=criteria,
+            examples=examples,
+            output_space=output_space,
+        )
         user_prompt = (
             feedback_prompts.SENTIMENT_USER
             + text

--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -778,9 +778,10 @@ class LLMProvider(core_provider.Provider):
     def _langchain_evaluate(
         self,
         text: str,
-        criteria: str,
-        min_score_val: int = 0,
-        max_score_val: int = 3,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
     ) -> float:
         """
         Uses chat completion model. A general function that completes a template
@@ -796,6 +797,7 @@ class LLMProvider(core_provider.Provider):
             float: A value between 0.0 and 1.0, representing the specified
                 evaluation.
         """
+
         criteria = criteria.format(
             min_score=min_score_val, max_score=max_score_val
         )
@@ -812,15 +814,16 @@ class LLMProvider(core_provider.Provider):
             user_prompt,
             min_score_val=min_score_val,
             max_score_val=max_score_val,
+            temperature=temperature,
         )
 
     def _langchain_evaluate_with_cot_reasons(
         self,
         text: str,
-        criteria: str,
-        min_score_val: int = 0,
-        max_score_val: int = 3,
-        temperature: float = 0.0,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
     ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A general function that completes a template
@@ -856,7 +859,14 @@ class LLMProvider(core_provider.Provider):
             temperature=temperature,
         )
 
-    def conciseness(self, text: str) -> float:
+    def conciseness(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> float:
         """
         Uses chat completion model. A function that completes a template to
         check the conciseness of some text. Prompt credit to LangChain Eval.
@@ -873,12 +883,24 @@ class LLMProvider(core_provider.Provider):
             A value between 0.0 (not concise) and 1.0 (concise).
 
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_CONCISENESS_SYSTEM_PROMPT
         return self._langchain_evaluate(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_CONCISENESS_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-    def conciseness_with_cot_reasons(self, text: str) -> Tuple[float, Dict]:
+    def conciseness_with_cot_reasons(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A function that completes a template to
         check the conciseness of some text. Prompt credit to LangChain Eval.
@@ -893,12 +915,17 @@ class LLMProvider(core_provider.Provider):
         Returns:
             Tuple[float, str]: A tuple containing a value between 0.0 (not concise) and 1.0 (concise) and a string containing the reasons for the evaluation.
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_CONCISENESS_SYSTEM_PROMPT
         return self._langchain_evaluate_with_cot_reasons(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_CONCISENESS_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-    def correctness(self, text: str) -> float:
+    def correctness(self, text: str, criteria: str) -> float:
         """
         Uses chat completion model. A function that completes a template to
         check the correctness of some text. Prompt credit to LangChain Eval.
@@ -914,12 +941,21 @@ class LLMProvider(core_provider.Provider):
         Returns:
             A value between 0.0 (not correct) and 1.0 (correct).
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_CORRECTNESS_SYSTEM_PROMPT
         return self._langchain_evaluate(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_CORRECTNESS_SYSTEM_PROMPT,
+            criteria=criteria,
         )
 
-    def correctness_with_cot_reasons(self, text: str) -> Tuple[float, Dict]:
+    def correctness_with_cot_reasons(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A function that completes a template to
         check the correctness of some text. Prompt credit to LangChain Eval.
@@ -936,12 +972,24 @@ class LLMProvider(core_provider.Provider):
         Returns:
             Tuple[float, str]: A tuple containing a value between 0 (not correct) and 1.0 (correct) and a string containing the reasons for the evaluation.
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_CORRECTNESS_SYSTEM_PROMPT
         return self._langchain_evaluate_with_cot_reasons(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_CORRECTNESS_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-    def coherence(self, text: str) -> float:
+    def coherence(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> float:
         """
         Uses chat completion model. A function that completes a
         template to check the coherence of some text. Prompt credit to LangChain Eval.
@@ -957,12 +1005,24 @@ class LLMProvider(core_provider.Provider):
         Returns:
             float: A value between 0.0 (not coherent) and 1.0 (coherent).
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_COHERENCE_SYSTEM_PROMPT
         return self._langchain_evaluate(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_COHERENCE_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-    def coherence_with_cot_reasons(self, text: str) -> Tuple[float, Dict]:
+    def coherence_with_cot_reasons(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A function that completes a template to
         check the coherence of some text. Prompt credit to LangChain Eval. Also
@@ -979,12 +1039,24 @@ class LLMProvider(core_provider.Provider):
         Returns:
             Tuple[float, str]: A tuple containing a value between 0 (not coherent) and 1.0 (coherent) and a string containing the reasons for the evaluation.
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_COHERENCE_SYSTEM_PROMPT
         return self._langchain_evaluate_with_cot_reasons(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_COHERENCE_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-    def harmfulness(self, text: str) -> float:
+    def harmfulness(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> float:
         """
         Uses chat completion model. A function that completes a template to
         check the harmfulness of some text. Prompt credit to LangChain Eval.
@@ -1000,12 +1072,24 @@ class LLMProvider(core_provider.Provider):
         Returns:
             float: A value between 0.0 (not harmful) and 1.0 (harmful)".
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_HARMFULNESS_SYSTEM_PROMPT
         return self._langchain_evaluate(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_HARMFULNESS_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-    def harmfulness_with_cot_reasons(self, text: str) -> Tuple[float, Dict]:
+    def harmfulness_with_cot_reasons(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A function that completes a template to
         check the harmfulness of some text. Prompt credit to LangChain Eval.
@@ -1023,12 +1107,24 @@ class LLMProvider(core_provider.Provider):
             Tuple[float, str]: A tuple containing a value between 0 (not harmful) and 1.0 (harmful) and a string containing the reasons for the evaluation.
         """
 
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_HARMFULNESS_SYSTEM_PROMPT
         return self._langchain_evaluate_with_cot_reasons(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_HARMFULNESS_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-    def maliciousness(self, text: str) -> float:
+    def maliciousness(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> float:
         """
         Uses chat completion model. A function that completes a template to
         check the maliciousness of some text. Prompt credit to LangChain Eval.
@@ -1045,12 +1141,24 @@ class LLMProvider(core_provider.Provider):
             float: A value between 0.0 (not malicious) and 1.0 (malicious).
         """
 
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_MALICIOUSNESS_SYSTEM_PROMPT
         return self._langchain_evaluate(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_MALICIOUSNESS_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-    def maliciousness_with_cot_reasons(self, text: str) -> Tuple[float, Dict]:
+    def maliciousness_with_cot_reasons(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A function that completes a
         template to check the maliciousness of some text. Prompt credit to LangChain Eval.
@@ -1067,12 +1175,24 @@ class LLMProvider(core_provider.Provider):
         Returns:
             Tuple[float, str]: A tuple containing a value between 0 (not malicious) and 1.0 (malicious) and a string containing the reasons for the evaluation.
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_MALICIOUSNESS_SYSTEM_PROMPT
         return self._langchain_evaluate_with_cot_reasons(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_MALICIOUSNESS_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-    def helpfulness(self, text: str) -> float:
+    def helpfulness(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> float:
         """
         Uses chat completion model. A function that completes a template to
         check the helpfulness of some text. Prompt credit to LangChain Eval.
@@ -1088,12 +1208,24 @@ class LLMProvider(core_provider.Provider):
         Returns:
             float: A value between 0.0 (not helpful) and 1.0 (helpful).
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_HELPFULNESS_SYSTEM_PROMPT
         return self._langchain_evaluate(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_HELPFULNESS_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-    def helpfulness_with_cot_reasons(self, text: str) -> Tuple[float, Dict]:
+    def helpfulness_with_cot_reasons(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A function that completes a template to
         check the helpfulness of some text. Prompt credit to LangChain Eval.
@@ -1110,12 +1242,24 @@ class LLMProvider(core_provider.Provider):
         Returns:
             Tuple[float, str]: A tuple containing a value between 0 (not helpful) and 1.0 (helpful) and a string containing the reasons for the evaluation.
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_HELPFULNESS_SYSTEM_PROMPT
         return self._langchain_evaluate_with_cot_reasons(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_HELPFULNESS_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-    def controversiality(self, text: str) -> float:
+    def controversiality(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> float:
         """
         Uses chat completion model. A function that completes a template to
         check the controversiality of some text. Prompt credit to Langchain
@@ -1133,13 +1277,23 @@ class LLMProvider(core_provider.Provider):
             float: A value between 0.0 (not controversial) and 1.0
                 (controversial).
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_CONTROVERSIALITY_SYSTEM_PROMPT
         return self._langchain_evaluate(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_CONTROVERSIALITY_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
     def controversiality_with_cot_reasons(
-        self, text: str
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
     ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A function that completes a template to
@@ -1157,12 +1311,24 @@ class LLMProvider(core_provider.Provider):
         Returns:
             Tuple[float, str]: A tuple containing a value between 0 (not controversial) and 1.0 (controversial) and a string containing the reasons for the evaluation.
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_CONTROVERSIALITY_SYSTEM_PROMPT
         return self._langchain_evaluate_with_cot_reasons(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_CONTROVERSIALITY_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-    def misogyny(self, text: str) -> float:
+    def misogyny(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> float:
         """
         Uses chat completion model. A function that completes a template to
         check the misogyny of some text. Prompt credit to LangChain Eval.
@@ -1178,12 +1344,24 @@ class LLMProvider(core_provider.Provider):
         Returns:
             float: A value between 0.0 (not misogynistic) and 1.0 (misogynistic).
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_MISOGYNY_SYSTEM_PROMPT
         return self._langchain_evaluate(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_MISOGYNY_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-    def misogyny_with_cot_reasons(self, text: str) -> Tuple[float, Dict]:
+    def misogyny_with_cot_reasons(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A function that completes a template to
         check the misogyny of some text. Prompt credit to LangChain Eval. Also
@@ -1200,12 +1378,24 @@ class LLMProvider(core_provider.Provider):
         Returns:
             Tuple[float, str]: A tuple containing a value between 0.0 (not misogynistic) and 1.0 (misogynistic) and a string containing the reasons for the evaluation.
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_MISOGYNY_SYSTEM_PROMPT
         return self._langchain_evaluate_with_cot_reasons(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_MISOGYNY_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-    def criminality(self, text: str) -> float:
+    def criminality(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> float:
         """
         Uses chat completion model. A function that completes a template to
         check the criminality of some text. Prompt credit to LangChain Eval.
@@ -1222,12 +1412,24 @@ class LLMProvider(core_provider.Provider):
             float: A value between 0.0 (not criminal) and 1.0 (criminal).
 
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_CRIMINALITY_SYSTEM_PROMPT
         return self._langchain_evaluate(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_CRIMINALITY_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-    def criminality_with_cot_reasons(self, text: str) -> Tuple[float, Dict]:
+    def criminality_with_cot_reasons(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A function that completes a template to
         check the criminality of some text. Prompt credit to LangChain Eval.
@@ -1244,12 +1446,24 @@ class LLMProvider(core_provider.Provider):
         Returns:
             Tuple[float, str]: A tuple containing a value between 0.0 (not criminal) and 1.0 (criminal) and a string containing the reasons for the evaluation.
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_CRIMINALITY_SYSTEM_PROMPT
         return self._langchain_evaluate_with_cot_reasons(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_CRIMINALITY_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-    def insensitivity(self, text: str) -> float:
+    def insensitivity(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> float:
         """
         Uses chat completion model. A function that completes a template to
         check the insensitivity of some text. Prompt credit to LangChain Eval.
@@ -1265,12 +1479,24 @@ class LLMProvider(core_provider.Provider):
         Returns:
             float: A value between 0.0 (not insensitive) and 1.0 (insensitive).
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_INSENSITIVITY_SYSTEM_PROMPT
         return self._langchain_evaluate(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_INSENSITIVITY_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-    def insensitivity_with_cot_reasons(self, text: str) -> Tuple[float, Dict]:
+    def insensitivity_with_cot_reasons(
+        self,
+        text: str,
+        criteria: Optional[str] = None,
+        min_score_val: Optional[int] = 0,
+        max_score_val: Optional[int] = 3,
+        temperature: Optional[float] = 0.0,
+    ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A function that completes a template to
         check the insensitivity of some text. Prompt credit to LangChain Eval.
@@ -1287,9 +1513,14 @@ class LLMProvider(core_provider.Provider):
         Returns:
             Tuple[float, str]: A tuple containing a value between 0.0 (not insensitive) and 1.0 (insensitive) and a string containing the reasons for the evaluation.
         """
+        if criteria is None:
+            criteria = feedback_prompts.LANGCHAIN_INSENSITIVITY_SYSTEM_PROMPT
         return self._langchain_evaluate_with_cot_reasons(
             text=text,
-            criteria=feedback_prompts.LANGCHAIN_INSENSITIVITY_SYSTEM_PROMPT,
+            criteria=criteria,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
     def _get_answer_agreement(

--- a/src/feedback/trulens/feedback/prompts.py
+++ b/src/feedback/trulens/feedback/prompts.py
@@ -143,34 +143,6 @@ GENERATE_KEY_POINTS_USER_PROMPT = """
 /END OF SOURCE TEXT/
 """
 
-COMPREHENSIVENESS_SYSTEM_PROMPT = """
-You are tasked with evaluating summarization quality. Please follow the instructions below.
+COMPREHENSIVENESS_SYSTEM_PROMPT = v2.Comprehensiveness.system_prompt
 
-INSTRUCTIONS:
-
-1. Given a key point, score well the summary captures that key points.
-
-Are the key points from the source text comprehensively included in the summary? More important key points matter more in the evaluation.
-
-Scoring criteria:
-{min_score} - The key point is not included in the summary.
-A middle score - The key point is vaguely mentioned or partially included in the summary.
-{max_score} - The key point is fully included in the summary.
-
-Answer using the entire template below.
-
-TEMPLATE:
-Score: <The score from {min_score} (the key point is not captured at all) to {max_score} (the key point is fully captured).>
-Key Point: <Mention the key point from the source text being evaluated>
-Supporting Evidence: <Evidence of whether the key point is present or absent in the summary.>
-"""
-
-COMPREHENSIVENESS_USER_PROMPT = """
-/KEY POINT/
-{key_point}
-/END OF KEY POINT/
-
-/SUMMARY/
-{summary}
-/END OF SUMMARY/
-"""
+COMPREHENSIVENESS_USER_PROMPT = v2.Comprehensiveness.user_prompt

--- a/src/feedback/trulens/feedback/v2/feedback.py
+++ b/src/feedback/trulens/feedback/v2/feedback.py
@@ -330,8 +330,6 @@ class CriteriaOutputSpaceMixin:
             formatted_examples = fewshot_examples.format_examples()
             prompt += formatted_examples
 
-        print(prompt)
-
         return prompt
 
 

--- a/src/feedback/trulens/feedback/v2/feedback.py
+++ b/src/feedback/trulens/feedback/v2/feedback.py
@@ -350,13 +350,9 @@ class Relevance(Semantics):
 
 
 class Groundedness(Semantics, WithPrompt, CriteriaOutputSpaceMixin):
-    # hugs._summarized_groundedness
-    # hugs._doc_groundedness
-
     output_space_prompt: ClassVar[str] = LIKERT_0_3_PROMPT
     output_space: ClassVar[str] = OutputSpace.LIKERT_0_3.name
     criteria_template: ClassVar[str] = """
-    You should score the groundedness of the statement based on the following criteria:
     - Statements that are directly supported by the source should be considered grounded and should get a high score.
     - Statements that are not directly supported by the source should be considered not grounded and should get a low score.
     - Statements of doubt, that admissions of uncertainty or not knowing the answer are considered abstention, and should be counted as the most overlap and therefore get a max score of {max_score}.
@@ -367,7 +363,9 @@ class Groundedness(Semantics, WithPrompt, CriteriaOutputSpaceMixin):
 
         Respond only as a number from {output_space_prompt}.
 
+        You should score the groundedness of the statement based on the following criteria:
         {criteria}
+
         Never elaborate."""
     )
 
@@ -590,9 +588,6 @@ class Sentiment(Semantics, WithPrompt, CriteriaOutputSpaceMixin):
 
 
 class Helpfulness(Semantics):
-    # openai.helpfulness
-    # openai.helpfulness_with_cot_reasons
-
     # langchain Criteria.HELPFULNESS
     system_prompt: ClassVar[str] = cleandoc(
         f"""{supported_criteria["helpfulness"]}

--- a/src/feedback/trulens/feedback/v2/feedback.py
+++ b/src/feedback/trulens/feedback/v2/feedback.py
@@ -601,7 +601,6 @@ class Helpfulness(Semantics, CriteriaOutputSpaceMixin):
 
     system_prompt_template: ClassVar[str] = cleandoc(
         """
-        Criteria for evluating helpfulness:
         {criteria}
         """
     )
@@ -616,18 +615,30 @@ class Helpfulness(Semantics, CriteriaOutputSpaceMixin):
 
 
 class Controversiality(Semantics):
-    # openai.controversiality
-    # openai.controversiality_with_cot_reasons
+    output_space_prompt: ClassVar[str] = LIKERT_0_3_PROMPT
+    output_space: ClassVar[str] = OutputSpace.LIKERT_0_3.name
+    criteria_template: ClassVar[str] = f"""
+        {supported_criteria["controversiality"]}
+        """
 
-    # langchain Criteria.CONTROVERSIALITY
-    system_prompt: ClassVar[str] = cleandoc(
-        f"""{supported_criteria["controversiality"]}
-
-        Criteria for evluating controversiality:
-        {"{criteria}"}
-
-        Respond only as a number from {"{min_score}"} (least controversial) to {"{max_score}"} (most controversial)."""
+    criteria: ClassVar[str] = criteria_template.format(
+        min_score=OutputSpace.LIKERT_0_3.value[0],
+        max_score=OutputSpace.LIKERT_0_3.value[1],
     )
+
+    system_prompt_template: ClassVar[str] = cleandoc(
+        """
+        {criteria}
+        """
+    )
+
+    system_prompt: ClassVar[str] = cleandoc(
+        system_prompt_template.format(
+            output_space_prompt=output_space_prompt, criteria=criteria
+        )
+    )
+
+    user_prompt: ClassVar[str] = cleandoc("""Submission: """)
 
 
 class Moderation(Semantics):
@@ -657,13 +668,30 @@ class Legality(Semantics):
 
 
 class Criminality(Legality, WithPrompt):
-    # openai.criminality
-    # openai.criminality_with_cot_reasons
+    output_space_prompt: ClassVar[str] = LIKERT_0_3_PROMPT
+    output_space: ClassVar[str] = OutputSpace.LIKERT_0_3.name
+    criteria_template: ClassVar[str] = f"""
+        {supported_criteria["criminality"]}
+        """
 
-    # langchain Criteria.CRIMINALITY
-    system_prompt: ClassVar[str] = cleandoc(
-        f"""{supported_criteria["criminality"]} Respond only as a number from {"{min_score}"} (least criminal) to {"{max_score}"} (most criminal)."""
+    criteria: ClassVar[str] = criteria_template.format(
+        min_score=OutputSpace.LIKERT_0_3.value[0],
+        max_score=OutputSpace.LIKERT_0_3.value[1],
     )
+
+    system_prompt_template: ClassVar[str] = cleandoc(
+        """
+        {criteria}
+        """
+    )
+
+    system_prompt: ClassVar[str] = cleandoc(
+        system_prompt_template.format(
+            output_space_prompt=output_space_prompt, criteria=criteria
+        )
+    )
+
+    user_prompt: ClassVar[str] = cleandoc("""Submission: """)
 
 
 class Harmfulness(Moderation, WithPrompt):
@@ -671,10 +699,30 @@ class Harmfulness(Moderation, WithPrompt):
     Examples of Harmfulness:
     """
 
-    # langchain Criteria.HARMFULNESS
-    system_prompt: ClassVar[str] = cleandoc(
-        f"""{supported_criteria["harmfulness"]} Respond only as a number from {"{min_score}"} (least harmful) to {"{max_score}"} (most harmful)."""
+    output_space_prompt: ClassVar[str] = LIKERT_0_3_PROMPT
+    output_space: ClassVar[str] = OutputSpace.LIKERT_0_3.name
+    criteria_template: ClassVar[str] = f"""
+        {supported_criteria["harmfulness"]}
+        """
+
+    criteria: ClassVar[str] = criteria_template.format(
+        min_score=OutputSpace.LIKERT_0_3.value[0],
+        max_score=OutputSpace.LIKERT_0_3.value[1],
     )
+
+    system_prompt_template: ClassVar[str] = cleandoc(
+        """
+        {criteria}
+        """
+    )
+
+    system_prompt: ClassVar[str] = cleandoc(
+        system_prompt_template.format(
+            output_space_prompt=output_space_prompt, criteria=criteria
+        )
+    )
+
+    user_prompt: ClassVar[str] = cleandoc("""Submission: """)
 
 
 class Insensitivity(Semantics, WithPrompt):  # categorize
@@ -684,10 +732,30 @@ class Insensitivity(Semantics, WithPrompt):  # categorize
     Examples and categorization of racial insensitivity: https://sph.umn.edu/site/docs/hewg/microaggressions.pdf .
     """
 
-    # langchain Criteria.INSENSITIVITY
-    system_prompt: ClassVar[str] = cleandoc(
-        f"""{supported_criteria["insensitivity"]} Respond only as a number from {"{min_score}"} (least insensitive) to {"{max_score}"} (most insensitive)."""
+    output_space_prompt: ClassVar[str] = LIKERT_0_3_PROMPT
+    output_space: ClassVar[str] = OutputSpace.LIKERT_0_3.name
+    criteria_template: ClassVar[str] = f"""
+        {supported_criteria["insensitivity"]}
+        """
+
+    criteria: ClassVar[str] = criteria_template.format(
+        min_score=OutputSpace.LIKERT_0_3.value[0],
+        max_score=OutputSpace.LIKERT_0_3.value[1],
     )
+
+    system_prompt_template: ClassVar[str] = cleandoc(
+        """
+        {criteria}
+        """
+    )
+
+    system_prompt: ClassVar[str] = cleandoc(
+        system_prompt_template.format(
+            output_space_prompt=output_space_prompt, criteria=criteria
+        )
+    )
+
+    user_prompt: ClassVar[str] = cleandoc("""Submission: """)
 
 
 class Toxicity(Semantics):
@@ -701,10 +769,29 @@ class Maliciousness(Moderation, WithPrompt):
 
     """
 
-    # langchain Criteria.MALICIOUSNESS
-    system_prompt: ClassVar[str] = cleandoc(
-        f"""{supported_criteria["maliciousness"]} Respond only as a number from {"{min_score}"} (least malicious) to {"{max_score}"} (most malicious)."""
+    output_space_prompt: ClassVar[str] = LIKERT_0_3_PROMPT
+    output_space: ClassVar[str] = OutputSpace.LIKERT_0_3.name
+    criteria_template: ClassVar[str] = f"""
+        {supported_criteria["maliciousness"]}
+        """
+
+    criteria: ClassVar[str] = criteria_template.format(
+        min_score=OutputSpace.LIKERT_0_3.value[0],
+        max_score=OutputSpace.LIKERT_0_3.value[1],
     )
+
+    system_prompt_template: ClassVar[str] = cleandoc(
+        """
+        {criteria}
+        """
+    )
+
+    system_prompt: ClassVar[str] = cleandoc(
+        system_prompt_template.format(
+            output_space_prompt=output_space_prompt, criteria=criteria
+        )
+    )
+
     user_prompt: ClassVar[str] = cleandoc("""Submission: """)
 
 
@@ -719,13 +806,30 @@ class Hate(Moderation):
 
 
 class Misogyny(Hate, WithPrompt):
-    # openai.misogyny
-    # openai.misogyny_with_cot_reasons
+    output_space_prompt: ClassVar[str] = LIKERT_0_3_PROMPT
+    output_space: ClassVar[str] = OutputSpace.LIKERT_0_3.name
+    criteria_template: ClassVar[str] = f"""
+        {supported_criteria["misogyny"]}
+        """
 
-    # langchain Criteria.MISOGYNY
-    system_prompt: ClassVar[str] = cleandoc(
-        f"""{supported_criteria["misogyny"]} Respond only as a number from {"{min_score}"} (least misogynistic) to {"{max_score}"} (most misogynistic)."""
+    criteria: ClassVar[str] = criteria_template.format(
+        min_score=OutputSpace.LIKERT_0_3.value[0],
+        max_score=OutputSpace.LIKERT_0_3.value[1],
     )
+
+    system_prompt_template: ClassVar[str] = cleandoc(
+        """
+        {criteria}
+        """
+    )
+
+    system_prompt: ClassVar[str] = cleandoc(
+        system_prompt_template.format(
+            output_space_prompt=output_space_prompt, criteria=criteria
+        )
+    )
+
+    user_prompt: ClassVar[str] = cleandoc("""Submission: """)
 
 
 class HateThreatening(Hate):

--- a/src/feedback/trulens/feedback/v2/feedback.py
+++ b/src/feedback/trulens/feedback/v2/feedback.py
@@ -587,18 +587,32 @@ class Sentiment(Semantics, WithPrompt, CriteriaOutputSpaceMixin):
     user_prompt: ClassVar[str] = cleandoc("""Submission: """)
 
 
-class Helpfulness(Semantics):
-    # langchain Criteria.HELPFULNESS
-    system_prompt: ClassVar[str] = cleandoc(
-        f"""{supported_criteria["helpfulness"]}
+class Helpfulness(Semantics, CriteriaOutputSpaceMixin):
+    output_space_prompt: ClassVar[str] = LIKERT_0_3_PROMPT
+    output_space: ClassVar[str] = OutputSpace.LIKERT_0_3.name
+    criteria_template: ClassVar[str] = f"""
+        {supported_criteria["helpfulness"]}
+        """
 
+    criteria: ClassVar[str] = criteria_template.format(
+        min_score=OutputSpace.LIKERT_0_3.value[0],
+        max_score=OutputSpace.LIKERT_0_3.value[1],
+    )
+
+    system_prompt_template: ClassVar[str] = cleandoc(
+        """
         Criteria for evluating helpfulness:
-        {"{criteria}"}
-
-        Respond only as a number from {"{min_score}"} (least helpful) to {"{max_score}"} (most helpful).
-
+        {criteria}
         """
     )
+
+    system_prompt: ClassVar[str] = cleandoc(
+        system_prompt_template.format(
+            output_space_prompt=output_space_prompt, criteria=criteria
+        )
+    )
+
+    user_prompt: ClassVar[str] = cleandoc("""Submission: """)
 
 
 class Controversiality(Semantics):

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -2389,6 +2389,20 @@ trulens.feedback.v2.feedback.BinarySentimentModel:
     feedback: trulens.feedback.v2.feedback.Feedback
     id: builtins.str
     output_type: trulens.feedback.v2.feedback.FeedbackOutputType
+trulens.feedback.v2.feedback.Comprehensiveness:
+  __bases__:
+  - trulens.feedback.v2.feedback.Semantics
+  - trulens.feedback.v2.feedback.WithPrompt
+  - trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin
+  __class__: pydantic._internal._model_construction.ModelMetaclass
+  attributes:
+    criteria: builtins.str
+    criteria_template: builtins.str
+    output_space: builtins.str
+    output_space_prompt: builtins.str
+    system_prompt: builtins.str
+    system_prompt_template: builtins.str
+    user_prompt: builtins.str
 trulens.feedback.v2.feedback.COTExplained:
   __bases__:
   - trulens.feedback.v2.feedback.Feedback
@@ -2465,6 +2479,7 @@ trulens.feedback.v2.feedback.Criminality:
   __bases__:
   - trulens.feedback.v2.feedback.Legality
   - trulens.feedback.v2.feedback.WithPrompt
+  - trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
     languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
@@ -2593,6 +2608,7 @@ trulens.feedback.v2.feedback.Harmfulness:
   __bases__:
   - trulens.feedback.v2.feedback.Moderation
   - trulens.feedback.v2.feedback.WithPrompt
+  - trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
     languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
@@ -2734,6 +2750,7 @@ trulens.feedback.v2.feedback.Sentiment:
   __bases__:
   - trulens.feedback.v2.feedback.Semantics
   - trulens.feedback.v2.feedback.WithPrompt
+  - trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
     languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
@@ -2755,6 +2772,7 @@ trulens.feedback.v2.feedback.Stereotypes:
   __bases__:
   - trulens.feedback.v2.feedback.Moderation
   - trulens.feedback.v2.feedback.WithPrompt
+  - trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
     languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -2397,7 +2397,7 @@ trulens.feedback.v2.feedback.Comprehensiveness:
   - trulens.feedback.v2.feedback.Semantics
   - trulens.feedback.v2.feedback.WithPrompt
   - trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin
-  __class__: pydantic._internal._model_construction.ModelMetaclass
+  __class__: pydantic.main.ModelMetaclass
   attributes:
     criteria: builtins.str
     criteria_template: builtins.str

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -2397,7 +2397,7 @@ trulens.feedback.v2.feedback.Comprehensiveness:
   - trulens.feedback.v2.feedback.Semantics
   - trulens.feedback.v2.feedback.WithPrompt
   - trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin
-  __class__: pydantic.main.ModelMetaclass
+  __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
     criteria: builtins.str
     criteria_template: builtins.str

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -2401,12 +2401,12 @@ trulens.feedback.v2.feedback.Comprehensiveness:
   attributes:
     criteria: builtins.str
     criteria_template: builtins.str
+    languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
     output_space: builtins.str
     output_space_prompt: builtins.str
     system_prompt: builtins.str
     system_prompt_template: builtins.str
     user_prompt: builtins.str
-    languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
 trulens.feedback.v2.feedback.COTExplained:
   __bases__:
   - trulens.feedback.v2.feedback.Feedback

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -2406,6 +2406,7 @@ trulens.feedback.v2.feedback.Comprehensiveness:
     system_prompt: builtins.str
     system_prompt_template: builtins.str
     user_prompt: builtins.str
+    languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
 trulens.feedback.v2.feedback.COTExplained:
   __bases__:
   - trulens.feedback.v2.feedback.Feedback
@@ -2488,7 +2489,6 @@ trulens.feedback.v2.feedback.Criminality:
   __bases__:
   - trulens.feedback.v2.feedback.Legality
   - trulens.feedback.v2.feedback.WithPrompt
-  - trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
     criteria: builtins.str
@@ -2623,7 +2623,6 @@ trulens.feedback.v2.feedback.Harmfulness:
   __bases__:
   - trulens.feedback.v2.feedback.Moderation
   - trulens.feedback.v2.feedback.WithPrompt
-  - trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
     criteria: builtins.str
@@ -2649,6 +2648,7 @@ trulens.feedback.v2.feedback.HateThreatening:
 trulens.feedback.v2.feedback.Helpfulness:
   __bases__:
   - trulens.feedback.v2.feedback.Semantics
+  - trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
     criteria: builtins.str

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -538,6 +538,7 @@ trulens.core.feedback.feedback.Feedback:
     aggregator: typing.Union[trulens.core.utils.pyschema.Function, trulens.core.utils.pyschema.Method,
       builtins.NoneType]
     check_selectors: builtins.function
+    criteria: typing.Optional[builtins.str, builtins.NoneType]
     combinations: typing.Optional[trulens.core.schema.feedback.FeedbackCombinations,
       builtins.NoneType]
     evaluate_deferred: builtins.staticmethod
@@ -600,6 +601,7 @@ trulens.core.feedback.feedback.SnowflakeFeedback:
       builtins.NoneType]
     combinations: typing.Optional[trulens.core.schema.feedback.FeedbackCombinations,
       builtins.NoneType]
+    criteria: typing.Optional[builtins.str, builtins.NoneType]
     examples: typing.Optional[typing.List[typing.Tuple], builtins.NoneType]
     feedback_definition_id: builtins.str
     groundedness_configs: typing.Optional[trulens.core.feedback.feedback.GroundednessConfigs,
@@ -899,6 +901,7 @@ trulens.core.schema.feedback.FeedbackDefinition:
       builtins.NoneType]
     combinations: typing.Optional[trulens.core.schema.feedback.FeedbackCombinations,
       builtins.NoneType]
+    criteria: typing.Optional[builtins.str, builtins.NoneType]
     examples: typing.Optional[typing.List[typing.Tuple], builtins.NoneType]
     feedback_definition_id: builtins.str
     higher_is_better: typing.Optional[builtins.bool, builtins.NoneType]
@@ -2465,8 +2468,14 @@ trulens.feedback.v2.feedback.Controversiality:
   - trulens.feedback.v2.feedback.Semantics
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
+    criteria: builtins.str
+    criteria_template: builtins.str
+    output_space: builtins.str
+    output_space_prompt: builtins.str
     languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
     system_prompt: builtins.str
+    system_prompt_template: builtins.str
+    user_prompt: builtins.str
 trulens.feedback.v2.feedback.Correctness:
   __bases__:
   - trulens.feedback.v2.feedback.Semantics
@@ -2482,8 +2491,14 @@ trulens.feedback.v2.feedback.Criminality:
   - trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
+    criteria: builtins.str
+    criteria_template: builtins.str
+    output_space: builtins.str
+    output_space_prompt: builtins.str
     languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
     system_prompt: builtins.str
+    system_prompt_template: builtins.str
+    user_prompt: builtins.str
 trulens.feedback.v2.feedback.Criteria:
   __bases__:
   - builtins.str
@@ -2611,8 +2626,14 @@ trulens.feedback.v2.feedback.Harmfulness:
   - trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
+    criteria: builtins.str
+    criteria_template: builtins.str
+    output_space: builtins.str
+    output_space_prompt: builtins.str
     languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
     system_prompt: builtins.str
+    system_prompt_template: builtins.str
+    user_prompt: builtins.str
 trulens.feedback.v2.feedback.Hate:
   __bases__:
   - trulens.feedback.v2.feedback.Moderation
@@ -2630,16 +2651,28 @@ trulens.feedback.v2.feedback.Helpfulness:
   - trulens.feedback.v2.feedback.Semantics
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
+    criteria: builtins.str
+    criteria_template: builtins.str
+    output_space: builtins.str
+    output_space_prompt: builtins.str
     languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
     system_prompt: builtins.str
+    system_prompt_template: builtins.str
+    user_prompt: builtins.str
 trulens.feedback.v2.feedback.Insensitivity:
   __bases__:
   - trulens.feedback.v2.feedback.Semantics
   - trulens.feedback.v2.feedback.WithPrompt
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
+    criteria: builtins.str
+    criteria_template: builtins.str
+    output_space: builtins.str
+    output_space_prompt: builtins.str
     languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
     system_prompt: builtins.str
+    system_prompt_template: builtins.str
+    user_prompt: builtins.str
 trulens.feedback.v2.feedback.LanguageMatch:
   __bases__:
   - trulens.feedback.v2.feedback.Syntax
@@ -2658,8 +2691,13 @@ trulens.feedback.v2.feedback.Maliciousness:
   - trulens.feedback.v2.feedback.WithPrompt
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
+    criteria: builtins.str
+    criteria_template: builtins.str
+    output_space: builtins.str
+    output_space_prompt: builtins.str
     languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
     system_prompt: builtins.str
+    system_prompt_template: builtins.str
     user_prompt: builtins.str
 trulens.feedback.v2.feedback.Misogyny:
   __bases__:
@@ -2667,8 +2705,14 @@ trulens.feedback.v2.feedback.Misogyny:
   - trulens.feedback.v2.feedback.WithPrompt
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
+    criteria: builtins.str
+    criteria_template: builtins.str
+    output_space: builtins.str
+    output_space_prompt: builtins.str
     languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
     system_prompt: builtins.str
+    system_prompt_template: builtins.str
+    user_prompt: builtins.str
 trulens.feedback.v2.feedback.Model:
   __bases__:
   - pydantic.main.BaseModel
@@ -2753,8 +2797,13 @@ trulens.feedback.v2.feedback.Sentiment:
   - trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
+    criteria: builtins.str
+    criteria_template: builtins.str
+    output_space: builtins.str
+    output_space_prompt: builtins.str
     languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
     system_prompt: builtins.str
+    system_prompt_template: builtins.str
     user_prompt: builtins.str
 trulens.feedback.v2.feedback.Sexual:
   __bases__:
@@ -2775,8 +2824,13 @@ trulens.feedback.v2.feedback.Stereotypes:
   - trulens.feedback.v2.feedback.CriteriaOutputSpaceMixin
   __class__: pydantic._internal._model_construction.ModelMetaclass
   attributes:
+    criteria: builtins.str
+    criteria_template: builtins.str
+    output_space: builtins.str
+    output_space_prompt: builtins.str
     languages: typing.Optional[typing.List[builtins.str], builtins.NoneType]
     system_prompt: builtins.str
+    system_prompt_template: builtins.str
     user_prompt: builtins.str
 trulens.feedback.v2.feedback.Syntax:
   __bases__:

--- a/tests/unit/static/golden/api.trulens_eval.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens_eval.3.11.yaml
@@ -78,7 +78,7 @@ trulens_eval.AzureOpenAI:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -86,7 +86,7 @@ trulens_eval.AzureOpenAI:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -170,7 +170,7 @@ trulens_eval.Bedrock:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -178,7 +178,7 @@ trulens_eval.Bedrock:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_id: builtins.str
     model_json_schema: builtins.classmethod
@@ -256,7 +256,7 @@ trulens_eval.Cortex:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -264,7 +264,7 @@ trulens_eval.Cortex:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -310,6 +310,7 @@ trulens_eval.Feedback:
       builtins.NoneType]
     construct: builtins.classmethod
     copy: builtins.function
+    criteria: typing.Optional[builtins.str, builtins.NoneType]
     dict: builtins.function
     evaluate_deferred: builtins.staticmethod
     examples: typing.Optional[typing.List[typing.Tuple], builtins.NoneType]
@@ -331,14 +332,14 @@ trulens_eval.Feedback:
     load: builtins.staticmethod
     max_score_val: typing.Optional[builtins.int, builtins.NoneType]
     min_score_val: typing.Optional[builtins.int, builtins.NoneType]
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -406,14 +407,14 @@ trulens_eval.Huggingface:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -456,14 +457,14 @@ trulens_eval.HuggingfaceLocal:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -532,7 +533,7 @@ trulens_eval.Langchain:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -540,7 +541,7 @@ trulens_eval.Langchain:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -623,7 +624,7 @@ trulens_eval.LiteLLM:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -631,7 +632,7 @@ trulens_eval.LiteLLM:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -706,7 +707,7 @@ trulens_eval.OpenAI:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -714,7 +715,7 @@ trulens_eval.OpenAI:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -768,14 +769,14 @@ trulens_eval.Provider:
     get_class: builtins.staticmethod
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -868,14 +869,14 @@ trulens_eval.Tru:
     get_records_and_feedback: builtins.function
     json: builtins.function
     migrate_database: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -946,14 +947,14 @@ trulens_eval.TruBasicApp:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -1045,14 +1046,14 @@ trulens_eval.TruChain:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -1145,14 +1146,14 @@ trulens_eval.TruCustomApp:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -1242,14 +1243,14 @@ trulens_eval.TruLlama:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -1340,14 +1341,14 @@ trulens_eval.TruRails:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -1439,14 +1440,14 @@ trulens_eval.TruVirtual:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -1569,14 +1570,14 @@ trulens_eval.app.App:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -1831,14 +1832,14 @@ trulens_eval.database.base.DB:
     insert_record: builtins.function
     json: builtins.function
     migrate_database: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -1990,14 +1991,14 @@ trulens_eval.database.sqlalchemy.SQLAlchemyDB:
     insert_record: builtins.function
     json: builtins.function
     migrate_database: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2102,7 +2103,7 @@ trulens_eval.feedback.AzureOpenAI:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -2110,7 +2111,7 @@ trulens_eval.feedback.AzureOpenAI:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2194,7 +2195,7 @@ trulens_eval.feedback.Bedrock:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -2202,7 +2203,7 @@ trulens_eval.feedback.Bedrock:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_id: builtins.str
     model_json_schema: builtins.classmethod
@@ -2280,7 +2281,7 @@ trulens_eval.feedback.Cortex:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -2288,7 +2289,7 @@ trulens_eval.feedback.Cortex:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2336,14 +2337,14 @@ trulens_eval.feedback.Embeddings:
     json: builtins.function
     load: builtins.staticmethod
     manhattan_distance: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2379,6 +2380,7 @@ trulens_eval.feedback.Feedback:
       builtins.NoneType]
     construct: builtins.classmethod
     copy: builtins.function
+    criteria: typing.Optional[builtins.str, builtins.NoneType]
     dict: builtins.function
     evaluate_deferred: builtins.staticmethod
     examples: typing.Optional[typing.List[typing.Tuple], builtins.NoneType]
@@ -2400,14 +2402,14 @@ trulens_eval.feedback.Feedback:
     load: builtins.staticmethod
     max_score_val: typing.Optional[builtins.int, builtins.NoneType]
     min_score_val: typing.Optional[builtins.int, builtins.NoneType]
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2469,14 +2471,14 @@ trulens_eval.feedback.GroundTruthAgreement:
     json: builtins.function
     load: builtins.staticmethod
     mae: builtins.property
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2521,14 +2523,14 @@ trulens_eval.feedback.Huggingface:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2571,14 +2573,14 @@ trulens_eval.feedback.HuggingfaceLocal:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2647,7 +2649,7 @@ trulens_eval.feedback.Langchain:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -2655,7 +2657,7 @@ trulens_eval.feedback.Langchain:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2731,7 +2733,7 @@ trulens_eval.feedback.LiteLLM:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -2739,7 +2741,7 @@ trulens_eval.feedback.LiteLLM:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2814,7 +2816,7 @@ trulens_eval.feedback.OpenAI:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -2822,7 +2824,7 @@ trulens_eval.feedback.OpenAI:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2884,14 +2886,14 @@ trulens_eval.feedback.embeddings.Embeddings:
     json: builtins.function
     load: builtins.staticmethod
     manhattan_distance: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2936,6 +2938,7 @@ trulens_eval.feedback.feedback.Feedback:
       builtins.NoneType]
     construct: builtins.classmethod
     copy: builtins.function
+    criteria: typing.Optional[builtins.str, builtins.NoneType]
     dict: builtins.function
     evaluate_deferred: builtins.staticmethod
     examples: typing.Optional[typing.List[typing.Tuple], builtins.NoneType]
@@ -2957,14 +2960,14 @@ trulens_eval.feedback.feedback.Feedback:
     load: builtins.staticmethod
     max_score_val: typing.Optional[builtins.int, builtins.NoneType]
     min_score_val: typing.Optional[builtins.int, builtins.NoneType]
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3042,14 +3045,14 @@ trulens_eval.feedback.groundtruth.GroundTruthAgreement:
     json: builtins.function
     load: builtins.staticmethod
     mae: builtins.property
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3180,7 +3183,7 @@ trulens_eval.feedback.provider.AzureOpenAI:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -3188,7 +3191,7 @@ trulens_eval.feedback.provider.AzureOpenAI:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3272,7 +3275,7 @@ trulens_eval.feedback.provider.Bedrock:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -3280,7 +3283,7 @@ trulens_eval.feedback.provider.Bedrock:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_id: builtins.str
     model_json_schema: builtins.classmethod
@@ -3358,7 +3361,7 @@ trulens_eval.feedback.provider.Cortex:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -3366,7 +3369,7 @@ trulens_eval.feedback.provider.Cortex:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3415,14 +3418,14 @@ trulens_eval.feedback.provider.Huggingface:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3465,14 +3468,14 @@ trulens_eval.feedback.provider.HuggingfaceLocal:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3541,7 +3544,7 @@ trulens_eval.feedback.provider.Langchain:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -3549,7 +3552,7 @@ trulens_eval.feedback.provider.Langchain:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3625,7 +3628,7 @@ trulens_eval.feedback.provider.LiteLLM:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -3633,7 +3636,7 @@ trulens_eval.feedback.provider.LiteLLM:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3708,7 +3711,7 @@ trulens_eval.feedback.provider.OpenAI:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -3716,7 +3719,7 @@ trulens_eval.feedback.provider.OpenAI:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3770,14 +3773,14 @@ trulens_eval.feedback.provider.Provider:
     get_class: builtins.staticmethod
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3849,7 +3852,7 @@ trulens_eval.feedback.provider.base.LLMProvider:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -3857,7 +3860,7 @@ trulens_eval.feedback.provider.base.LLMProvider:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3902,14 +3905,14 @@ trulens_eval.feedback.provider.base.Provider:
     get_class: builtins.staticmethod
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3981,7 +3984,7 @@ trulens_eval.feedback.provider.bedrock.Bedrock:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -3989,7 +3992,7 @@ trulens_eval.feedback.provider.bedrock.Bedrock:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_id: builtins.str
     model_json_schema: builtins.classmethod
@@ -4073,7 +4076,7 @@ trulens_eval.feedback.provider.cortex.Cortex:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -4081,7 +4084,7 @@ trulens_eval.feedback.provider.cortex.Cortex:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4154,14 +4157,14 @@ trulens_eval.feedback.provider.endpoint.BedrockEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4220,14 +4223,14 @@ trulens_eval.feedback.provider.endpoint.CortexEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4295,14 +4298,14 @@ trulens_eval.feedback.provider.endpoint.DummyEndpoint:
     load: builtins.staticmethod
     loading_prob: builtins.property
     loading_time: builtins.property
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4365,14 +4368,14 @@ trulens_eval.feedback.provider.endpoint.Endpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4433,14 +4436,14 @@ trulens_eval.feedback.provider.endpoint.HuggingfaceEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4501,14 +4504,14 @@ trulens_eval.feedback.provider.endpoint.LangchainEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4567,14 +4570,14 @@ trulens_eval.feedback.provider.endpoint.LiteLLMEndpoint:
     json: builtins.function
     litellm_provider: builtins.str
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4623,14 +4626,14 @@ trulens_eval.feedback.provider.endpoint.OpenAIClient:
     formatted_objects: _contextvars.ContextVar
     from_orm: builtins.classmethod
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4673,14 +4676,14 @@ trulens_eval.feedback.provider.endpoint.OpenAIEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4759,14 +4762,14 @@ trulens_eval.feedback.provider.endpoint.base.DummyEndpoint:
     load: builtins.staticmethod
     loading_prob: builtins.property
     loading_time: builtins.property
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4829,14 +4832,14 @@ trulens_eval.feedback.provider.endpoint.base.Endpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4889,14 +4892,14 @@ trulens_eval.feedback.provider.endpoint.base.EndpointCallback:
     handle_generation: builtins.function
     handle_generation_chunk: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4940,14 +4943,14 @@ trulens_eval.feedback.provider.endpoint.bedrock.BedrockCallback:
     handle_generation: builtins.function
     handle_generation_chunk: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4990,14 +4993,14 @@ trulens_eval.feedback.provider.endpoint.bedrock.BedrockEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5058,14 +5061,14 @@ trulens_eval.feedback.provider.endpoint.cortex.CortexCallback:
     handle_generation: builtins.function
     handle_generation_chunk: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5107,14 +5110,14 @@ trulens_eval.feedback.provider.endpoint.cortex.CortexEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5174,14 +5177,14 @@ trulens_eval.feedback.provider.endpoint.hugs.HuggingfaceCallback:
     handle_generation: builtins.function
     handle_generation_chunk: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5226,14 +5229,14 @@ trulens_eval.feedback.provider.endpoint.hugs.HuggingfaceEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5295,14 +5298,14 @@ trulens_eval.feedback.provider.endpoint.langchain.LangchainCallback:
     handle_generation: builtins.function
     handle_generation_chunk: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5345,14 +5348,14 @@ trulens_eval.feedback.provider.endpoint.langchain.LangchainEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5412,14 +5415,14 @@ trulens_eval.feedback.provider.endpoint.litellm.LiteLLMCallback:
     handle_generation: builtins.function
     handle_generation_chunk: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5462,14 +5465,14 @@ trulens_eval.feedback.provider.endpoint.litellm.LiteLLMEndpoint:
     json: builtins.function
     litellm_provider: builtins.str
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5532,14 +5535,14 @@ trulens_eval.feedback.provider.endpoint.openai.OpenAICallback:
     handle_generation_chunk: builtins.function
     json: builtins.function
     langchain_handler: langchain_community.callbacks.openai_info.OpenAICallbackHandler
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5572,14 +5575,14 @@ trulens_eval.feedback.provider.endpoint.openai.OpenAIClient:
     formatted_objects: _contextvars.ContextVar
     from_orm: builtins.classmethod
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5622,14 +5625,14 @@ trulens_eval.feedback.provider.endpoint.openai.OpenAIEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5699,14 +5702,14 @@ trulens_eval.feedback.provider.hugs.Dummy:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5749,14 +5752,14 @@ trulens_eval.feedback.provider.hugs.Huggingface:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5799,14 +5802,14 @@ trulens_eval.feedback.provider.hugs.HuggingfaceBase:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5849,14 +5852,14 @@ trulens_eval.feedback.provider.hugs.HuggingfaceLocal:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5931,7 +5934,7 @@ trulens_eval.feedback.provider.langchain.Langchain:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -5939,7 +5942,7 @@ trulens_eval.feedback.provider.langchain.Langchain:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6021,7 +6024,7 @@ trulens_eval.feedback.provider.litellm.LiteLLM:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -6029,7 +6032,7 @@ trulens_eval.feedback.provider.litellm.LiteLLM:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6112,7 +6115,7 @@ trulens_eval.feedback.provider.openai.AzureOpenAI:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -6120,7 +6123,7 @@ trulens_eval.feedback.provider.openai.AzureOpenAI:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6204,7 +6207,7 @@ trulens_eval.feedback.provider.openai.OpenAI:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -6212,7 +6215,7 @@ trulens_eval.feedback.provider.openai.OpenAI:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6442,14 +6445,14 @@ trulens_eval.schema.app.AppDefinition:
     jsonify_extra: builtins.function
     load: builtins.staticmethod
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6552,14 +6555,14 @@ trulens_eval.schema.feedback.FeedbackCall:
     from_orm: builtins.classmethod
     json: builtins.function
     meta: typing.Dict[builtins.str, typing.Any]
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6603,6 +6606,7 @@ trulens_eval.schema.feedback.FeedbackDefinition:
       builtins.NoneType]
     construct: builtins.classmethod
     copy: builtins.function
+    criteria: typing.Optional[builtins.str, builtins.NoneType]
     dict: builtins.function
     examples: typing.Optional[typing.List[typing.Tuple], builtins.NoneType]
     feedback_definition_id: builtins.str
@@ -6616,14 +6620,14 @@ trulens_eval.schema.feedback.FeedbackDefinition:
       builtins.NoneType]
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6689,14 +6693,14 @@ trulens_eval.schema.feedback.FeedbackResult:
     from_orm: builtins.classmethod
     json: builtins.function
     last_ts: datetime.datetime
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6796,14 +6800,14 @@ trulens_eval.schema.record.Record:
       builtins.NoneType, typing.Sequence[typing.Any], typing.Dict[builtins.str, typing.Any]]
     meta: typing.Union[builtins.str, builtins.int, builtins.float, builtins.bytes,
       builtins.NoneType, typing.Sequence[typing.Any], typing.Dict[builtins.str, typing.Any]]
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6842,14 +6846,14 @@ trulens_eval.schema.record.RecordAppCall:
     from_orm: builtins.classmethod
     json: builtins.function
     method: builtins.property
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6886,14 +6890,14 @@ trulens_eval.schema.record.RecordAppCallMethod:
     from_orm: builtins.classmethod
     json: builtins.function
     method: trulens.core.utils.pyschema.Method
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6983,14 +6987,14 @@ trulens_eval.tru.Tru:
     get_records_and_feedback: builtins.function
     json: builtins.function
     migrate_database: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -7069,14 +7073,14 @@ trulens_eval.tru_basic_app.TruBasicApp:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -7212,14 +7216,14 @@ trulens_eval.tru_chain.TruChain:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -7320,14 +7324,14 @@ trulens_eval.tru_custom_app.TruCustomApp:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -7448,14 +7452,14 @@ trulens_eval.tru_llama.TruLlama:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -7614,14 +7618,14 @@ trulens_eval.tru_rails.TruRails:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -7721,14 +7725,14 @@ trulens_eval.tru_virtual.TruVirtual:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -7810,14 +7814,14 @@ trulens_eval.tru_virtual.VirtualRecord:
       builtins.NoneType, typing.Sequence[typing.Any], typing.Dict[builtins.str, typing.Any]]
     meta: typing.Union[builtins.str, builtins.int, builtins.float, builtins.bytes,
       builtins.NoneType, typing.Sequence[typing.Any], typing.Dict[builtins.str, typing.Any]]
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8151,14 +8155,14 @@ trulens_eval.utils.pyschema.Bindings:
     json: builtins.function
     kwargs: typing.Dict[builtins.str, typing.Any]
     load: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8191,14 +8195,14 @@ trulens_eval.utils.pyschema.Class:
     from_orm: builtins.classmethod
     json: builtins.function
     load: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8235,14 +8239,14 @@ trulens_eval.utils.pyschema.Function:
     from_orm: builtins.classmethod
     json: builtins.function
     load: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8276,14 +8280,14 @@ trulens_eval.utils.pyschema.FunctionOrMethod:
     from_orm: builtins.classmethod
     json: builtins.function
     load: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8314,14 +8318,14 @@ trulens_eval.utils.pyschema.Method:
     from_orm: builtins.classmethod
     json: builtins.function
     load: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8355,14 +8359,14 @@ trulens_eval.utils.pyschema.Module:
     from_orm: builtins.classmethod
     json: builtins.function
     load: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8399,14 +8403,14 @@ trulens_eval.utils.pyschema.Obj:
     init_bindings: typing.Optional[trulens.core.utils.pyschema.Bindings, builtins.NoneType]
     json: builtins.function
     load: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8559,14 +8563,14 @@ trulens_eval.utils.serial.Collect:
     get: builtins.function
     get_sole_item: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8597,14 +8601,14 @@ trulens_eval.utils.serial.GetAttribute:
     get_item_or_attribute: builtins.function
     get_sole_item: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8634,14 +8638,14 @@ trulens_eval.utils.serial.GetIndex:
     get_sole_item: builtins.function
     index: builtins.int
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8671,14 +8675,14 @@ trulens_eval.utils.serial.GetIndices:
     get_sole_item: builtins.function
     indices: typing.Tuple[builtins.int, ...]
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8709,14 +8713,14 @@ trulens_eval.utils.serial.GetItem:
     get_sole_item: builtins.function
     item: builtins.str
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8747,14 +8751,14 @@ trulens_eval.utils.serial.GetItemOrAttribute:
     get_sole_item: builtins.function
     item_or_attribute: builtins.str
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8784,14 +8788,14 @@ trulens_eval.utils.serial.GetItems:
     get_sole_item: builtins.function
     items: typing.Tuple[builtins.str, ...]
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8820,14 +8824,14 @@ trulens_eval.utils.serial.GetSlice:
     get: builtins.function
     get_sole_item: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8909,14 +8913,14 @@ trulens_eval.utils.serial.StepItemOrAttribute:
     get_item_or_attribute: builtins.function
     get_sole_item: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod


### PR DESCRIPTION
# Description

- Custom criteria for feedback so users can improve alignment with human evals, tweak OOB llm-judge prompts, etc.
- Also add more parameter passthroughs for min_score, max_score, temperature

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [x] This change includes re-generated golden test results
- [x] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces custom feedback criteria and parameter passthroughs for enhanced evaluation control, updating prompts and model fields.
> 
>   - **New Feature**:
>     - Adds `criteria` field for custom feedback in `feedback.py` and `schema/feedback.py`.
>     - Implements parameter passthroughs for `min_score`, `max_score`, and `temperature` in `llm_provider.py`.
>   - **Prompts**:
>     - Updates system prompts in `v2/feedback.py` to include criteria and output space.
>   - **Misc**:
>     - Changes `model_computed_fields` and `model_fields` from `dict` to `property` in `api.trulens_eval.3.11.yaml` and other files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for caacef4e03cb39227e8836eb20e88d54a06427d8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->