### PR TITLE
Update prpr example notebook to reflect latest Cortex provider API 

### DIFF
--- a/examples/quickstart/snowflake_ai_observability_example.ipynb
+++ b/examples/quickstart/snowflake_ai_observability_example.ipynb
@@ -196,7 +196,7 @@
     "from trulens.core import Select\n",
     "from trulens.providers.cortex.provider import Cortex\n",
     "\n",
-    "provider = Cortex(snowpark_session.connection, \"llama3.1-8b\")\n",
+    "provider = Cortex(snowpark_session, \"llama3.1-8b\")\n",
     "f_context_relevance = (\n",
     "    Feedback(provider.context_relevance, name=\"Context Relevance\")\n",
     "    .on(Select.RecordCalls.retrieve.args.query)\n",


### PR DESCRIPTION
# Description

Cortex provider now takes `snowpark session` instead of connection instance since trulens 1.2.9

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [x] This change requires a documentation update
