### PR TITLE
Remove / retire sql instrumentation in Cortex Endpoint

### DIFF
--- a/src/providers/cortex/trulens/providers/cortex/endpoint.py
+++ b/src/providers/cortex/trulens/providers/cortex/endpoint.py
@@ -5,11 +5,8 @@ import os
 import pprint
 from typing import Any, Callable, ClassVar, Optional
 
-from snowflake.connector.cursor import SnowflakeCursor
 from snowflake.cortex._sse_client import Event
 from snowflake.cortex._sse_client import SSEClient
-from snowflake.snowpark import DataFrame
-from snowflake.snowpark import Session
 from trulens.core.feedback import endpoint as core_endpoint
 
 logger = logging.getLogger(__name__)
@@ -99,9 +96,6 @@ class CortexEndpoint(core_endpoint.Endpoint):
 
         super().__init__(*args, **kwargs)
 
-        # we instrument sql and fetchall in case users are calling Cortex LLM functions via Snowflake SQL
-        self._instrument_class(Session, "sql")
-        self._instrument_class(SnowflakeCursor, "fetchall")
         # we instrument the SSEClient class from snowflake.cortex module to get the usage information from the HTTP response when calling the REST Complete endpoint
         self._instrument_class(SSEClient, "events")
 
@@ -121,11 +115,6 @@ class CortexEndpoint(core_endpoint.Endpoint):
                 response_dict = json.loads(
                     response.data
                 )  # response is a server-sent event (SSE). see _sse_client.py from snowflake.cortex module for reference
-
-            elif isinstance(response, DataFrame):
-                response_dict = json.loads(response.collect()[0][0])
-            elif isinstance(response, list):
-                response_dict = json.loads(response[0][0])
 
         except Exception as e:
             logger.error(f"Error occurred while parsing response: {e}")


### PR DESCRIPTION
# Description

With Cortex moving toward REST api, I think it's time we retire the other 2 instrumented methods.

Motivation is that we've seen PrPr customers running into issue when they try to decorate some other non-Cortex related function that includes `session.sql(...)` with `@instrument` and the returned values from SQL statements are not being parsed properly. (and should not be either way)
## Other details good to know for developers

previous discussion thread: https://github.com/truera/trulens/pull/1650/files#diff-61064baa307b9d4b228c8e834915c482288ab5239b23451d3978f7bf70ea8e3e
Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove SQL instrumentation from `CortexEndpoint` and focus on handling `Event` responses from `SSEClient`.
> 
>   - **Behavior**:
>     - Remove SQL instrumentation for `Session.sql` and `SnowflakeCursor.fetchall` in `CortexEndpoint`.
>     - Remove handling of `DataFrame` and `list` response types in `handle_wrapped_call`.
>     - Focus on handling `Event` responses from `SSEClient`.
>   - **Motivation**:
>     - Address issues with `@instrument` decorator on non-Cortex functions using SQL methods.
>     - Align with Cortex's shift towards REST API.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 488984c8bb9df474583410bea4d3b6f690b90114. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->