### PR TITLE
Set default isolation level to AUTOCOMMIT for snowflake

### DIFF
--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -136,6 +136,12 @@ class SQLAlchemyDB(core_db.DB):
 
     def _reload_engine(self):
         if self.engine is None:
+            # Check if the dialect is snowflake and set isolation_level
+            if (
+                "url" in self.engine_params
+                and "snowflake" in self.engine_params["url"]
+            ):
+                self.engine_params.setdefault("isolation_level", "AUTOCOMMIT")
             self.engine = sa.create_engine(**self.engine_params)
         self.session = sessionmaker(self.engine, **self.session_params)
 

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -141,7 +141,13 @@ class SQLAlchemyDB(core_db.DB):
                 "url" in self.engine_params
                 and "snowflake" in self.engine_params["url"]
             ):
-                self.engine_params.setdefault("isolation_level", "AUTOCOMMIT")
+                temp_engine = sa.create_engine(**self.engine_params)
+                if temp_engine.dialect.name == "snowflake":
+                    self.engine_params.setdefault(
+                        "isolation_level", "AUTOCOMMIT"
+                    )
+                # Dispose of the temporary engine
+                temp_engine.dispose()
             self.engine = sa.create_engine(**self.engine_params)
         self.session = sessionmaker(self.engine, **self.session_params)
 


### PR DESCRIPTION
# Description

This is needed after `snowflake-sqlalchemy` >= 1.7.2 because of https://github.com/snowflakedb/snowflake-sqlalchemy/pull/555
## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Set default isolation level to AUTOCOMMIT for Snowflake connections in `SQLAlchemyDB` to ensure compatibility with `snowflake-sqlalchemy` >= 1.7.2.
> 
>   - **Behavior**:
>     - Set default `isolation_level` to `AUTOCOMMIT` for Snowflake connections in `_reload_engine()` of `SQLAlchemyDB`.
>     - Applies only if `snowflake` is detected in `engine_params['url']`.
>   - **Compatibility**:
>     - Ensures compatibility with `snowflake-sqlalchemy` version 1.7.2 and above.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 41cea5bd1f0b9e92caa5457de7f6497d66f25246. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->