### PR TITLE
Update Cortex model cost table

### DIFF
--- a/src/providers/cortex/trulens/providers/cortex/config/cortex_model_costs.json
+++ b/src/providers/cortex/trulens/providers/cortex/config/cortex_model_costs.json
@@ -1,17 +1,10 @@
 {
-    "reka-core": 5.5,
     "mistral-large": 5.1,
-    "llama3.1-405b": 5,
+    "llama3.1-405b": 3,
     "mistral-large2": 1.95,
-    "llama3-70b": 1.21,
     "llama3.1-70b": 1.21,
-    "snowflake-arctic": 0.84,
-    "jamba-instruct": 0.83,
-    "llama2-chat-70b": 0.45,
-    "reka-flash": 0.45,
-    "mixtral-8x7b": 0.22,
-    "llama3-8b": 0.19,
     "llama3.1-8b": 0.19,
     "mistral-7b": 0.12,
-    "gemma-7b": 0.12
+    "llama3.2-3b": 0.06,
+    "llama3.2-1b": 0.04
 }

--- a/src/providers/cortex/trulens/providers/cortex/endpoint.py
+++ b/src/providers/cortex/trulens/providers/cortex/endpoint.py
@@ -26,6 +26,7 @@ class CortexCallback(core_endpoint.EndpointCallback):
             if self._model_costs is None:
                 # the credit consumption table needs to be kept up-to-date with
                 # the latest cost information https://www.snowflake.com/legal-files/CreditConsumptionTable.pdf#page=9.
+                # We should refer to the latest model availability of REST api https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-llm-rest-api#model-availability
 
                 with open(
                     os.path.join(


### PR DESCRIPTION
# Description

Since we now only support usage/cost tracking of models available in Cortex REST endpoints (https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-llm-rest-api#model-availability), we should update the table to reflect it.  
## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `cortex_model_costs.json` and comments in `endpoint.py` to reflect current model availability in Cortex REST API.
> 
>   - **Behavior**:
>     - Update `cortex_model_costs.json` to reflect current model availability in Cortex REST API.
>     - Update comment in `_compute_credits_consumed` in `endpoint.py` to refer to latest model availability documentation.
>   - **Misc**:
>     - Remove unsupported models from `cortex_model_costs.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 31dbcd815f4bc833dde7dcc3e7d5a00e0c6bd70d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->