### PR TITLE
Update Snowflake quickstart from using arctic to more general Cortex LLMs

### DIFF
--- a/examples/expositional/models/snowflake_cortex/cortex_llm_quickstart.ipynb
+++ b/examples/expositional/models/snowflake_cortex/cortex_llm_quickstart.ipynb
@@ -4,18 +4,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# ❄️ Snowflake Arctic Quickstart with Cortex LLM Functions\n",
+    "# ❄️ Snowflake Quickstart with Cortex LLM Functions\n",
     "\n",
-    "In this quickstart you will learn build and evaluate a RAG application with Snowflake Arctic.\n",
+    "In this quickstart you will learn build and evaluate a RAG application with Snowflake Cortex LLM Functions.\n",
     "\n",
-    "Building and evaluating RAG applications with Snowflake Arctic offers developers a unique opportunity to leverage a top-tier, enterprise-focused LLM that is both cost-effective and open-source. Arctic excels in enterprise tasks like SQL generation and coding, providing a robust foundation for developing intelligent applications with significant cost savings. [Learn more about Snowflake Arctic](https://www.snowflake.com/blog/arctic-open-efficient-foundation-language-models-snowflake/)\n",
+    "Building and evaluating RAG applications with Snowflake Cortex offers developers a unique opportunity to leverage a top-tier, enterprise-focused LLM that is both cost-effective and open-source. Cortex excels in enterprise tasks like SQL generation and coding, providing a robust foundation for developing intelligent applications with significant cost savings. \n",
     "\n",
-    "In this example, we will use Arctic Embed (`snowflake-arctic-embed-m`) as our embedding model via HuggingFace, and Arctic, a 480B hybrid MoE LLM for both generation and as the LLM to power TruLens feedback functions. The Arctic LLM is fully-mananaged by [Cortex LLM functions](https://docs.snowflake.com/en/user-guide/snowflake-cortex/llm-functions)\n",
+    "In this example, we will use Arctic Embed (`snowflake-arctic-embed-m`) as our embedding model via HuggingFace, and LLM of your choice for both generation and as the LLM judge to power TruLens feedback functions. The LLM models are fully-mananaged by [Cortex LLM functions](https://docs.snowflake.com/en/user-guide/snowflake-cortex/llm-functions)\n",
     "\n",
     "Note, you'll need to have an [active Snowflake account](https://signup.snowflake.com/\n",
     ") to run Cortex LLM functions from Snowflake's data warehouse.\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/truera/trulens/blob/main/examples/expositional/models/snowflake_cortex/arctic_quickstart.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/truera/trulens/blob/main/examples/expositional/models/snowflake_cortex/cortex_llm_quickstart.ipynb)"
    ]
   },
   {
@@ -192,7 +192,7 @@
     "            {context_str}\n",
     "            Given this information, please answer the question: {query}\n",
     "        \"\"\"\n",
-    "        resp = Complete(model='snowflake-arctic', prompt=[{'role': 'user', 'content': prompt}], session=snowpark_session)\n",
+    "        resp = Complete(model='mistral-large2', prompt=[{'role': 'user', 'content': prompt}], session=snowpark_session)\n",
     "        \n",
     "        return resp\n",
     "\n",
@@ -230,7 +230,7 @@
     "\n",
     "provider = Cortex(\n",
     "    snowpark_session=snowpark_session,\n",
-    "    model_engine=\"snowflake-arctic\",\n",
+    "    model_engine=\"llama3.1-8b\",\n",
     ")\n",
     "\n",
     "\n",


### PR DESCRIPTION
# Description

Snowflake Arctic is no longer supported in Cortex Complete's REST API, and we've also stopped using it as our default model engine in Cortex provider a while ago.  Updating quickstart to reflect this and prevent users from using `snowflake-arctic`

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [x] This change requires a documentation update
