### PR TITLE
Don't create event tables unless `TRULENS_OTEL_TRACING` env variable is set.

### DIFF
--- a/src/core/trulens/core/database/migrations/versions/10_create_event_table.py
+++ b/src/core/trulens/core/database/migrations/versions/10_create_event_table.py
@@ -5,6 +5,8 @@ Revises: 9
 Create Date: 2024-12-11 09:32:48.976169
 """
 
+import os
+
 from alembic import op
 import sqlalchemy as sa
 
@@ -15,15 +17,14 @@ branch_labels = None
 depends_on = None
 
 
-def _is_snowflake_dialect(config):
-    return (
-        config.get_main_option("sqlalchemy.url").startswith("snowflake")
-        or config.get_main_option("dialect") == "snowflake"
-    )
+def _use_event_table():
+    # We only use event table if specifically enabled as it requires the often
+    # unsupported JSON type and is for temporary testing purposes anyway.
+    return os.getenv("TRULENS_OTEL_TRACING", "").lower() in ["1", "true"]
 
 
 def upgrade(config) -> None:
-    if _is_snowflake_dialect(config):
+    if not _use_event_table():
         return
 
     prefix = config.get_main_option("trulens.table_prefix")
@@ -46,7 +47,7 @@ def upgrade(config) -> None:
 
 
 def downgrade(config) -> None:
-    if _is_snowflake_dialect(config):
+    if not _use_event_table():
         return
 
     prefix = config.get_main_option("trulens.table_prefix")

--- a/src/core/trulens/core/database/migrations/versions/10_create_event_table.py
+++ b/src/core/trulens/core/database/migrations/versions/10_create_event_table.py
@@ -15,7 +15,17 @@ branch_labels = None
 depends_on = None
 
 
+def _is_snowflake_dialect(config):
+    return (
+        config.get_main_option("sqlalchemy.url").startswith("snowflake")
+        or config.get_main_option("dialect") == "snowflake"
+    )
+
+
 def upgrade(config) -> None:
+    if _is_snowflake_dialect(config):
+        return
+
     prefix = config.get_main_option("trulens.table_prefix")
 
     if prefix is None:
@@ -36,6 +46,9 @@ def upgrade(config) -> None:
 
 
 def downgrade(config) -> None:
+    if _is_snowflake_dialect(config):
+        return
+
     prefix = config.get_main_option("trulens.table_prefix")
 
     if prefix is None:

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -4,7 +4,7 @@ trulens:
   lows: {}
 trulens.benchmark:
   __class__: builtins.module
-  __version__: 1.2.11
+  __version__: 1.3.1
   highs: {}
   lows:
     __version__: builtins.str
@@ -60,7 +60,7 @@ trulens.benchmark.test_cases:
     generate_summeval_groundedness_golden_set: builtins.function
 trulens.core:
   __class__: builtins.module
-  __version__: 1.2.11
+  __version__: 1.3.1
   highs:
     Feedback: pydantic._internal._model_construction.ModelMetaclass
     FeedbackMode: enum.EnumType
@@ -1727,7 +1727,7 @@ trulens.core.utils.trulens.Other:
   attributes: {}
 trulens.dashboard:
   __class__: builtins.module
-  __version__: 1.2.11
+  __version__: 1.3.1
   highs:
     run_dashboard: builtins.function
     run_dashboard_sis: builtins.function
@@ -2015,7 +2015,7 @@ trulens.dashboard.ux.styles.ResultCategoryType:
     value: enum.property
 trulens.feedback:
   __class__: builtins.module
-  __version__: 1.2.11
+  __version__: 1.3.1
   highs:
     Embeddings: pydantic._internal._model_construction.ModelMetaclass
     GroundTruthAggregator: pydantic._internal._model_construction.ModelMetaclass

--- a/tests/unit/static/golden/api.trulens_eval.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens_eval.3.11.yaml
@@ -78,7 +78,7 @@ trulens_eval.AzureOpenAI:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -86,7 +86,7 @@ trulens_eval.AzureOpenAI:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -170,7 +170,7 @@ trulens_eval.Bedrock:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -178,7 +178,7 @@ trulens_eval.Bedrock:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_id: builtins.str
     model_json_schema: builtins.classmethod
@@ -256,7 +256,7 @@ trulens_eval.Cortex:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -264,7 +264,7 @@ trulens_eval.Cortex:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -332,14 +332,14 @@ trulens_eval.Feedback:
     load: builtins.staticmethod
     max_score_val: typing.Optional[builtins.int, builtins.NoneType]
     min_score_val: typing.Optional[builtins.int, builtins.NoneType]
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -407,14 +407,14 @@ trulens_eval.Huggingface:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -457,14 +457,14 @@ trulens_eval.HuggingfaceLocal:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -533,7 +533,7 @@ trulens_eval.Langchain:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -541,7 +541,7 @@ trulens_eval.Langchain:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -624,7 +624,7 @@ trulens_eval.LiteLLM:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -632,7 +632,7 @@ trulens_eval.LiteLLM:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -707,7 +707,7 @@ trulens_eval.OpenAI:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -715,7 +715,7 @@ trulens_eval.OpenAI:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -769,14 +769,14 @@ trulens_eval.Provider:
     get_class: builtins.staticmethod
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -869,14 +869,14 @@ trulens_eval.Tru:
     get_records_and_feedback: builtins.function
     json: builtins.function
     migrate_database: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -947,14 +947,14 @@ trulens_eval.TruBasicApp:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -1048,14 +1048,14 @@ trulens_eval.TruChain:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -1150,14 +1150,14 @@ trulens_eval.TruCustomApp:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -1249,14 +1249,14 @@ trulens_eval.TruLlama:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -1349,14 +1349,14 @@ trulens_eval.TruRails:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -1450,14 +1450,14 @@ trulens_eval.TruVirtual:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -1582,14 +1582,14 @@ trulens_eval.app.App:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -1846,14 +1846,14 @@ trulens_eval.database.base.DB:
     insert_record: builtins.function
     json: builtins.function
     migrate_database: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2005,14 +2005,14 @@ trulens_eval.database.sqlalchemy.SQLAlchemyDB:
     insert_record: builtins.function
     json: builtins.function
     migrate_database: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2117,7 +2117,7 @@ trulens_eval.feedback.AzureOpenAI:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -2125,7 +2125,7 @@ trulens_eval.feedback.AzureOpenAI:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2209,7 +2209,7 @@ trulens_eval.feedback.Bedrock:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -2217,7 +2217,7 @@ trulens_eval.feedback.Bedrock:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_id: builtins.str
     model_json_schema: builtins.classmethod
@@ -2295,7 +2295,7 @@ trulens_eval.feedback.Cortex:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -2303,7 +2303,7 @@ trulens_eval.feedback.Cortex:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2351,14 +2351,14 @@ trulens_eval.feedback.Embeddings:
     json: builtins.function
     load: builtins.staticmethod
     manhattan_distance: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2416,14 +2416,14 @@ trulens_eval.feedback.Feedback:
     load: builtins.staticmethod
     max_score_val: typing.Optional[builtins.int, builtins.NoneType]
     min_score_val: typing.Optional[builtins.int, builtins.NoneType]
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2485,14 +2485,14 @@ trulens_eval.feedback.GroundTruthAgreement:
     json: builtins.function
     load: builtins.staticmethod
     mae: builtins.property
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2537,14 +2537,14 @@ trulens_eval.feedback.Huggingface:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2587,14 +2587,14 @@ trulens_eval.feedback.HuggingfaceLocal:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2663,7 +2663,7 @@ trulens_eval.feedback.Langchain:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -2671,7 +2671,7 @@ trulens_eval.feedback.Langchain:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2747,7 +2747,7 @@ trulens_eval.feedback.LiteLLM:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -2755,7 +2755,7 @@ trulens_eval.feedback.LiteLLM:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2830,7 +2830,7 @@ trulens_eval.feedback.OpenAI:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -2838,7 +2838,7 @@ trulens_eval.feedback.OpenAI:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2900,14 +2900,14 @@ trulens_eval.feedback.embeddings.Embeddings:
     json: builtins.function
     load: builtins.staticmethod
     manhattan_distance: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -2974,14 +2974,14 @@ trulens_eval.feedback.feedback.Feedback:
     load: builtins.staticmethod
     max_score_val: typing.Optional[builtins.int, builtins.NoneType]
     min_score_val: typing.Optional[builtins.int, builtins.NoneType]
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3059,14 +3059,14 @@ trulens_eval.feedback.groundtruth.GroundTruthAgreement:
     json: builtins.function
     load: builtins.staticmethod
     mae: builtins.property
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3197,7 +3197,7 @@ trulens_eval.feedback.provider.AzureOpenAI:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -3205,7 +3205,7 @@ trulens_eval.feedback.provider.AzureOpenAI:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3289,7 +3289,7 @@ trulens_eval.feedback.provider.Bedrock:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -3297,7 +3297,7 @@ trulens_eval.feedback.provider.Bedrock:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_id: builtins.str
     model_json_schema: builtins.classmethod
@@ -3375,7 +3375,7 @@ trulens_eval.feedback.provider.Cortex:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -3383,7 +3383,7 @@ trulens_eval.feedback.provider.Cortex:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3432,14 +3432,14 @@ trulens_eval.feedback.provider.Huggingface:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3482,14 +3482,14 @@ trulens_eval.feedback.provider.HuggingfaceLocal:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3558,7 +3558,7 @@ trulens_eval.feedback.provider.Langchain:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -3566,7 +3566,7 @@ trulens_eval.feedback.provider.Langchain:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3642,7 +3642,7 @@ trulens_eval.feedback.provider.LiteLLM:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -3650,7 +3650,7 @@ trulens_eval.feedback.provider.LiteLLM:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3725,7 +3725,7 @@ trulens_eval.feedback.provider.OpenAI:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -3733,7 +3733,7 @@ trulens_eval.feedback.provider.OpenAI:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3787,14 +3787,14 @@ trulens_eval.feedback.provider.Provider:
     get_class: builtins.staticmethod
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3866,7 +3866,7 @@ trulens_eval.feedback.provider.base.LLMProvider:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -3874,7 +3874,7 @@ trulens_eval.feedback.provider.base.LLMProvider:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3919,14 +3919,14 @@ trulens_eval.feedback.provider.base.Provider:
     get_class: builtins.staticmethod
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -3998,7 +3998,7 @@ trulens_eval.feedback.provider.bedrock.Bedrock:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -4006,7 +4006,7 @@ trulens_eval.feedback.provider.bedrock.Bedrock:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_id: builtins.str
     model_json_schema: builtins.classmethod
@@ -4090,7 +4090,7 @@ trulens_eval.feedback.provider.cortex.Cortex:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -4098,7 +4098,7 @@ trulens_eval.feedback.provider.cortex.Cortex:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4171,14 +4171,14 @@ trulens_eval.feedback.provider.endpoint.BedrockEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4237,14 +4237,14 @@ trulens_eval.feedback.provider.endpoint.CortexEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4312,14 +4312,14 @@ trulens_eval.feedback.provider.endpoint.DummyEndpoint:
     load: builtins.staticmethod
     loading_prob: builtins.property
     loading_time: builtins.property
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4382,14 +4382,14 @@ trulens_eval.feedback.provider.endpoint.Endpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4450,14 +4450,14 @@ trulens_eval.feedback.provider.endpoint.HuggingfaceEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4518,14 +4518,14 @@ trulens_eval.feedback.provider.endpoint.LangchainEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4584,14 +4584,14 @@ trulens_eval.feedback.provider.endpoint.LiteLLMEndpoint:
     json: builtins.function
     litellm_provider: builtins.str
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4640,14 +4640,14 @@ trulens_eval.feedback.provider.endpoint.OpenAIClient:
     formatted_objects: _contextvars.ContextVar
     from_orm: builtins.classmethod
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4690,14 +4690,14 @@ trulens_eval.feedback.provider.endpoint.OpenAIEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4776,14 +4776,14 @@ trulens_eval.feedback.provider.endpoint.base.DummyEndpoint:
     load: builtins.staticmethod
     loading_prob: builtins.property
     loading_time: builtins.property
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4846,14 +4846,14 @@ trulens_eval.feedback.provider.endpoint.base.Endpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4906,14 +4906,14 @@ trulens_eval.feedback.provider.endpoint.base.EndpointCallback:
     handle_generation: builtins.function
     handle_generation_chunk: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -4957,14 +4957,14 @@ trulens_eval.feedback.provider.endpoint.bedrock.BedrockCallback:
     handle_generation: builtins.function
     handle_generation_chunk: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5007,14 +5007,14 @@ trulens_eval.feedback.provider.endpoint.bedrock.BedrockEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5075,14 +5075,14 @@ trulens_eval.feedback.provider.endpoint.cortex.CortexCallback:
     handle_generation: builtins.function
     handle_generation_chunk: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5124,14 +5124,14 @@ trulens_eval.feedback.provider.endpoint.cortex.CortexEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5191,14 +5191,14 @@ trulens_eval.feedback.provider.endpoint.hugs.HuggingfaceCallback:
     handle_generation: builtins.function
     handle_generation_chunk: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5243,14 +5243,14 @@ trulens_eval.feedback.provider.endpoint.hugs.HuggingfaceEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5312,14 +5312,14 @@ trulens_eval.feedback.provider.endpoint.langchain.LangchainCallback:
     handle_generation: builtins.function
     handle_generation_chunk: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5362,14 +5362,14 @@ trulens_eval.feedback.provider.endpoint.langchain.LangchainEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5429,14 +5429,14 @@ trulens_eval.feedback.provider.endpoint.litellm.LiteLLMCallback:
     handle_generation: builtins.function
     handle_generation_chunk: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5479,14 +5479,14 @@ trulens_eval.feedback.provider.endpoint.litellm.LiteLLMEndpoint:
     json: builtins.function
     litellm_provider: builtins.str
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5549,14 +5549,14 @@ trulens_eval.feedback.provider.endpoint.openai.OpenAICallback:
     handle_generation_chunk: builtins.function
     json: builtins.function
     langchain_handler: langchain_community.callbacks.openai_info.OpenAICallbackHandler
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5589,14 +5589,14 @@ trulens_eval.feedback.provider.endpoint.openai.OpenAIClient:
     formatted_objects: _contextvars.ContextVar
     from_orm: builtins.classmethod
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5639,14 +5639,14 @@ trulens_eval.feedback.provider.endpoint.openai.OpenAIEndpoint:
     instrumented_methods: collections.defaultdict
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5716,14 +5716,14 @@ trulens_eval.feedback.provider.hugs.Dummy:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5766,14 +5766,14 @@ trulens_eval.feedback.provider.hugs.Huggingface:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5816,14 +5816,14 @@ trulens_eval.feedback.provider.hugs.HuggingfaceBase:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5866,14 +5866,14 @@ trulens_eval.feedback.provider.hugs.HuggingfaceLocal:
     json: builtins.function
     language_match: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -5948,7 +5948,7 @@ trulens_eval.feedback.provider.langchain.Langchain:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -5956,7 +5956,7 @@ trulens_eval.feedback.provider.langchain.Langchain:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6038,7 +6038,7 @@ trulens_eval.feedback.provider.litellm.LiteLLM:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -6046,7 +6046,7 @@ trulens_eval.feedback.provider.litellm.LiteLLM:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6129,7 +6129,7 @@ trulens_eval.feedback.provider.openai.AzureOpenAI:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -6137,7 +6137,7 @@ trulens_eval.feedback.provider.openai.AzureOpenAI:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6221,7 +6221,7 @@ trulens_eval.feedback.provider.openai.OpenAI:
     misogyny: builtins.function
     misogyny_with_cot_reasons: builtins.function
     model_agreement: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
@@ -6229,7 +6229,7 @@ trulens_eval.feedback.provider.openai.OpenAI:
     model_dump_json: builtins.function
     model_engine: builtins.str
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6459,14 +6459,14 @@ trulens_eval.schema.app.AppDefinition:
     jsonify_extra: builtins.function
     load: builtins.staticmethod
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6569,14 +6569,14 @@ trulens_eval.schema.feedback.FeedbackCall:
     from_orm: builtins.classmethod
     json: builtins.function
     meta: typing.Dict[builtins.str, typing.Any]
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6634,14 +6634,14 @@ trulens_eval.schema.feedback.FeedbackDefinition:
       builtins.NoneType]
     json: builtins.function
     load: builtins.staticmethod
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6707,14 +6707,14 @@ trulens_eval.schema.feedback.FeedbackResult:
     from_orm: builtins.classmethod
     json: builtins.function
     last_ts: datetime.datetime
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6814,14 +6814,14 @@ trulens_eval.schema.record.Record:
       builtins.NoneType, typing.Sequence[typing.Any], typing.Dict[builtins.str, typing.Any]]
     meta: typing.Union[builtins.str, builtins.int, builtins.float, builtins.bytes,
       builtins.NoneType, typing.Sequence[typing.Any], typing.Dict[builtins.str, typing.Any]]
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6860,14 +6860,14 @@ trulens_eval.schema.record.RecordAppCall:
     from_orm: builtins.classmethod
     json: builtins.function
     method: builtins.property
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -6904,14 +6904,14 @@ trulens_eval.schema.record.RecordAppCallMethod:
     from_orm: builtins.classmethod
     json: builtins.function
     method: trulens.core.utils.pyschema.Method
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -7001,14 +7001,14 @@ trulens_eval.tru.Tru:
     get_records_and_feedback: builtins.function
     json: builtins.function
     migrate_database: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -7087,14 +7087,14 @@ trulens_eval.tru_basic_app.TruBasicApp:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -7232,14 +7232,14 @@ trulens_eval.tru_chain.TruChain:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -7342,14 +7342,14 @@ trulens_eval.tru_custom_app.TruCustomApp:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -7472,14 +7472,14 @@ trulens_eval.tru_llama.TruLlama:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -7640,14 +7640,14 @@ trulens_eval.tru_rails.TruRails:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -7749,14 +7749,14 @@ trulens_eval.tru_virtual.TruVirtual:
     manage_pending_feedback_results_thread: typing.Optional[trulens.core.utils.threading.Thread,
       builtins.NoneType]
     metadata: typing.Dict
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -7840,14 +7840,14 @@ trulens_eval.tru_virtual.VirtualRecord:
       builtins.NoneType, typing.Sequence[typing.Any], typing.Dict[builtins.str, typing.Any]]
     meta: typing.Union[builtins.str, builtins.int, builtins.float, builtins.bytes,
       builtins.NoneType, typing.Sequence[typing.Any], typing.Dict[builtins.str, typing.Any]]
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8181,14 +8181,14 @@ trulens_eval.utils.pyschema.Bindings:
     json: builtins.function
     kwargs: typing.Dict[builtins.str, typing.Any]
     load: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8221,14 +8221,14 @@ trulens_eval.utils.pyschema.Class:
     from_orm: builtins.classmethod
     json: builtins.function
     load: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8265,14 +8265,14 @@ trulens_eval.utils.pyschema.Function:
     from_orm: builtins.classmethod
     json: builtins.function
     load: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8306,14 +8306,14 @@ trulens_eval.utils.pyschema.FunctionOrMethod:
     from_orm: builtins.classmethod
     json: builtins.function
     load: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8344,14 +8344,14 @@ trulens_eval.utils.pyschema.Method:
     from_orm: builtins.classmethod
     json: builtins.function
     load: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8385,14 +8385,14 @@ trulens_eval.utils.pyschema.Module:
     from_orm: builtins.classmethod
     json: builtins.function
     load: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8429,14 +8429,14 @@ trulens_eval.utils.pyschema.Obj:
     init_bindings: typing.Optional[trulens.core.utils.pyschema.Bindings, builtins.NoneType]
     json: builtins.function
     load: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8589,14 +8589,14 @@ trulens_eval.utils.serial.Collect:
     get: builtins.function
     get_sole_item: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8627,14 +8627,14 @@ trulens_eval.utils.serial.GetAttribute:
     get_item_or_attribute: builtins.function
     get_sole_item: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8664,14 +8664,14 @@ trulens_eval.utils.serial.GetIndex:
     get_sole_item: builtins.function
     index: builtins.int
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8701,14 +8701,14 @@ trulens_eval.utils.serial.GetIndices:
     get_sole_item: builtins.function
     indices: typing.Tuple[builtins.int, ...]
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8739,14 +8739,14 @@ trulens_eval.utils.serial.GetItem:
     get_sole_item: builtins.function
     item: builtins.str
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8777,14 +8777,14 @@ trulens_eval.utils.serial.GetItemOrAttribute:
     get_sole_item: builtins.function
     item_or_attribute: builtins.str
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8814,14 +8814,14 @@ trulens_eval.utils.serial.GetItems:
     get_sole_item: builtins.function
     items: typing.Tuple[builtins.str, ...]
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8850,14 +8850,14 @@ trulens_eval.utils.serial.GetSlice:
     get: builtins.function
     get_sole_item: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod
@@ -8939,14 +8939,14 @@ trulens_eval.utils.serial.StepItemOrAttribute:
     get_item_or_attribute: builtins.function
     get_sole_item: builtins.function
     json: builtins.function
-    model_computed_fields: builtins.dict
+    model_computed_fields: builtins.property
     model_config: builtins.dict
     model_construct: builtins.classmethod
     model_copy: builtins.function
     model_dump: builtins.function
     model_dump_json: builtins.function
     model_extra: builtins.property
-    model_fields: builtins.dict
+    model_fields: builtins.property
     model_fields_set: builtins.property
     model_json_schema: builtins.classmethod
     model_parametrized_name: builtins.classmethod

--- a/tests/unit/test_otel_instrument.py
+++ b/tests/unit/test_otel_instrument.py
@@ -2,6 +2,7 @@
 Tests for OTEL instrument decorator.
 """
 
+import os
 from unittest import main
 
 import pandas as pd
@@ -72,6 +73,7 @@ class TestOtelInstrument(TruTestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
+        os.environ["TRULENS_OTEL_TRACING"] = "1"
         cls.clear_TruSession_singleton()
         tru_session = TruSession()
         tru_session.experimental_enable_feature("otel_tracing")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -367,7 +367,9 @@ def get_class_members(
     # Cannot get attributes of pydantic models in the above ways so we have
     # special handling for them here:
     fields_members = []
-    if hasattr(class_, "model_fields"):  # pydantic.BaseModel (v2)
+    if hasattr(class_, "model_fields") and hasattr(
+        class_.model_fields, "items"
+    ):  # pydantic.BaseModel (v2)
         fields_members = [
             (name, field.default, field.annotation)
             for name, field in class_.model_fields.items()


### PR DESCRIPTION
# Description
Don't create event tables unless `TRULENS_OTEL_TRACING` env variable is set.

Currently things are broken for dialects that don't handle JSON which include Snowflake and possibly other stuff.

## Other details good to know for developers

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Event tables are conditionally created based on `TRULENS_OTEL_TRACING` environment variable to fix JSON dialect issues.
> 
>   - **Behavior**:
>     - Event tables are only created if `TRULENS_OTEL_TRACING` environment variable is set to "1" or "true" in `10_create_event_table.py`.
>     - Fixes issues with database dialects that do not support JSON, such as Snowflake.
>   - **Testing**:
>     - Sets `TRULENS_OTEL_TRACING` to "1" in `setUpClass` of `TestOtelInstrument` in `test_otel_instrument.py`.
>   - **Utilities**:
>     - Adds check for `model_fields` having `items` attribute in `get_class_members` in `utils.py` to handle Pydantic models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for d420a17bd117c9b98aa5e9b69d424c40f8c7f8e4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->