### PR TITLE
Handle pydantic upgrade that now handles `model_fields` as a `property` that can resolve to a `dict` when there's nothing.

### DIFF
--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -4,7 +4,7 @@ trulens:
   lows: {}
 trulens.benchmark:
   __class__: builtins.module
-  __version__: 1.2.11
+  __version__: 1.3.1
   highs: {}
   lows:
     __version__: builtins.str
@@ -60,7 +60,7 @@ trulens.benchmark.test_cases:
     generate_summeval_groundedness_golden_set: builtins.function
 trulens.core:
   __class__: builtins.module
-  __version__: 1.2.11
+  __version__: 1.3.1
   highs:
     Feedback: pydantic._internal._model_construction.ModelMetaclass
     FeedbackMode: enum.EnumType
@@ -1727,7 +1727,7 @@ trulens.core.utils.trulens.Other:
   attributes: {}
 trulens.dashboard:
   __class__: builtins.module
-  __version__: 1.2.11
+  __version__: 1.3.1
   highs:
     run_dashboard: builtins.function
     run_dashboard_sis: builtins.function
@@ -2015,7 +2015,7 @@ trulens.dashboard.ux.styles.ResultCategoryType:
     value: enum.property
 trulens.feedback:
   __class__: builtins.module
-  __version__: 1.2.11
+  __version__: 1.3.1
   highs:
     Embeddings: pydantic._internal._model_construction.ModelMetaclass
     GroundTruthAggregator: pydantic._internal._model_construction.ModelMetaclass

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -367,7 +367,9 @@ def get_class_members(
     # Cannot get attributes of pydantic models in the above ways so we have
     # special handling for them here:
     fields_members = []
-    if hasattr(class_, "model_fields"):  # pydantic.BaseModel (v2)
+    if hasattr(class_, "model_fields") and hasattr(
+        class_.model_fields, "items"
+    ):  # pydantic.BaseModel (v2)
         fields_members = [
             (name, field.default, field.annotation)
             for name, field in class_.model_fields.items()


### PR DESCRIPTION
# Description
Handle pydantic upgrade that now handles `model_fields` as a `property` that can resolve to a `dict` when there's nothing.

## Other details good to know for developers
`pydantic` 2.9.2 was fine, but the newer versions do this (like 2.10.4).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix compatibility with Pydantic 2.10.4+ by checking `model_fields` for `items` method in `get_class_members`.
> 
>   - **Bug Fix**:
>     - Update `get_class_members` in `tests/utils.py` to check if `model_fields` has `items` method before accessing, ensuring compatibility with Pydantic 2.10.4+.
>   - **Misc**:
>     - Update version numbers in `api.trulens.3.11.yaml` to 1.3.1.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 72646c6aac660515063103bd336b29139fc650f0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->