### PR TITLE
Require version of snowflake ml python >= 1.7.2

### DIFF
--- a/src/connectors/snowflake/meta.yaml
+++ b/src/connectors/snowflake/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   host:
-    - python >=3.8.1,<3.12
+    - python >=3.9,<3.12
     - poetry-core <2.0.0
     - pip
   run:

--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   host:
-    - python >=3.8.1
+    - python >=3.9
     - poetry-core <2.0.0
     - pip
   run:

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   host:
-    - python >=3.9.0,<3.12
+    - python >=3.9,<3.12
     - poetry-core <2.0.0
     - pip
   run:

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   host:
-    - python >=3.8,<3.12
+    - python >=3.9.0,<3.12
     - poetry-core <2.0.0
     - pip
   run:

--- a/src/feedback/meta.yaml
+++ b/src/feedback/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   host:
-    - python >=3.8.1
+    - python >=3.9
     - poetry-core <2.0.0
     - pip
   run:

--- a/src/otel/semconv/meta.yaml
+++ b/src/otel/semconv/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   host:
-    - python >=3.8.1,<3.12
+    - python >=3.9,<3.12
     - poetry-core <2.0.0
     - pip
   run:
-    - python >=3.8.1,<3.12
+    - python >=3.9,<3.12
     - opentelemetry-semantic-conventions >=0.36b0
 
 test:

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   host:
-    - python >=3.8.1,<3.12
+    - python >=3.9,<3.12
     - poetry-core <2.0.0
     - pip
   run:

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - trulens-core >=1.0.0,<2.0.0
     - trulens-feedback >=1.0.0,<2.0.0
     - snowflake-connector-python >=3.11.0,<4.0.0
-    - snowflake-ml-python >=1.7.1
+    - snowflake-ml-python >=1.7.2
     - snowflake-snowpark-python >=1.18.0,<2.0.0
 
 test:

--- a/src/providers/cortex/pyproject.toml
+++ b/src/providers/cortex/pyproject.toml
@@ -32,7 +32,7 @@ packaging = ">=23.0"
 trulens-core = { version = "^1.0.0" }
 trulens-feedback = { version = "^1.0.0" }
 snowflake-connector-python = "^3.11"
-snowflake-ml-python = "^1.6.4"
+snowflake-ml-python = "^1.7.2"
 scipy = [
   { version = ">=1.7.0,<1.11.1", python = "<3.9" },
   { version = ">=1.11.1", python = ">=3.9" },

--- a/src/providers/cortex/pyproject.toml
+++ b/src/providers/cortex/pyproject.toml
@@ -27,14 +27,13 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8.1,<3.12"
+python = "^3.9,<3.12"
 packaging = ">=23.0"
 trulens-core = { version = "^1.0.0" }
 trulens-feedback = { version = "^1.0.0" }
 snowflake-connector-python = "^3.11"
 snowflake-ml-python = "^1.7.2"
 scipy = [
-  { version = ">=1.7.0,<1.11.1", python = "<3.9" },
   { version = ">=1.11.1", python = ">=3.9" },
 ]
 snowflake-snowpark-python = "^1.18.0"


### PR DESCRIPTION
# Description

This is to ensure customers running Cortex LLM Complete are all hitting the latest code path using REST API, and to get cost tracking working properly.

We previously couldn't do this as Streamlit in Snowflake did not support python > 3.8, but now it does. 

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update Python version to `>=3.9,<3.12` and `snowflake-ml-python` to `>=1.7.2` across multiple components.
> 
>   - **Requirements**:
>     - Update Python version requirement to `>=3.9,<3.12` in `meta.yaml` files for `connectors/snowflake`, `core`, `dashboard`, `feedback`, `otel/semconv`, and `providers/cortex`.
>     - Update `snowflake-ml-python` version to `>=1.7.2` in `providers/cortex/meta.yaml` and `pyproject.toml`.
>   - **Misc**:
>     - Remove specific `scipy` version constraint for Python `<3.9` in `providers/cortex/pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 6d84397aebdeb95b580e1f0d33c2f11bab7a6cba. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->