### PR TITLE
Quieter Instrumentation

### DIFF
--- a/src/core/trulens/apps/app.py
+++ b/src/core/trulens/apps/app.py
@@ -416,7 +416,7 @@ class TruApp(core_app.App):
                         next(full_path.get(json))
 
                     except Exception:
-                        logger.warning(
+                        logger.debug(
                             f"App has no component owner of instrumented method {m} at path {full_path}. "
                             f"Specify the component with the `app_extra_json` argument to TruApp constructor. "
                             f"Creating a placeholder there for now."

--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -1592,7 +1592,7 @@ you use the `%s` wrapper to make sure `%s` does get instrumented. `%s` method
     def print_instrumented_methods(self) -> None:
         """Print instrumented methods."""
 
-        print(self.format_instrumented_methods())
+        logger.info(self.format_instrumented_methods())
 
     def print_instrumented_components(self) -> None:
         """Print instrumented components and their categories."""
@@ -1606,7 +1606,7 @@ you use the `%s` wrapper to make sure `%s` does get instrumented. `%s` method
                 f"\t{type(obj).__name__} ({t[1].__class__.__name__}) at 0x{id(obj):x} with path {str(t[0])}"
             )
 
-        print("\n".join(object_strings))
+        logger.info("\n".join(object_strings))
 
 
 # NOTE: Cannot App.model_rebuild here due to circular imports involving mod_session.TruSession

--- a/src/core/trulens/core/feedback/endpoint.py
+++ b/src/core/trulens/core/feedback/endpoint.py
@@ -504,7 +504,7 @@ class Endpoint(
                     # at getattr. Skip either way.
                     continue
                 except Exception as e:
-                    logger.warning(
+                    logger.debug(
                         "Could not import tracking module %s. "
                         "trulens will not track costs/usage of this endpoint. %s",
                         endpoint_setup.module_name,
@@ -520,7 +520,7 @@ class Endpoint(
                 try:
                     if endpoint is None:
                         if cls.__name__ not in Endpoint.BASE_ENDPOINTS:
-                            logger.warning(
+                            logger.debug(
                                 "Could not find an instance of %s. "
                                 "trulens will create an endpoint for cost tracking.",
                                 cls.__name__,

--- a/src/core/trulens/core/instruments.py
+++ b/src/core/trulens/core/instruments.py
@@ -479,7 +479,7 @@ class Instrument:
         t = "  "
 
         for mod in sorted(self.include_modules):
-            print(f"Module {mod}*")
+            logger.info(f"Module {mod}*")
 
             for cls in sorted(
                 self.include_classes,
@@ -489,17 +489,17 @@ class Instrument:
                     continue
 
                 if isinstance(cls, import_utils.Dummy):
-                    print(
+                    logger.warning(
                         f"{t * 1}Class {cls.__module__}.{cls.__qualname__}\n{t * 2}WARNING: this class could not be imported. It may have been (re)moved. Error:"
                     )
-                    print(
+                    logger.warning(
                         text_utils.retab(
                             tab=f"{t * 3}> ", s=str(cls.original_exception)
                         )
                     )
                     continue
 
-                print(f"{t * 1}Class {cls.__module__}.{cls.__qualname__}")
+                logger.info(f"{t * 1}Class {cls.__module__}.{cls.__qualname__}")
 
                 for instrumented_method in self.include_methods:
                     method = instrumented_method.method
@@ -508,9 +508,9 @@ class Instrument:
                         f=class_filter, obj=cls
                     ) and python_utils.safe_hasattr(cls, method):
                         f = getattr(cls, method)
-                        print(f"{t * 2}Method {method}: {inspect.signature(f)}")
-
-            print()
+                        logger.info(
+                            f"{t * 2}Method {method}: {inspect.signature(f)}"
+                        )
 
     def to_instrument_object(self, obj: object) -> bool:
         """Determine whether the given object should be instrumented."""
@@ -794,7 +794,7 @@ class Instrument:
                 # pairs even if positional arguments were provided.
                 bindings: BoundArguments = sig.bind(*args, **kwargs)
 
-                print(f"calling {func} with {args}")
+                logger.info(f"calling {func} with {args}")
 
                 rets, tally = core_endpoint.Endpoint.track_all_costs_tally(
                     func, *args, **kwargs
@@ -1100,7 +1100,7 @@ class Instrument:
 
             try:
                 if not self.to_instrument_class(base):
-                    print(f"skipping base {base} because of class")
+                    logger.debug(f"skipping base {base} because of class")
                     continue
 
             except Exception as e:


### PR DESCRIPTION
# Description

Change printing to logging for some instrumentation related things, addressing https://github.com/truera/trulens/issues/1776

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR updates logging practices by changing certain `warning` logs to `debug` and replacing `print` statements with `logger.info` in various files for improved log management.
> 
>   - **Logging Changes**:
>     - Change `logger.warning` to `logger.debug` in `app.py` and `endpoint.py` for non-critical messages.
>     - Replace `print` with `logger.info` in `core/app.py` and `instruments.py` for better logging practices.
>   - **Affected Functions**:
>     - `__init__` in `app.py` and `track_all_costs` in `endpoint.py` now use `logger.debug` for certain exceptions.
>     - `print_instrumented_methods` and `print_instrumented_components` in `core/app.py` now use `logger.info` instead of `print`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for fdabcee51fad209e0317532c6da765ead077165b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->