### PR TITLE
Remove `pytest.ini` as it's interfering with the `pyproject.toml`.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-markers =
-    slow: marks tests as slow
-    nonfree: marks tests that may incur API costs


### PR DESCRIPTION
# Description
Remove `pytest.ini` as I think it's interfering with the `pyproject.toml`.

It's not a big deal or anything, but the tests keep saying stuff like:
```
##[warning]Unknown pytest.mark.optional - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
```
even though I put it in the `pyproject.toml`. The existence of the `pytest.ini` seems to take precedence though so I'm removing it as it's not even necessary.

## Other details good to know for developers

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
