### PR TITLE
Create OTEL span processor that can add trulens span attributes into spans not originated by trulens.

### DIFF
--- a/src/core/trulens/experimental/otel_tracing/core/session.py
+++ b/src/core/trulens/experimental/otel_tracing/core/session.py
@@ -48,7 +48,9 @@ class TrulensOtelSpanProcessor(otel_export_sdk.BatchSpanProcessor):
         self, span: Span, parent_context: Optional[Context] = None
     ) -> None:
         set_general_span_attributes(
-            span, span_type=SpanAttributes.SpanType.UNKNOWN
+            span,
+            span_type=SpanAttributes.SpanType.UNKNOWN,
+            context=parent_context,
         )
 
 

--- a/src/core/trulens/experimental/otel_tracing/core/session.py
+++ b/src/core/trulens/experimental/otel_tracing/core/session.py
@@ -2,15 +2,20 @@ import logging
 from typing import Any, Callable, Dict, Optional
 
 from opentelemetry import trace
+from opentelemetry.context import Context
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace import export as otel_export_sdk
+from opentelemetry.trace.span import Span
 from trulens.core import session as core_session
 from trulens.core.database.connector import DBConnector
 from trulens.core.utils import python as python_utils
 from trulens.core.utils import text as text_utils
 from trulens.experimental.otel_tracing.core.exporter.connector import (
     TruLensOTELSpanExporter,
+)
+from trulens.experimental.otel_tracing.core.span import (
+    set_general_span_attributes,
 )
 from trulens.otel.semconv.trace import SpanAttributes
 
@@ -36,6 +41,15 @@ def _can_import(to_import: str) -> bool:
         return True
     except ImportError:
         return False
+
+
+class TrulensOtelSpanProcessor(otel_export_sdk.BatchSpanProcessor):
+    def on_start(
+        self, span: Span, parent_context: Optional[Context] = None
+    ) -> None:
+        set_general_span_attributes(
+            span, span_type=SpanAttributes.SpanType.UNKNOWN
+        )
 
 
 class _TruSession(core_session.TruSession):
@@ -82,8 +96,8 @@ class _TruSession(core_session.TruSession):
             self, exporter, connector
         )
 
-        self._experimental_otel_span_processor = (
-            otel_export_sdk.BatchSpanProcessor(exporter)
+        self._experimental_otel_span_processor = TrulensOtelSpanProcessor(
+            exporter
         )
         tracer_provider.add_span_processor(
             self._experimental_otel_span_processor

--- a/src/core/trulens/experimental/otel_tracing/core/span.py
+++ b/src/core/trulens/experimental/otel_tracing/core/span.py
@@ -134,10 +134,6 @@ def set_general_span_attributes(
     target_record_id = get_baggage(
         SpanAttributes.EVAL.TARGET_RECORD_ID, context
     )
-    record_id = get_baggage(SpanAttributes.RECORD_ID)
-    if record_id:
-        span.set_attribute(SpanAttributes.RECORD_ID, record_id)
-    target_record_id = get_baggage(SpanAttributes.EVAL.TARGET_RECORD_ID)
     if target_record_id:
         span.set_attribute(
             SpanAttributes.EVAL.TARGET_RECORD_ID, target_record_id
@@ -145,7 +141,7 @@ def set_general_span_attributes(
     eval_root_id = get_baggage(SpanAttributes.EVAL.EVAL_ROOT_ID, context)
     if eval_root_id:
         span.set_attribute(SpanAttributes.EVAL.EVAL_ROOT_ID, eval_root_id)
-    feedback_name = get_baggage(SpanAttributes.EVAL.FEEDBACK_NAME)
+    feedback_name = get_baggage(SpanAttributes.EVAL.FEEDBACK_NAME, context)
     if feedback_name:
         span.set_attribute(SpanAttributes.EVAL.FEEDBACK_NAME, feedback_name)
 

--- a/tests/unit/test_otel_span_processor.py
+++ b/tests/unit/test_otel_span_processor.py
@@ -1,0 +1,54 @@
+from opentelemetry import trace
+from trulens.apps.app import TruApp
+from trulens.core.otel.instrument import instrument
+from trulens.core.session import TruSession
+from trulens.otel.semconv.trace import SpanAttributes
+
+from tests.util.otel_app_test_case import OtelAppTestCase
+
+
+class _TestApp:
+    @instrument()
+    def greet(self, name: str) -> str:
+        ret = f"Hello, {name}!"
+        ret = self.capitalize(ret)
+        return ret
+
+    def capitalize(self, txt: str) -> str:
+        tracer = trace.get_tracer(__name__)
+        with tracer.start_as_current_span("capitalize") as span:
+            span.set_attribute("best_baby", "Kojikun")
+        return txt.upper()
+
+
+class TestOtelSpanProcessor(OtelAppTestCase):
+    def test_span_processor(self) -> None:
+        # Create app.
+        app = _TestApp()
+        tru_recorder = TruApp(
+            app,
+            app_name="Simple Greeter",
+            app_version="v1",
+            main_method=app.greet,
+        )
+        # Record and invoke.
+        with tru_recorder(run_name="test run", input_id="42"):
+            app.greet("Kojikun")
+        # Verify.
+        TruSession().force_flush()
+        events = self._get_events()
+        self.assertEqual(len(events), 3)
+        self.assertEqual(
+            "Kojikun", events.iloc[-1]["record_attributes"]["best_baby"]
+        )
+        for curr in [
+            SpanAttributes.RECORD_ID,
+            SpanAttributes.APP_NAME,
+            SpanAttributes.APP_VERSION,
+            SpanAttributes.RUN_NAME,
+            SpanAttributes.INPUT_ID,
+        ]:
+            self.assertEqual(
+                events.iloc[1]["record_attributes"][curr],
+                events.iloc[-1]["record_attributes"][curr],
+            )

--- a/tests/unit/test_otel_span_processor.py
+++ b/tests/unit/test_otel_span_processor.py
@@ -48,7 +48,9 @@ class TestOtelSpanProcessor(OtelAppTestCase):
             SpanAttributes.RUN_NAME,
             SpanAttributes.INPUT_ID,
         ]:
-            self.assertEqual(
-                events.iloc[1]["record_attributes"][curr],
-                events.iloc[-1]["record_attributes"][curr],
-            )
+            self.assertTrue(bool(events.iloc[-1]["record_attributes"][curr]))
+            for i in range(1, len(events)):
+                self.assertEqual(
+                    events.iloc[0]["record_attributes"][curr],
+                    events.iloc[i]["record_attributes"][curr],
+                )

--- a/tests/unit/test_otel_tru_chain.py
+++ b/tests/unit/test_otel_tru_chain.py
@@ -4,7 +4,6 @@ Tests for OTEL TruChain app.
 
 import pytest
 from trulens.core.otel.instrument import instrument
-from trulens.core.session import TruSession
 
 from tests.util.otel_app_test_case import OtelAppTestCase
 
@@ -18,6 +17,7 @@ try:
     from langchain_community.vectorstores import FAISS
     from langchain_core.runnables import RunnablePassthrough
     from langchain_text_splitters import RecursiveCharacterTextSplitter
+    from opentelemetry.instrumentation.langchain import LangchainInstrumentor
     from trulens.apps.langchain import TruChain
 except Exception:
     pass
@@ -59,9 +59,8 @@ class TestOtelTruChain(OtelAppTestCase):
         )
 
     def test_smoke(self) -> None:
-        # Set up.
-        tru_session = TruSession()
-        tru_session.reset_database()
+        # Instrument langchain
+        LangchainInstrumentor().instrument()
         # Create app.
         rag_chain = self._create_simple_rag()
         tru_recorder = TruChain(

--- a/tests/unit/test_otel_tru_chain.py
+++ b/tests/unit/test_otel_tru_chain.py
@@ -17,7 +17,6 @@ try:
     from langchain_community.vectorstores import FAISS
     from langchain_core.runnables import RunnablePassthrough
     from langchain_text_splitters import RecursiveCharacterTextSplitter
-    from opentelemetry.instrumentation.langchain import LangchainInstrumentor
     from trulens.apps.langchain import TruChain
 except Exception:
     pass
@@ -59,8 +58,6 @@ class TestOtelTruChain(OtelAppTestCase):
         )
 
     def test_smoke(self) -> None:
-        # Instrument langchain
-        LangchainInstrumentor().instrument()
         # Create app.
         rag_chain = self._create_simple_rag()
         tru_recorder = TruChain(


### PR DESCRIPTION
# Description
Create OTEL span processor that can add trulens span attributes into spans not originated by trulens. This will make it possible to incorporate spans from others.

## Other details good to know for developers\

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `TrulensOtelSpanProcessor` to enhance span attributes and includes tests for verification.
> 
>   - **New Feature**:
>     - Introduces `TrulensOtelSpanProcessor` in `session.py` to add TruLens span attributes to non-TruLens spans.
>     - Utilizes `set_general_span_attributes` in `span.py` to set attributes like `APP_NAME`, `APP_VERSION`, etc.
>   - **Tests**:
>     - Adds `test_otel_span_processor.py` to verify the new span processor functionality.
>     - Updates `test_otel_tru_chain.py` to ensure compatibility with the new processor.
>   - **Misc**:
>     - Modifies `set_general_span_attributes` in `span.py` to accept an optional `Context` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 21c7fd6886c9963be4200352ce05681ce9248e87. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->