### PR TITLE
Bugfix: Avoid ingestion of incorrectly generated spans.

### DIFF
--- a/examples/experimental/otel_exporter.ipynb
+++ b/examples/experimental/otel_exporter.ipynb
@@ -63,15 +63,23 @@
     "\n",
     "from snowflake.snowpark import Session\n",
     "\n",
-    "snowflake_connection_parameters = {\n",
-    "    \"account\": os.environ[\"SNOWFLAKE_ACCOUNT\"],\n",
-    "    \"user\": os.environ[\"SNOWFLAKE_USER\"],\n",
-    "    \"password\": os.environ[\"SNOWFLAKE_USER_PASSWORD\"],\n",
-    "    \"database\": os.environ[\"SNOWFLAKE_DATABASE\"],\n",
-    "    \"schema\": os.environ[\"SNOWFLAKE_SCHEMA\"],\n",
-    "    \"role\": os.environ[\"SNOWFLAKE_ROLE\"],\n",
-    "    \"warehouse\": os.environ[\"SNOWFLAKE_WAREHOUSE\"],\n",
-    "}\n",
+    "conn_name = os.environ.get(\"SNOWFLAKE_CONNECTION_NAME\", \"qa6\")\n",
+    "if conn_name:\n",
+    "    snowflake_connection_parameters = {\n",
+    "        \"connection_name\": conn_name,\n",
+    "        \"database\": \"APGUPTA\",\n",
+    "        \"schema\": \"AI_EVAL_0205\",\n",
+    "    }\n",
+    "else:\n",
+    "    snowflake_connection_parameters = {\n",
+    "        \"account\": os.environ[\"SNOWFLAKE_ACCOUNT\"],\n",
+    "        \"user\": os.environ[\"SNOWFLAKE_USER\"],\n",
+    "        \"password\": os.environ[\"SNOWFLAKE_USER_PASSWORD\"],\n",
+    "        \"database\": os.environ[\"SNOWFLAKE_DATABASE\"],\n",
+    "        \"schema\": os.environ[\"SNOWFLAKE_SCHEMA\"],\n",
+    "        \"role\": os.environ[\"SNOWFLAKE_ROLE\"],\n",
+    "        \"warehouse\": os.environ[\"SNOWFLAKE_WAREHOUSE\"],\n",
+    "    }\n",
     "snowpark_session = Session.builder.configs(\n",
     "    snowflake_connection_parameters\n",
     ").create()"
@@ -154,7 +162,7 @@
     "\n",
     "from trulens.apps.app import TruApp\n",
     "\n",
-    "APP_NAME = f\"{os.getlogin()}'s test app\"\n",
+    "APP_NAME = f\"{os.getlogin()} - 0214\"\n",
     "APP_VERSION = str(datetime.now())\n",
     "\n",
     "test_app = TestApp()\n",
@@ -270,11 +278,29 @@
     "res = wait_for_nonzero_results()\n",
     "res"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "APP_NAME"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wait_for_nonzero_results()"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "trulens_3_11",
+   "display_name": "snow",
    "language": "python",
    "name": "python3"
   },

--- a/examples/experimental/otel_exporter.ipynb
+++ b/examples/experimental/otel_exporter.ipynb
@@ -63,23 +63,15 @@
     "\n",
     "from snowflake.snowpark import Session\n",
     "\n",
-    "conn_name = os.environ.get(\"SNOWFLAKE_CONNECTION_NAME\", \"qa6\")\n",
-    "if conn_name:\n",
-    "    snowflake_connection_parameters = {\n",
-    "        \"connection_name\": conn_name,\n",
-    "        \"database\": \"APGUPTA\",\n",
-    "        \"schema\": \"AI_EVAL_0205\",\n",
-    "    }\n",
-    "else:\n",
-    "    snowflake_connection_parameters = {\n",
-    "        \"account\": os.environ[\"SNOWFLAKE_ACCOUNT\"],\n",
-    "        \"user\": os.environ[\"SNOWFLAKE_USER\"],\n",
-    "        \"password\": os.environ[\"SNOWFLAKE_USER_PASSWORD\"],\n",
-    "        \"database\": os.environ[\"SNOWFLAKE_DATABASE\"],\n",
-    "        \"schema\": os.environ[\"SNOWFLAKE_SCHEMA\"],\n",
-    "        \"role\": os.environ[\"SNOWFLAKE_ROLE\"],\n",
-    "        \"warehouse\": os.environ[\"SNOWFLAKE_WAREHOUSE\"],\n",
-    "    }\n",
+    "snowflake_connection_parameters = {\n",
+    "    \"account\": os.environ[\"SNOWFLAKE_ACCOUNT\"],\n",
+    "    \"user\": os.environ[\"SNOWFLAKE_USER\"],\n",
+    "    \"password\": os.environ[\"SNOWFLAKE_USER_PASSWORD\"],\n",
+    "    \"database\": os.environ[\"SNOWFLAKE_DATABASE\"],\n",
+    "    \"schema\": os.environ[\"SNOWFLAKE_SCHEMA\"],\n",
+    "    \"role\": os.environ[\"SNOWFLAKE_ROLE\"],\n",
+    "    \"warehouse\": os.environ[\"SNOWFLAKE_WAREHOUSE\"],\n",
+    "}\n",
     "snowpark_session = Session.builder.configs(\n",
     "    snowflake_connection_parameters\n",
     ").create()"
@@ -162,7 +154,7 @@
     "\n",
     "from trulens.apps.app import TruApp\n",
     "\n",
-    "APP_NAME = f\"{os.getlogin()} - 0214_2\"\n",
+    "APP_NAME = f\"{os.getlogin()}'s test app\"\n",
     "APP_VERSION = str(datetime.now())\n",
     "\n",
     "test_app = TestApp()\n",
@@ -182,21 +174,21 @@
    "source": [
     "# Run app directly (a few separate ways).\n",
     "\n",
-    "# tru_app.instrumented_invoke_main_method(\n",
-    "#     run_name=\"test_run\",\n",
-    "#     input_id=\"456\",\n",
-    "#     main_method_args=(\"test\",),\n",
-    "# )\n",
+    "tru_app.instrumented_invoke_main_method(\n",
+    "    run_name=\"test_run\",\n",
+    "    input_id=\"456\",\n",
+    "    main_method_args=(\"test\",),\n",
+    ")\n",
     "\n",
-    "# with tru_app.run(\"test run 2\"):\n",
-    "#     with tru_app.input(\"789\"):\n",
-    "#         test_app.respond_to_query(\"789\")\n",
+    "with tru_app.run(\"test run 2\"):\n",
+    "    with tru_app.input(\"789\"):\n",
+    "        test_app.respond_to_query(\"789\")\n",
     "\n",
-    "# with tru_app:\n",
-    "#     test_app.respond_to_query(\"throw\")\n",
+    "with tru_app:\n",
+    "    test_app.respond_to_query(\"throw\")\n",
     "\n",
-    "# # Without flushing, the spans are not guaranteed to be sent.\n",
-    "# tru_session.force_flush()"
+    "# Without flushing, the spans are not guaranteed to be sent.\n",
+    "tru_session.force_flush()"
    ]
   },
   {
@@ -206,8 +198,6 @@
    "outputs": [],
    "source": [
     "# Run the app on a pandas DataFrame.\n",
-    "\n",
-    "import time\n",
     "\n",
     "import pandas as pd\n",
     "from trulens.core.app import App\n",
@@ -226,18 +216,12 @@
     "                main_method = getattr(test_app, tru_app.main_method_name)\n",
     "                main_method(row[input_column])\n",
     "    tru_app.session.force_flush()\n",
-    "    logging.debug(\"Run ended\")\n",
-    "    print(time.ctime())\n",
     "\n",
-    "\n",
-    "num_inputs = 1000\n",
-    "input_ids = list(range(num_inputs))\n",
-    "inputs = [f\"text{i}\" for i in range(num_inputs)]\n",
     "\n",
     "run_on_df(\n",
     "    tru_app,\n",
     "    \"df_run\",\n",
-    "    pd.DataFrame({\"input_id\": input_ids, \"input\": input_ids}),\n",
+    "    pd.DataFrame({\"input_id\": [1, 2], \"input\": [\"a\", \"b\"]}),\n",
     "    \"input_id\",\n",
     "    \"input\",\n",
     ")"
@@ -250,6 +234,8 @@
    "outputs": [],
    "source": [
     "# Read the event table.\n",
+    "\n",
+    "import time\n",
     "\n",
     "\n",
     "def wait_for_nonzero_results(\n",
@@ -284,38 +270,11 @@
     "res = wait_for_nonzero_results()\n",
     "res"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "APP_NAME"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wait_for_nonzero_results()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "bool(None)"
-   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "snow",
+   "display_name": "trulens_3_11",
    "language": "python",
    "name": "python3"
   },

--- a/examples/experimental/otel_exporter.ipynb
+++ b/examples/experimental/otel_exporter.ipynb
@@ -162,7 +162,7 @@
     "\n",
     "from trulens.apps.app import TruApp\n",
     "\n",
-    "APP_NAME = f\"{os.getlogin()} - 0214\"\n",
+    "APP_NAME = f\"{os.getlogin()} - 0214_2\"\n",
     "APP_VERSION = str(datetime.now())\n",
     "\n",
     "test_app = TestApp()\n",
@@ -182,21 +182,21 @@
    "source": [
     "# Run app directly (a few separate ways).\n",
     "\n",
-    "tru_app.instrumented_invoke_main_method(\n",
-    "    run_name=\"test_run\",\n",
-    "    input_id=\"456\",\n",
-    "    main_method_args=(\"test\",),\n",
-    ")\n",
+    "# tru_app.instrumented_invoke_main_method(\n",
+    "#     run_name=\"test_run\",\n",
+    "#     input_id=\"456\",\n",
+    "#     main_method_args=(\"test\",),\n",
+    "# )\n",
     "\n",
-    "with tru_app.run(\"test run 2\"):\n",
-    "    with tru_app.input(\"789\"):\n",
-    "        test_app.respond_to_query(\"789\")\n",
+    "# with tru_app.run(\"test run 2\"):\n",
+    "#     with tru_app.input(\"789\"):\n",
+    "#         test_app.respond_to_query(\"789\")\n",
     "\n",
-    "with tru_app:\n",
-    "    test_app.respond_to_query(\"throw\")\n",
+    "# with tru_app:\n",
+    "#     test_app.respond_to_query(\"throw\")\n",
     "\n",
-    "# Without flushing, the spans are not guaranteed to be sent.\n",
-    "tru_session.force_flush()"
+    "# # Without flushing, the spans are not guaranteed to be sent.\n",
+    "# tru_session.force_flush()"
    ]
   },
   {
@@ -206,6 +206,8 @@
    "outputs": [],
    "source": [
     "# Run the app on a pandas DataFrame.\n",
+    "\n",
+    "import time\n",
     "\n",
     "import pandas as pd\n",
     "from trulens.core.app import App\n",
@@ -224,12 +226,18 @@
     "                main_method = getattr(test_app, tru_app.main_method_name)\n",
     "                main_method(row[input_column])\n",
     "    tru_app.session.force_flush()\n",
+    "    logging.debug(\"Run ended\")\n",
+    "    print(time.ctime())\n",
     "\n",
+    "\n",
+    "num_inputs = 1000\n",
+    "input_ids = list(range(num_inputs))\n",
+    "inputs = [f\"text{i}\" for i in range(num_inputs)]\n",
     "\n",
     "run_on_df(\n",
     "    tru_app,\n",
     "    \"df_run\",\n",
-    "    pd.DataFrame({\"input_id\": [1, 2], \"input\": [\"a\", \"b\"]}),\n",
+    "    pd.DataFrame({\"input_id\": input_ids, \"input\": input_ids}),\n",
     "    \"input_id\",\n",
     "    \"input\",\n",
     ")"
@@ -242,8 +250,6 @@
    "outputs": [],
    "source": [
     "# Read the event table.\n",
-    "\n",
-    "import time\n",
     "\n",
     "\n",
     "def wait_for_nonzero_results(\n",
@@ -295,6 +301,15 @@
    "outputs": [],
    "source": [
     "wait_for_nonzero_results()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bool(None)"
    ]
   }
  ],

--- a/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
@@ -45,6 +45,9 @@ class SnowflakeConnector(DBConnector):
         schema: Optional[str] = None,
         warehouse: Optional[str] = None,
         role: Optional[str] = None,
+        protocol: Optional[str] = "https",
+        port: Optional[int] = 443,
+        host: Optional[str] = None,
         snowpark_session: Optional[Session] = None,
         init_server_side: bool = False,
         init_server_side_with_staged_packages: bool = False,
@@ -62,6 +65,9 @@ class SnowflakeConnector(DBConnector):
             "schema": schema,
             "warehouse": warehouse,
             "role": role,
+            "protocol": protocol,
+            "port": port,
+            "host": host,
         }
         if snowpark_session is None:
             snowpark_session = self._create_snowpark_session(
@@ -74,7 +80,7 @@ class SnowflakeConnector(DBConnector):
                 )
             )
 
-        self.snowpark_session = snowpark_session
+        self.snowpark_session: Session = snowpark_session
         self.connection_parameters: Dict[str, str] = connection_parameters
         self.use_staged_packages: bool = init_server_side_with_staged_packages
 

--- a/src/connectors/snowflake/trulens/connectors/snowflake/otel_exporter.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/otel_exporter.py
@@ -91,6 +91,9 @@ class TruLensSnowflakeSpanExporter(SpanExporter):
             app_version,
             run_name,
         ), spans in app_and_run_info_to_spans.items():
+            logger.debug(
+                f"Logging {len(spans)} for app:{app_name} version:{app_version} run:{run_name}"
+            )
             res = self._export_to_snowflake_stage_for_app_and_run(
                 app_name, app_version, run_name, spans, dry_run
             )

--- a/src/connectors/snowflake/trulens/connectors/snowflake/otel_exporter.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/otel_exporter.py
@@ -179,11 +179,7 @@ class TruLensSnowflakeSpanExporter(SpanExporter):
                 ],
             )
             if not dry_run:
-                sql_cmd.collect()
-                # job: AsyncJob = sql_cmd.collect_nowait()
-                # logger.debug(f"Uploading files in query: {job.query_id}")
-                # result = job.result()[0][0]
-                # logger.debug(f"Upload result: {result}")
+                logger.debug(sql_cmd.collect()[0][0])
         finally:
             if original_trace_level != "ALWAYS":
                 snowpark_session.sql(

--- a/src/core/trulens/experimental/otel_tracing/core/exporter/utils.py
+++ b/src/core/trulens/experimental/otel_tracing/core/exporter/utils.py
@@ -117,8 +117,9 @@ def check_if_trulens_span(span: ReadableSpan) -> bool:
     """
     if not span.attributes:
         return False
-
-    return bool(span.attributes.get(SpanAttributes.APP_NAME))
+    # NOTE(apgupta) Workaround for a bug where app_name='None'
+    app_name = span.attributes.get(SpanAttributes.APP_NAME)
+    return app_name and app_name != "None"
 
 
 def construct_event(span: ReadableSpan) -> event_schema.Event:


### PR DESCRIPTION
# Description

Bugfix: Avoid ingestion of incorrectly generated spans.
 - Improves logging.
 - Will undo notebook changes.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes span ingestion bug by adding validation, logging improvements, and handling `app_name='None'` in `check_if_trulens_span`.
> 
>   - **Behavior**:
>     - Adds `protocol`, `port`, and `host` parameters to `SnowflakeConnector` constructor in `connector.py`.
>     - Validates `SnowflakeConnector` type in `TruLensSnowflakeSpanExporter` constructor in `otel_exporter.py`.
>     - Updates `check_if_trulens_span` in `utils.py` to handle `app_name='None'` case.
>   - **Logging**:
>     - Adds debug logging for span export process in `otel_exporter.py`.
>     - Uses `logger.exception` for error logging in `otel_exporter.py`.
>   - **Misc**:
>     - Renames `_export_to_snowflake_stage` to `_export_to_snowflake` in `otel_exporter.py`.
>     - Fixes type hint for `snowpark_session` in `connector.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 5641e69fb6dc0dd811ae4859e45433a101623e40. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->