### PR TITLE
Set default host for snowflake connector if not provided

### DIFF
--- a/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
@@ -67,8 +67,11 @@ class SnowflakeConnector(DBConnector):
             "role": role,
             "protocol": protocol,
             "port": port,
-            "host": host if host else f"{account}.snowflakecomputing.com",
         }
+
+        if host is not None:
+            connection_parameters["host"] = host
+
         if snowpark_session is None:
             snowpark_session = self._create_snowpark_session(
                 connection_parameters

--- a/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
@@ -67,7 +67,7 @@ class SnowflakeConnector(DBConnector):
             "role": role,
             "protocol": protocol,
             "port": port,
-            "host": host,
+            "host": host if host else f"{account}.snowflakecomputing.com",
         }
         if snowpark_session is None:
             snowpark_session = self._create_snowpark_session(


### PR DESCRIPTION
# Description

We started exposing `host` as connection params to snowflake connector, hence setting to default value to prevent breaking existing notebooks / customer demos 
## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Set default `host` in `SnowflakeConnector.__init__` to prevent breaking changes for users not providing it.
> 
>   - **Behavior**:
>     - In `SnowflakeConnector.__init__`, set default `host` if not provided to avoid breaking existing notebooks and demos.
>   - **Misc**:
>     - No changes to other files or functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for d07f2d99337309605566a21bcf0272513da4e387. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->