### PR TITLE
Ensure there's only one record root span and also discern the main method if none given for `TruApp`/`TruCustomApp`.

### DIFF
--- a/src/core/trulens/apps/app.py
+++ b/src/core/trulens/apps/app.py
@@ -363,7 +363,7 @@ class TruApp(core_app.App):
                     main_methods.add(method)
             if len(main_methods) != 1:
                 raise ValueError(
-                    f"Must have exactly one main method! Found: {list(main_methods)}"
+                    f"Must have exactly one main method or method decorated with span type 'record_root'! Found: {list(main_methods)}"
                 )
             main_method = main_methods.pop()
         if main_method is not None:

--- a/src/core/trulens/apps/app.py
+++ b/src/core/trulens/apps/app.py
@@ -191,14 +191,17 @@ Function <function CustomLLM.generate at 0x1779471f0> was not found during instr
   solution as needed.
 """
 
+import inspect
 import logging
 from pprint import PrettyPrinter
-from typing import Any, Callable, ClassVar, Set
+from typing import Any, Callable, ClassVar, Optional, Set
 
 import pydantic
 from pydantic import Field
 from trulens.core import app as core_app
+from trulens.core import experimental as core_experimental
 from trulens.core import instruments as core_instruments
+from trulens.core.session import TruSession
 from trulens.core.utils import pyschema as pyschema_utils
 from trulens.core.utils import serial as serial_utils
 from trulens.core.utils import text as text_utils
@@ -341,8 +344,30 @@ class TruApp(core_app.App):
     these methods are.
     """
 
-    def __init__(self, app: Any, methods_to_instrument=None, **kwargs: Any):
+    def __init__(
+        self,
+        app: Any,
+        main_method: Optional[Callable] = None,
+        methods_to_instrument=None,
+        **kwargs: Any,
+    ):
         kwargs["app"] = app
+        if TruSession().experimental_feature(
+            core_experimental.Feature.OTEL_TRACING
+        ):
+            main_methods = set()
+            if main_method is not None:
+                main_methods.add(main_method)
+            for _, method in inspect.getmembers(app, inspect.ismethod):
+                if self._has_record_root_instrumentation(method):
+                    main_methods.add(method)
+            if len(main_methods) != 1:
+                raise ValueError(
+                    f"Must have exactly one main method! Found: {list(main_methods)}"
+                )
+            main_method = main_methods.pop()
+        if main_method is not None:
+            kwargs["main_method"] = main_method
         kwargs["root_class"] = pyschema_utils.Class.of_object(app)
 
         instrument = core_instruments.Instrument(

--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -138,8 +138,8 @@ def _set_span_attributes(
 def instrument(
     *,
     span_type: SpanAttributes.SpanType = SpanAttributes.SpanType.UNKNOWN,
-    attributes: Attributes = dict(),
-    full_scoped_attributes: Attributes = dict(),
+    attributes: Attributes = None,
+    full_scoped_attributes: Attributes = None,
     must_be_first_wrapper: bool = False,
     **kwargs,
 ):
@@ -160,6 +160,10 @@ def instrument(
         If this is True and the function is already wrapped with the TruLens
         decorator, then the function will not be wrapped again.
     """
+    if attributes is None:
+        attributes = {}
+    if full_scoped_attributes is None:
+        full_scoped_attributes = {}
     is_record_root = span_type == SpanAttributes.SpanType.RECORD_ROOT
 
     def inner_decorator(func: Callable):

--- a/tests/unit/test_otel_record_root.py
+++ b/tests/unit/test_otel_record_root.py
@@ -1,0 +1,77 @@
+from trulens.apps.app import TruApp
+from trulens.core.otel.instrument import instrument
+from trulens.core.session import TruSession
+from trulens.otel.semconv.trace import SpanAttributes
+
+from tests.util.otel_app_test_case import OtelAppTestCase
+
+
+class TestOtelRecordRoot(OtelAppTestCase):
+    def test_no_main_method(self):
+        class App:
+            @instrument(span_type=SpanAttributes.SpanType.RECORD_ROOT)
+            def main(self):
+                pass
+
+            def main2(self):
+                pass
+
+        app = App()
+        tru_app = TruApp(app, pp_name="test", app_version="v1")
+        self.assertEqual(tru_app.main_method_name, "main")
+        # Record and invoke.
+        tru_app.instrumented_invoke_main_method(run_name="1", input_id="42")
+        TruSession().force_flush()
+        self.assertEqual(len(self._get_events()), 1)
+
+    def test_main_method_with_same_record_root_span(self):
+        class App:
+            @instrument(span_type=SpanAttributes.SpanType.RECORD_ROOT)
+            def main(self):
+                pass
+
+            def main2(self):
+                pass
+
+        app = App()
+        tru_app = TruApp(
+            app, main_method=app.main, app_name="test", app_version="v1"
+        )
+        self.assertEqual(tru_app.main_method_name, "main")
+        # Record and invoke.
+        tru_app.instrumented_invoke_main_method(run_name="1", input_id="42")
+        TruSession().force_flush()
+        self.assertEqual(len(self._get_events()), 1)
+
+    def test_main_method_with_different_record_root_span(self):
+        class App:
+            @instrument(span_type=SpanAttributes.SpanType.RECORD_ROOT)
+            def main(self):
+                pass
+
+            def main2(self):
+                pass
+
+        app = App()
+        with self.assertRaisesRegex(
+            ValueError, "Must have exactly one main method! Found:"
+        ):
+            TruApp(
+                app, main_method=app.main2, app_name="test", app_version="v1"
+            )
+
+    def test_multiple_record_root_spans(self):
+        class App:
+            @instrument(span_type=SpanAttributes.SpanType.RECORD_ROOT)
+            def main(self):
+                pass
+
+            @instrument(span_type=SpanAttributes.SpanType.RECORD_ROOT)
+            def main2(self):
+                pass
+
+        app = App()
+        with self.assertRaisesRegex(
+            ValueError, "Must have exactly one main method! Found:"
+        ):
+            TruApp(app, app_name="test", app_version="v1")

--- a/tests/unit/test_otel_record_root.py
+++ b/tests/unit/test_otel_record_root.py
@@ -17,7 +17,7 @@ class TestOtelRecordRoot(OtelAppTestCase):
                 pass
 
         app = App()
-        tru_app = TruApp(app, pp_name="test", app_version="v1")
+        tru_app = TruApp(app, app_name="test", app_version="v1")
         self.assertEqual(tru_app.main_method_name, "main")
         # Record and invoke.
         tru_app.instrumented_invoke_main_method(run_name="1", input_id="42")
@@ -54,7 +54,8 @@ class TestOtelRecordRoot(OtelAppTestCase):
 
         app = App()
         with self.assertRaisesRegex(
-            ValueError, "Must have exactly one main method! Found:"
+            ValueError,
+            "Must have exactly one main method or method decorated with span type 'record_root'! Found: ",
         ):
             TruApp(
                 app, main_method=app.main2, app_name="test", app_version="v1"
@@ -72,6 +73,7 @@ class TestOtelRecordRoot(OtelAppTestCase):
 
         app = App()
         with self.assertRaisesRegex(
-            ValueError, "Must have exactly one main method! Found:"
+            ValueError,
+            "Must have exactly one main method or method decorated with span type 'record_root'! Found: ",
         ):
             TruApp(app, app_name="test", app_version="v1")


### PR DESCRIPTION
# Description
Ensure there's only one record root span and also discern the main method if none given for `TruApp`/`TruCustomApp`.

## Other details good to know for developers
Also fixed a minor issue in `instrument.py` where the default arg was being shared across invocations.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure single record root span and discern main method in `TruApp`/`TruCustomApp`, with fixes and tests added.
> 
>   - **Behavior**:
>     - Ensure only one record root span in `TruApp`/`TruCustomApp`.
>     - Automatically discern main method if not provided, raising error if multiple candidates exist.
>   - **Fixes**:
>     - Corrects shared default argument issue in `instrument()` in `instrument.py`.
>   - **Tests**:
>     - Added `test_otel_record_root.py` to test scenarios with no main method, same and different record root spans, and multiple record root spans.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 424d82284aeb88cdd46e54837382cca2b5312ae7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->