### PR TITLE
Redefine span attribute dictionary so that the values of the dictionary map to kwargs of the function decorated or the return.

### DIFF
--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -63,6 +63,13 @@ def _resolve_attributes(
         return {}
     if callable(attributes):
         return attributes(ret, exception, *args, **all_kwargs)
+    if isinstance(attributes, dict):
+        ret = {}
+        value_string_to_value = all_kwargs.copy()
+        value_string_to_value["return"] = ret
+        for k, v in attributes.items():
+            ret[k] = value_string_to_value[v]
+        return ret
     return attributes.copy()
 
 

--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -64,12 +64,12 @@ def _resolve_attributes(
     if callable(attributes):
         return attributes(ret, exception, *args, **all_kwargs)
     if isinstance(attributes, dict):
-        ret = {}
+        resolved = {}
         value_string_to_value = all_kwargs.copy()
         value_string_to_value["return"] = ret
         for k, v in attributes.items():
-            ret[k] = value_string_to_value[v]
-        return ret
+            resolved[k] = value_string_to_value[v]
+        return resolved
     return attributes.copy()
 
 

--- a/tests/unit/test_otel_span.py
+++ b/tests/unit/test_otel_span.py
@@ -42,13 +42,13 @@ class TestOtelSpan(TestCase):
         with self.subTest("Dictionary attributes"):
             attributes_dict = {"key2": "value2"}
             self.assertEqual(
-                {"key2": "value2"},
+                {"key2": "Kojikun"},
                 _resolve_attributes(
                     attributes_dict,
                     ret=None,
                     exception=None,
                     args=(),
-                    all_kwargs={},
+                    all_kwargs={"value2": "Kojikun"},
                 ),
             )
 

--- a/tests/unit/test_otel_span.py
+++ b/tests/unit/test_otel_span.py
@@ -40,12 +40,12 @@ class TestOtelSpan(TestCase):
                 ),
             )
         with self.subTest("Dictionary attributes"):
-            attributes_dict = {"key2": "value2"}
+            attributes_dict = {"key2": "value2", "key3": "return"}
             self.assertEqual(
-                {"key2": "Kojikun"},
+                {"key2": "Kojikun", "key3": "Nolan"},
                 _resolve_attributes(
                     attributes_dict,
-                    ret=None,
+                    ret="Nolan",
                     exception=None,
                     args=(),
                     all_kwargs={"value2": "Kojikun"},

--- a/tests/unit/test_otel_tru_chain.py
+++ b/tests/unit/test_otel_tru_chain.py
@@ -27,7 +27,11 @@ class TestOtelTruChain(OtelAppTestCase):
     @staticmethod
     def _create_simple_rag():
         # Helper function.
-        @instrument(attributes={"best_baby": "Kojikun"})
+        @instrument(
+            attributes=lambda ret, exception, *args, **kwargs: {
+                "best_baby": "Kojikun"
+            }
+        )
         def format_docs(docs):
             return "\n\n".join(doc.page_content for doc in docs)
 

--- a/tests/unit/test_otel_tru_custom.py
+++ b/tests/unit/test_otel_tru_custom.py
@@ -15,7 +15,7 @@ class TestApp:
         return f"answer: {self.nested(query)}"
 
     @instrument(
-        attributes=lambda ret, exception, *args, **kargs: {
+        attributes=lambda ret, exception, *args, **kwargs: {
             "nested_attr1": "value1"
         }
     )

--- a/tests/unit/test_otel_tru_custom.py
+++ b/tests/unit/test_otel_tru_custom.py
@@ -14,7 +14,11 @@ class TestApp:
     def respond_to_query(self, query: str) -> str:
         return f"answer: {self.nested(query)}"
 
-    @instrument(attributes={"nested_attr1": "value1"})
+    @instrument(
+        attributes=lambda ret, exception, *args, **kargs: {
+            "nested_attr1": "value1"
+        }
+    )
     def nested(self, query: str) -> str:
         return f"nested: {self.nested2(query)}"
 


### PR DESCRIPTION
# Description
Redefine span attribute dictionary so that the values of the dictionary map to kwargs of the function decorated or the return.

## Other details good to know for developers

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Redefine span attribute resolution in `instrument.py` to allow dictionary values to map to function kwargs or return values, with updated tests.
> 
>   - **Behavior**:
>     - `_resolve_attributes` in `instrument.py` now supports dictionary attributes mapping to function kwargs or return values.
>     - Updated `test_otel_span.py` to test dictionary attributes resolving to kwargs and return values.
>   - **Tests**:
>     - Modified `test_otel_tru_chain.py` and `test_otel_tru_custom.py` to use lambda functions for attribute resolution in `instrument` decorator.
>     - Added test cases for dictionary attributes in `test_otel_span.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for dad7258cf9049ae1c9104af17dd496e62322ff09. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->