### PR TITLE
[non-OTEL] Don't track feedback functions.

### DIFF
--- a/src/core/trulens/core/instruments.py
+++ b/src/core/trulens/core/instruments.py
@@ -56,6 +56,8 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
+thread_local = th.local()
+
 
 class WithInstrumentCallbacks:
     """Abstract definition of callbacks invoked by Instrument during
@@ -659,6 +661,9 @@ class Instrument:
                 python_utils.is_really_coroutinefunction(func),
                 inspect.isasyncgenfunction(func),
             )
+
+            if getattr(thread_local, "do_not_track", False):
+                return func(*args, **kwargs)
 
             apps = getattr(tru_wrapper, Instrument.APPS)  # weakref
 

--- a/src/core/trulens/core/instruments.py
+++ b/src/core/trulens/core/instruments.py
@@ -56,8 +56,6 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
-thread_local = th.local()
-
 
 class WithInstrumentCallbacks:
     """Abstract definition of callbacks invoked by Instrument during
@@ -661,9 +659,6 @@ class Instrument:
                 python_utils.is_really_coroutinefunction(func),
                 inspect.isasyncgenfunction(func),
             )
-
-            if getattr(thread_local, "do_not_track", False):
-                return func(*args, **kwargs)
 
             apps = getattr(tru_wrapper, Instrument.APPS)  # weakref
 

--- a/src/core/trulens/core/schema/app.py
+++ b/src/core/trulens/core/schema/app.py
@@ -20,7 +20,6 @@ import warnings
 import dill
 import pydantic
 from trulens.core.feedback import feedback as core_feedback
-import trulens.core.instruments as core_instruments
 from trulens.core.schema import base as base_schema
 from trulens.core.schema import feedback as feedback_schema
 from trulens.core.schema import record as record_schema
@@ -366,24 +365,13 @@ class AppDefinition(pyschema_utils.WithClassInfo, serial_utils.SerialModel):
                 app: AppDefinition,
                 record: record_schema.Record,
             ):
-                orig_do_not_track = None
-                try:
-                    orig_do_not_track = getattr(
-                        core_instruments.thread_local, "do_not_track", False
-                    )
-                    core_instruments.thread_local.do_not_track = True
-                    temp = ffunc.run(app=app, record=record)
-                    if on_done is not None:
-                        try:
-                            on_done(temp)
-                        finally:
-                            return temp
-                    return temp
-                finally:
-                    if orig_do_not_track is not None:
-                        core_instruments.thread_local.do_not_track = (
-                            orig_do_not_track
-                        )
+                temp = ffunc.run(app=app, record=record)
+                if on_done is not None:
+                    try:
+                        on_done(temp)
+                    finally:
+                        return temp
+                return temp
 
             fut: Future[feedback_schema.FeedbackResult] = tp.submit(
                 run_and_call_callback,

--- a/tests/unit/test_feedback.py
+++ b/tests/unit/test_feedback.py
@@ -6,17 +6,22 @@ from unittest import TestCase
 import numpy as np
 import pytest
 from trulens.apps import basic as basic_app
-from trulens.apps.langchain import TruChain
 from trulens.core import Feedback
 from trulens.core import TruSession
 from trulens.core.feedback import feedback as core_feedback
 from trulens.core.schema import feedback as feedback_schema
 from trulens.core.schema import select as select_schema
-from trulens.providers.langchain import Langchain
 
 # Get the "globally importable" feedback implementations.
 from tests.unit import feedbacks as test_feedbacks
-import tests.unit.test_otel_tru_chain
+
+try:
+    from trulens.apps.langchain import TruChain
+    from trulens.providers.langchain import Langchain
+
+    import tests.unit.test_otel_tru_chain
+except ImportError:
+    pass
 
 
 class TestFeedbackEval(TestCase):

--- a/tests/unit/test_feedback.py
+++ b/tests/unit/test_feedback.py
@@ -75,8 +75,8 @@ class TestFeedbackEval(TestCase):
         # But status should be DONE (as opposed to SKIPPED or ERROR)
 
     def test_same_provider_for_app_and_feedback(self) -> None:
-        session = TruSession()
-        session.reset_database()
+        tru_session = TruSession()
+        tru_session.reset_database()
         rag_chain = (
             tests.unit.test_otel_tru_chain.TestOtelTruChain._create_simple_rag()
         )
@@ -96,7 +96,7 @@ class TestFeedbackEval(TestCase):
         with tru_recorder:
             rag_chain.invoke("What is Task Decomposition?")
             time.sleep(1)
-        res = TruSession().get_records_and_feedback()[0]
+        res = tru_session.get_records_and_feedback()[0]
         self.assertEqual(len(res), 1)
 
 

--- a/tests/unit/test_feedback.py
+++ b/tests/unit/test_feedback.py
@@ -4,6 +4,7 @@ import time
 from unittest import TestCase
 
 import numpy as np
+import pytest
 from trulens.apps import basic as basic_app
 from trulens.apps.langchain import TruChain
 from trulens.core import Feedback
@@ -74,6 +75,7 @@ class TestFeedbackEval(TestCase):
         self.assertEqual(res.status, feedback_schema.FeedbackResultStatus.DONE)
         # But status should be DONE (as opposed to SKIPPED or ERROR)
 
+    @pytest.mark.optional
     def test_same_provider_for_app_and_feedback(self) -> None:
         tru_session = TruSession()
         tru_session.reset_database()


### PR DESCRIPTION
# Description
[non-OTEL] Don't track feedback functions.

This is causing a problem since if we track feedback functions they make their own record, which then needs to have its own feedback computed on it ad infinitum.

This is for https://github.com/truera/trulens/issues/1824

## Other details good to know for developers

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes infinite feedback computation by preventing recursive tracking of feedback functions using a thread-local variable.
> 
>   - **Behavior**:
>     - Prevents tracking of feedback functions by using `thread_local.do_not_track` in `tru_wrapper` in `instruments.py` and `run_and_call_callback` in `app.py`.
>     - Fixes infinite feedback computation issue by skipping feedback function tracking.
>   - **Tests**:
>     - Adds `test_same_provider_for_app_and_feedback` in `test_feedback.py` to verify feedback functions are not tracked recursively.
>   - **Misc**:
>     - Introduces `thread_local` variable in `instruments.py` to manage tracking state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for fc3967da5dfed59914df5bd85c742c449ec9f8c5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->