### PR TITLE
change link from slack to snowflake discourse

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -223,7 +223,7 @@
                             <img src="https://img.shields.io/pypi/dm/trulens" alt="PyPI - Downloads" />
                         </a>
                         <a href="https://snowflake.discourse.group/c/ai-research-and-development-community/trulens/97" target="_blank">
-                            <img src="https://img.shields.io/badge/slack-join-green?logo=slack" alt="Slack" />
+                            <img src="https://img.shields.io/badge/discourse-forum-brightgreen.svg?style=flat-square" alt="Discourse Forum" />
                         </a>
                         <a href="getting_started" target="_blank">
                             <img src="https://img.shields.io/badge/docs-trulens.org-blue" alt="Docs" />
@@ -626,8 +626,7 @@
                         </a>
                         <p class="strong font-primary">Community</p>
                         <span>Come join the TruLens community on the <a
-                                href="https://snowflake.discourse.group/c/ai-research-and-development-community/trulens/97" target="_blank">AI Quality
-                                Forum slack</a>.</span>
+                                href="https://snowflake.discourse.group/c/ai-research-and-development-community/trulens/97" target="_blank">AI R&D Discourse Forum</a>.</span>
                     </div>
                 </div>
                 <div class="grid-columns-2 box-dark">

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -106,7 +106,7 @@
                         <a href="https://github.com/truera/trulens/" target="_blank">
                             <li>GitHub</li>
                         </a>
-                        <a href="https://communityinviter.com/apps/aiqualityforum/josh" target="blank">
+                        <a href="https://snowflake.discourse.group/c/ai-research-and-development-community/trulens/97" target="blank">
                             <li>Community</li>
                         </a>
                         <a href="getting_started" target="docs"
@@ -160,7 +160,7 @@
                                 </div>
                             </a>
 
-                            <a href="https://communityinviter.com/apps/aiqualityforum/josh" target="_blank"
+                            <a href="https://snowflake.discourse.group/c/ai-research-and-development-community/trulens/97" target="_blank"
                                 class="header__btn hero__btn btn-secondary d-if fd-r ai-c jc-c">
                                 <svg width="24" height="25" viewBox="0 0 16 16" fill="none"
                                     xmlns="http://www.w3.org/2000/svg">
@@ -222,7 +222,7 @@
                         <a href="https://pypi.org/project/trulens/" target="_blank">
                             <img src="https://img.shields.io/pypi/dm/trulens" alt="PyPI - Downloads" />
                         </a>
-                        <a href="https://communityinviter.com/apps/aiqualityforum/josh" target="_blank">
+                        <a href="https://snowflake.discourse.group/c/ai-research-and-development-community/trulens/97" target="_blank">
                             <img src="https://img.shields.io/badge/slack-join-green?logo=slack" alt="Slack" />
                         </a>
                         <a href="getting_started" target="_blank">
@@ -569,7 +569,7 @@
                                 target="_blank">here</a>.</span>
                     </div>
                     <div class="box__shadow">
-                        <a href="https://communityinviter.com/apps/aiqualityforum/josh" target="_blank"
+                        <a href="https://snowflake.discourse.group/c/ai-research-and-development-community/trulens/97" target="_blank"
                             class="btn__shadow">
                             <svg width="126" height="126" viewBox="0 0 126 126" fill="none"
                                 xmlns="http://www.w3.org/2000/svg">
@@ -626,7 +626,7 @@
                         </a>
                         <p class="strong font-primary">Community</p>
                         <span>Come join the TruLens community on the <a
-                                href="https://communityinviter.com/apps/aiqualityforum/josh" target="_blank">AI Quality
+                                href="https://snowflake.discourse.group/c/ai-research-and-development-community/trulens/97" target="_blank">AI Quality
                                 Forum slack</a>.</span>
                     </div>
                 </div>

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -106,7 +106,7 @@
                         <a href="https://github.com/truera/trulens/" target="_blank">
                             <li>GitHub</li>
                         </a>
-                        <a href="https://snowflake.discourse.group/c/ai-research-and-development-community/trulens/97" target="blank">
+                        <a href="https://snowflake.discourse.group/c/ai-research-and-development-community/trulens/97" target="_blank">
                             <li>Community</li>
                         </a>
                         <a href="getting_started" target="docs"

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -223,7 +223,7 @@
                             <img src="https://img.shields.io/pypi/dm/trulens" alt="PyPI - Downloads" />
                         </a>
                         <a href="https://snowflake.discourse.group/c/ai-research-and-development-community/trulens/97" target="_blank">
-                            <img src="https://img.shields.io/badge/discourse-forum-brightgreen.svg?style=flat-square" alt="Discourse Forum" />
+                            <img src="https://img.shields.io/discourse/users?server=https://snowflake.discourse.group/" alt="Discourse Community" />
                         </a>
                         <a href="getting_started" target="_blank">
                             <img src="https://img.shields.io/badge/docs-trulens.org-blue" alt="Docs" />


### PR DESCRIPTION
# Description

We are moving the Slack AI Quality Forum over to discourse :rocket::squid:
We're doing this for a few reasons:

- Discourse gives us a discoverable platform for the community content
- Messages will live forever (instead of expiring in slack)
- We have new opportunities for the community to meet and collaborate with adjacent snowflake communities, such as for Arctic Embed :slightly_smiling_face:
- This change allows us to consolidate and share some resources for maintaining the community.
- This community on slack will remain open for a while, but I'd encourage you to head over there and check out the new community. Looking forward to seeing everyone there!

Here's the link, go check it out: https://snowflake.discourse.group/c/ai-research-and-development-community/trulens/97

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update community link from Slack to Snowflake Discourse in `home.html`.
> 
>   - **Behavior**:
>     - Update community link from Slack to Snowflake Discourse in `home.html`.
>     - Changes affect multiple sections including navigation, buttons, and badges.
>   - **Misc**:
>     - Update badge image and alt text to reflect Discourse community.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 816af07cdb2d0273a6cace6465de328a63b7282b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->