### PR TITLE
[DO NOT MERGE] Output both `input`/`output`/`error` and `main_input`/`main_output`/`main_error` for record root spans.

### DIFF
--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -610,7 +610,13 @@ class App(
                     SpanAttributes.RECORD_ROOT.INPUT: self.main_input(
                         func, sig, sig.bind_partial(**kwargs)
                     ),
+                    SpanAttributes.RECORD_ROOT.MAIN_INPUT: self.main_input(
+                        func, sig, sig.bind_partial(**kwargs)
+                    ),
                     SpanAttributes.RECORD_ROOT.OUTPUT: self.main_output(
+                        func, sig, sig.bind_partial(**kwargs), ret
+                    ),
+                    SpanAttributes.RECORD_ROOT.MAIN_OUTPUT: self.main_output(
                         func, sig, sig.bind_partial(**kwargs), ret
                     ),
                 },

--- a/src/core/trulens/experimental/otel_tracing/core/span.py
+++ b/src/core/trulens/experimental/otel_tracing/core/span.py
@@ -213,6 +213,11 @@ def set_record_root_span_attributes(
         SpanAttributes.RECORD_ROOT.INPUT,
         get_main_input(func, args, kwargs),
     )
+    set_span_attribute_safely(
+        span,
+        SpanAttributes.RECORD_ROOT.MAIN_INPUT,
+        get_main_input(func, args, kwargs),
+    )
     ground_truth_output = get_baggage(
         SpanAttributes.RECORD_ROOT.GROUND_TRUTH_OUTPUT
     )
@@ -226,9 +231,17 @@ def set_record_root_span_attributes(
         set_span_attribute_safely(
             span, SpanAttributes.RECORD_ROOT.ERROR, str(exception)
         )
+        set_span_attribute_safely(
+            span, SpanAttributes.RECORD_ROOT.MAIN_ERROR, str(exception)
+        )
     if ret is not None:
         set_span_attribute_safely(
             span,
             SpanAttributes.RECORD_ROOT.OUTPUT,
+            signature_utils.main_output(func, ret),
+        )
+        set_span_attribute_safely(
+            span,
+            SpanAttributes.RECORD_ROOT.MAIN_OUTPUT,
             signature_utils.main_output(func, ret),
         )

--- a/src/otel/semconv/trulens/otel/semconv/trace.py
+++ b/src/otel/semconv/trulens/otel/semconv/trace.py
@@ -127,6 +127,18 @@ class SpanAttributes:
         Exclusive with main output.
         """
 
+        MAIN_INPUT = base + ".main_input"
+        """Main input to the app."""
+
+        MAIN_OUTPUT = base + ".main_output"
+        """Main output of the app."""
+
+        MAIN_ERROR = base + ".main_error"
+        """Main error of the app.
+
+        Exclusive with main output.
+        """
+
         GROUND_TRUTH_OUTPUT = base + ".ground_truth_output"
         """Ground truth of the record."""
 


### PR DESCRIPTION
# Description
[DO NOT MERGE] Output both `input`/`output`/`error` and `main_input`/`main_output`/`main_error` for record root spans.

This is for the bugbash on 2025/02/25

## Other details good to know for developers

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
