### PR TITLE
[non-OTEL] Use context variables instead of thread_local since the latter doesn't actually inherit values from the parent threads.

### DIFF
--- a/src/core/trulens/core/instruments.py
+++ b/src/core/trulens/core/instruments.py
@@ -8,6 +8,7 @@ typical use cases.
 from __future__ import annotations
 
 import contextvars
+from contextvars import ContextVar
 import dataclasses
 from datetime import datetime
 import functools
@@ -56,7 +57,7 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
-thread_local = th.local()
+do_not_track = ContextVar("do_not_track", default=False)
 
 
 class WithInstrumentCallbacks:
@@ -662,7 +663,7 @@ class Instrument:
                 inspect.isasyncgenfunction(func),
             )
 
-            if getattr(thread_local, "do_not_track", False):
+            if do_not_track.get():
                 return func(*args, **kwargs)
 
             apps = getattr(tru_wrapper, Instrument.APPS)  # weakref

--- a/src/core/trulens/core/schema/app.py
+++ b/src/core/trulens/core/schema/app.py
@@ -366,12 +366,9 @@ class AppDefinition(pyschema_utils.WithClassInfo, serial_utils.SerialModel):
                 app: AppDefinition,
                 record: record_schema.Record,
             ):
-                orig_do_not_track = None
+                token = None
                 try:
-                    orig_do_not_track = getattr(
-                        core_instruments.thread_local, "do_not_track", False
-                    )
-                    core_instruments.thread_local.do_not_track = True
+                    token = core_instruments.do_not_track.set(True)
                     temp = ffunc.run(app=app, record=record)
                     if on_done is not None:
                         try:
@@ -380,10 +377,8 @@ class AppDefinition(pyschema_utils.WithClassInfo, serial_utils.SerialModel):
                             return temp
                     return temp
                 finally:
-                    if orig_do_not_track is not None:
-                        core_instruments.thread_local.do_not_track = (
-                            orig_do_not_track
-                        )
+                    if token is not None:
+                        core_instruments.do_not_track.reset(token)
 
             fut: Future[feedback_schema.FeedbackResult] = tp.submit(
                 run_and_call_callback,

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -684,6 +684,7 @@ trulens.core.instruments:
     WithInstrumentCallbacks: builtins.type
     class_filter_disjunction: builtins.function
     class_filter_matches: builtins.function
+    do_not_track: _contextvars.ContextVar
     instrument: builtins.type
 trulens.core.instruments.AddInstruments:
   __bases__:

--- a/tests/unit/test_feedback.py
+++ b/tests/unit/test_feedback.py
@@ -91,14 +91,23 @@ class TestFeedbackEval(TestCase):
             1
         ]  # Bit of a hack, but this is the LLM for the chain.
         provider = Langchain(chain=llm)
+        context = TruChain.select_context(rag_chain)
         f_answer_relevance = Feedback(
             provider.relevance_with_cot_reasons, name="Answer Relevance"
         ).on_input_output()
+        f_groundedness = (
+            Feedback(
+                provider.groundedness_measure_with_cot_reasons,
+                name="Groundedness",
+            )
+            .on(context.collect())
+            .on_output()
+        )
         tru_recorder = TruChain(
             rag_chain,
             app_name="ChatApplication",
             app_version="Chain1",
-            feedbacks=[f_answer_relevance],
+            feedbacks=[f_answer_relevance, f_groundedness],
         )
         with tru_recorder:
             rag_chain.invoke("What is Task Decomposition?")


### PR DESCRIPTION
# Description
Use context variables instead of thread_local since the latter doesn't actually inherit values from the parent threads.

This was causing an issue when a feedback function kicked off its own threads like groundedness does.

## Other details good to know for developers

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replace `thread_local` with `contextvars` for context inheritance across threads, fixing feedback function threading issues.
> 
>   - **Behavior**:
>     - Replace `thread_local` with `contextvars` in `instruments.py` to ensure context inheritance across threads.
>     - Update `run_and_call_callback` in `app.py` to use `contextvars` for managing `do_not_track` state.
>   - **Tests**:
>     - Add `f_groundedness` feedback in `test_same_provider_for_app_and_feedback` in `test_feedback.py` to test new context management.
>   - **Misc**:
>     - Update `api.trulens.3.11.yaml` to reflect changes in `do_not_track` implementation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 89de23248e5a6c4d3da55f30fed8e01f14063b30. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->