### PR TITLE
remove redundant header in streamlit pills

### DIFF
--- a/src/dashboard/trulens/dashboard/streamlit.py
+++ b/src/dashboard/trulens/dashboard/streamlit.py
@@ -264,7 +264,6 @@ def trulens_feedback(record: record_schema.Record):
         )
         icons.append(feedbacks[call_data["feedback_name"]].icon)
 
-    st.header("Feedback Functions")
     format_func = lambda fcol: f"{fcol} {feedbacks[fcol].score:.4f}"
     if hasattr(st, "pills"):
         # Use native streamlit pills, released in 1.40.0


### PR DESCRIPTION
# Description

When we switched to native pills, a redundant header was added in. remove it.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove redundant header in `trulens_feedback` function in `streamlit.py`.
> 
>   - **UI Change**:
>     - Remove redundant `st.header("Feedback Functions")` in `trulens_feedback` function in `streamlit.py` to clean up the UI when using native Streamlit pills.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for ca5f24ad43e77db9ac80cb8a747280123b3466f8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->