### PR TITLE
Handle the possible creation of `TruSession` when `connector` argument is given to the tru app.

### DIFF
--- a/src/apps/langchain/trulens/apps/langchain/tru_chain.py
+++ b/src/apps/langchain/trulens/apps/langchain/tru_chain.py
@@ -248,8 +248,13 @@ class TruChain(core_app.App):
     ):
         # TruChain specific:
         kwargs["app"] = app
+        tru_session = (
+            TruSession()
+            if "connector" not in kwargs
+            else TruSession(connector=kwargs["connector"])
+        )
         if (
-            TruSession().experimental_feature(
+            tru_session.experimental_feature(
                 core_experimental.Feature.OTEL_TRACING
             )
             and main_method is None

--- a/src/apps/llamaindex/trulens/apps/llamaindex/tru_llama.py
+++ b/src/apps/llamaindex/trulens/apps/llamaindex/tru_llama.py
@@ -408,8 +408,13 @@ class TruLlama(core_app.App):
     ):
         # TruLlama specific:
         kwargs["app"] = app
+        tru_session = (
+            TruSession()
+            if "connector" not in kwargs
+            else TruSession(connector=kwargs["connector"])
+        )
         if (
-            TruSession().experimental_feature(
+            tru_session.experimental_feature(
                 core_experimental.Feature.OTEL_TRACING
             )
             and main_method is None

--- a/src/core/trulens/apps/app.py
+++ b/src/core/trulens/apps/app.py
@@ -352,7 +352,12 @@ class TruApp(core_app.App):
         **kwargs: Any,
     ):
         kwargs["app"] = app
-        if TruSession().experimental_feature(
+        tru_session = (
+            TruSession()
+            if "connector" not in kwargs
+            else TruSession(connector=kwargs["connector"])
+        )
+        if tru_session.experimental_feature(
             core_experimental.Feature.OTEL_TRACING
         ):
             main_methods = set()

--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -473,6 +473,11 @@ class App(
 
         # for us:
         if connector:
+            tru_session = TruSession(connector=connector)
+            if tru_session.connector is not connector:
+                raise ValueError(
+                    "Already created `TruSession` with different `connector`!"
+                )
             kwargs["connector"] = connector
 
         kwargs["feedbacks"] = feedbacks

--- a/tests/unit/test_otel_tru_custom.py
+++ b/tests/unit/test_otel_tru_custom.py
@@ -3,7 +3,9 @@ Tests for OTEL instrument decorator and custom app.
 """
 
 from trulens.apps.app import TruApp
+from trulens.core.database.connector import DefaultDBConnector
 from trulens.core.otel.instrument import instrument
+from trulens.core.session import TruSession
 from trulens.otel.semconv.trace import SpanAttributes
 
 from tests.util.otel_app_test_case import OtelAppTestCase
@@ -92,3 +94,38 @@ class TestOtelTruCustom(OtelAppTestCase):
         with tru_app:
             with self.assertRaisesRegex(KeyError, "does_not_exist"):
                 app.say_hi()
+
+    def test_with_existing_tru_session(self) -> None:
+        self.clear_TruSession_singleton()
+        connector1 = DefaultDBConnector()
+        connector2 = DefaultDBConnector()
+        self.assertIsNot(connector1, connector2)
+        TruSession(connector=connector1)
+        test_app = TestApp()
+        with self.assertRaisesRegex(
+            ValueError,
+            "Already created `TruSession` with different `connector`!",
+        ):
+            TruApp(
+                test_app,
+                main_method=test_app.respond_to_query,
+                connector=connector2,
+            )
+        tru_app = TruApp(
+            test_app,
+            main_method=test_app.respond_to_query,
+            connector=connector1,
+        )
+        self.assertIs(connector1, tru_app.connector)
+
+    def test_with_new_tru_session(self) -> None:
+        self.clear_TruSession_singleton()
+        connector = DefaultDBConnector()
+        test_app = TestApp()
+        tru_app = TruApp(
+            test_app,
+            main_method=test_app.respond_to_query,
+            connector=connector,
+        )
+        self.assertIs(connector, tru_app.connector)
+        self.assertIs(connector, TruSession().connector)


### PR DESCRIPTION
# Description
Handle the possible creation of `TruSession` when `connector` argument is given to the tru app.

## Other details good to know for developers

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Handle `TruSession` creation with `connector` argument in tru app, raising error for mismatched connectors, and add tests for verification.
> 
>   - **Behavior**:
>     - Handle `TruSession` creation with `connector` argument in `tru_chain.py`, `tru_llama.py`, and `app.py`.
>     - Raise `ValueError` if `TruSession` is created with a different `connector` in `app.py`.
>   - **Tests**:
>     - Add `test_with_existing_tru_session` and `test_with_new_tru_session` in `test_otel_tru_custom.py` to verify `TruSession` creation behavior with connectors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 095e1eccf15377b6f3e4c4d879d4815e675de3cf. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->