### PR TITLE
SDK run.start() should take ground_truth_output from dataset_spec

### DIFF
--- a/examples/experimental/pupr_e2e_cuj.ipynb
+++ b/examples/experimental/pupr_e2e_cuj.ipynb
@@ -214,7 +214,7 @@
     "    label=\"label\",\n",
     "    dataset_spec={\n",
     "        \"input\": \"custom_input\",\n",
-    "        \"input_2\": \"ground_truth_output\",\n",
+    "        \"ground_truth_output\": \"ground_truth_output\",\n",
     "    },\n",
     ")  # type: ignore\n",
     "\n",

--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -285,6 +285,7 @@ class Run(BaseModel):
             self.app.instrumented_invoke_main_method(
                 run_name=self.run_name,
                 input_id=input_id,
+                ground_truth_output="",
                 main_method_args=tuple(
                     main_method_args
                 ),  # Ensure correct order

--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -240,15 +240,15 @@ class Run(BaseModel):
             ).collect()
             input_df = pd.DataFrame([row.as_dict() for row in rows])
 
-        dataset_column_spec = self.source_info.column_spec
+        dataset_spec = self.source_info.column_spec
 
-        # Preprocess the dataset_column_spec to create mappings for input columns
+        # Preprocess the dataset_spec to create mappings for input columns
         # and map the inputs for reserved fields only once, before the iteration over rows.
         input_columns_by_subscripts = {}
         reserved_field_column_mapping = {}
 
         # Process dataset column spec to handle subscripting logic for input columns
-        for reserved_field, user_column in dataset_column_spec.items():
+        for reserved_field, user_column in dataset_spec.items():
             if (
                 reserved_field.startswith("input")
                 or reserved_field.split("_")[1] == "input"
@@ -275,18 +275,16 @@ class Run(BaseModel):
 
             # Call the instrumented main method with the arguments
             input_id = (
-                row[dataset_column_spec["input_id"]]
-                if "input_id" in dataset_column_spec
+                row[dataset_spec["input_id"]]
+                if "input_id" in dataset_spec
                 else None
             )
-            if input_id is None and "input" in dataset_column_spec:
-                input_id = hash(row[dataset_column_spec["input"]])
+            if input_id is None and "input" in dataset_spec:
+                input_id = hash(row[dataset_spec["input"]])
 
-            ground_truth_output = None
-            if "ground_truth_output" in dataset_column_spec:
-                ground_truth_output = row[
-                    dataset_column_spec["ground_truth_output"]
-                ]
+            ground_truth_output = row.get(
+                dataset_spec.get("ground_truth_output")
+            )
 
             self.app.instrumented_invoke_main_method(
                 run_name=self.run_name,

--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -282,10 +282,16 @@ class Run(BaseModel):
             if input_id is None and "input" in dataset_column_spec:
                 input_id = hash(row[dataset_column_spec["input"]])
 
+            ground_truth_output = None
+            if "ground_truth_output" in dataset_column_spec:
+                ground_truth_output = row[
+                    dataset_column_spec["ground_truth_output"]
+                ]
+
             self.app.instrumented_invoke_main_method(
                 run_name=self.run_name,
                 input_id=input_id,
-                ground_truth_output="",
+                ground_truth_output=ground_truth_output,
                 main_method_args=tuple(
                     main_method_args
                 ),  # Ensure correct order


### PR DESCRIPTION
# Description

Fix bugbash item - `ground_truth_output` not showing up in ingested span
## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
