### PR TITLE
TruLens 1.4.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens"
-version = "1.4.2"
+version = "1.4.3"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/langchain/pyproject.toml
+++ b/src/apps/langchain/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-langchain"
-version = "1.4.2"
+version = "1.4.3"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/llamaindex/pyproject.toml
+++ b/src/apps/llamaindex/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-llamaindex"
-version = "1.4.2"
+version = "1.4.3"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/nemo/pyproject.toml
+++ b/src/apps/nemo/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-nemo"
-version = "1.4.2"
+version = "1.4.3"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/benchmark/pyproject.toml
+++ b/src/benchmark/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-benchmark"
-version = "1.4.2"
+version = "1.4.3"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/connectors/snowflake/pyproject.toml
+++ b/src/connectors/snowflake/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-connectors-snowflake"
-version = "1.4.2"
+version = "1.4.3"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-core"
-version = "1.4.2"
+version = "1.4.3"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/dashboard/pyproject.toml
+++ b/src/dashboard/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-dashboard"
-version = "1.4.2"
+version = "1.4.3"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/feedback/pyproject.toml
+++ b/src/feedback/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-feedback"
-version = "1.4.2"
+version = "1.4.3"
 description = "A TruLens extension package implementing feedback functions for LLM App evaluation."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/hotspots/pyproject.toml
+++ b/src/hotspots/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-hotspots"
-version = "1.4.2"
+version = "1.4.3"
 description = "Library and command-line tool to list features lowering your evaluation score."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/otel/semconv/pyproject.toml
+++ b/src/otel/semconv/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-otel-semconv"
-version = "1.4.2"
+version = "1.4.3"
 description = "Semantic conventions for spans produced by TruLens."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/bedrock/pyproject.toml
+++ b/src/providers/bedrock/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-bedrock"
-version = "1.4.2"
+version = "1.4.3"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/cortex/pyproject.toml
+++ b/src/providers/cortex/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-cortex"
-version = "1.4.2"
+version = "1.4.3"
 description = "A TruLens extension package adding Snowflake Cortex support for LLM App evaluation."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/huggingface/pyproject.toml
+++ b/src/providers/huggingface/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-huggingface"
-version = "1.4.2"
+version = "1.4.3"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/langchain/pyproject.toml
+++ b/src/providers/langchain/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-langchain"
-version = "1.4.2"
+version = "1.4.3"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/litellm/pyproject.toml
+++ b/src/providers/litellm/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-litellm"
-version = "1.4.2"
+version = "1.4.3"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/openai/pyproject.toml
+++ b/src/providers/openai/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-openai"
-version = "1.4.2"
+version = "1.4.3"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/trulens_eval/pyproject.toml
+++ b/src/trulens_eval/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens_eval"
-version = "1.4.2"
+version = "1.4.3"
 description = "Backwards-compatibility package for API of trulens_eval<1.0.0 using API of trulens-*>=1.0.0."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",


### PR DESCRIPTION
# Description

## What's Changed

## Bug Fixes
* Filipg/fix hotspots for release by @sfc-gh-fgralinski in https://github.com/truera/trulens/pull/1821
* LiteLLM fixes by @sfc-gh-jreini in https://github.com/truera/trulens/pull/1829
* Don't track feedback functions. by @sfc-gh-dkurokawa in https://github.com/truera/trulens/pull/1833
* Use context variables instead of thread_local since the latter doesn't actually inherit values from the parent threads. by @sfc-gh-dkurokawa in https://github.com/truera/trulens/pull/1838
* remove redundant header in streamlit pills by @sfc-gh-jreini in https://github.com/truera/trulens/pull/1839

## Docs
* change link from slack to snowflake discourse by @sfc-gh-jreini in https://github.com/truera/trulens/pull/1835
* update the README with community link by @sfc-gh-jreini in https://github.com/truera/trulens/pull/1841

## Otel and other updates
* Fix issue where for `llama-index` apps, we don't handle the app specific record root correctly. by @sfc-gh-dkurokawa in https://github.com/truera/trulens/pull/1810
* Redefine span attribute dictionary so that the values of the dictionary map to kwargs of the function decorated or the return. by @sfc-gh-dkurokawa in https://github.com/truera/trulens/pull/1826
* Replace `attributes` with `full_scoped_attributes`. by @sfc-gh-dkurokawa in https://github.com/truera/trulens/pull/1827
* Rename `main_input`/`main_output`/`main_error` to `input`/`output`/`error`. by @sfc-gh-dkurokawa in https://github.com/truera/trulens/pull/1828
* SDK bugbash action items by @sfc-gh-dhuang in https://github.com/truera/trulens/pull/1830
* SDK - run.describe() to return Run object directly #1831 by @sfc-gh-dhuang in https://github.com/truera/trulens/pull/1832
* Clean up tests a bit and add a test to check if span attributes fail, then everything fails. by @sfc-gh-dkurokawa in https://github.com/truera/trulens/pull/1837
* Handle the possible creation of `TruSession` when `connector` argument is given to the tru app. by @sfc-gh-dkurokawa in https://github.com/truera/trulens/pull/1842
* SDK run.start() should take ground_truth_output from dataset_spec by @sfc-gh-dhuang in https://github.com/truera/trulens/pull/1843


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update TruLens to version 1.4.3 with bug fixes, documentation updates, and improvements in OpenTelemetry handling.
> 
>   - **Version Update**:
>     - Update version to `1.4.3` in `pyproject.toml` for `trulens`, `trulens-apps-langchain`, `trulens-apps-llamaindex`, and 15 other components.
>   - **Bug Fixes**:
>     - Fix hotspots for release.
>     - LiteLLM related fixes.
>     - Avoid tracking feedback functions.
>     - Use context variables instead of `thread_local` for value inheritance.
>     - Remove redundant header in Streamlit pills.
>   - **Documentation**:
>     - Change link from Slack to Snowflake Discourse.
>     - Update README with community link.
>   - **Otel and Other Updates**:
>     - Fix handling of app-specific record root for `llama-index` apps.
>     - Redefine span attribute dictionary for function kwargs or return values.
>     - Replace `attributes` with `full_scoped_attributes`.
>     - Rename `main_input`/`main_output`/`main_error` to `input`/`output`/`error`.
>     - SDK `run.describe()` now returns Run object directly.
>     - Handle `TruSession` creation when `connector` argument is given.
>     - SDK `run.start()` takes `ground_truth_output` from `dataset_spec`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 3070d57de6a8e54b439b47b7bf2948f3a33c4457. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->