### PR TITLE
Handle Japanese (and other non-ascii languages) better.

### DIFF
--- a/src/core/trulens/core/utils/json.py
+++ b/src/core/trulens/core/utils/json.py
@@ -111,6 +111,7 @@ def json_str_of_obj(
     return json.dumps(
         jsonify(obj, *args, redact_keys=redact_keys, **kwargs),
         default=json_default,
+        ensure_ascii=False,
     )
 
 

--- a/tests/e2e/test_snowflake_feedback_evaluation.py
+++ b/tests/e2e/test_snowflake_feedback_evaluation.py
@@ -241,25 +241,13 @@ class TestSnowflakeFeedbackEvaluation(SnowflakeTestCase):
     @pytest.mark.optional
     def test_japanese(self) -> None:
         session = self.get_session("test_japanese")
-        f_snowflake = self._get_cortex_relevance_feedback_function()
         tru_app = TruBasicApp(
             text_to_text=lambda _: "幸士君が世界で一番かわいい赤ちゃんです！",
-            feedbacks=[f_snowflake],
         )
         with tru_app:
             tru_app.main_call("世界で一番かわいい赤ちゃんは誰ですか?")
-        self._wait_till_feedbacks_done(num_expected_feedbacks=1)
         records_and_feedback = session.get_records_and_feedback()
-        self.assertEqual(len(records_and_feedback), 2)
-        self.assertListEqual(
-            records_and_feedback[1],
-            ["relevance"],
-        )
         self.assertEqual(records_and_feedback[0].shape[0], 1)
-        self.assertGreaterEqual(
-            records_and_feedback[0]["relevance"].iloc[0],
-            0.5,
-        )
         res = self.run_query(
             f"SELECT INPUT, OUTPUT FROM {self._database}.{self._schema}.TRULENS_RECORDS"
         )

--- a/tests/unit/test_otel_tru_basic.py
+++ b/tests/unit/test_otel_tru_basic.py
@@ -3,6 +3,8 @@ Tests for OTEL TruBasic app.
 """
 
 from trulens.apps.basic import TruBasicApp
+from trulens.core.session import TruSession
+from trulens.otel.semconv.trace import SpanAttributes
 
 import tests.util.otel_tru_app_test_case
 
@@ -31,4 +33,32 @@ class TestOtelTruBasic(tests.util.otel_tru_app_test_case.OtelTruAppTestCase):
         # Compare results to expected.
         self._compare_events_to_golden_dataframe(
             "tests/unit/static/golden/test_otel_tru_basic__test_smoke.csv"
+        )
+
+    def test_japanese(self) -> None:
+        # Create and run app.
+        text_to_text_fn = (
+            lambda name: f"{name}が世界で一番かわいい赤ちゃんです！"
+        )
+        basic_app = TruBasicApp(text_to_text=text_to_text_fn)
+        basic_app.instrumented_invoke_main_method(
+            run_name="test run",
+            input_id="42",
+            main_method_args=("幸士君",),
+        )
+        # Compare results to expected.
+        TruSession().force_flush()
+        events = self._get_events()
+        self.assertEqual(len(events), 1)
+        self.assertEqual(
+            events.iloc[0]["record_attributes"][
+                SpanAttributes.RECORD_ROOT.INPUT
+            ],
+            "幸士君",
+        )
+        self.assertEqual(
+            events.iloc[0]["record_attributes"][
+                SpanAttributes.RECORD_ROOT.OUTPUT
+            ],
+            "幸士君が世界で一番かわいい赤ちゃんです！",
         )


### PR DESCRIPTION
# Description
Handle Japanese (and other non-ascii languages) better.

This is for https://github.com/truera/trulens/issues/1823.

I have also discovered that my son Kojikun/幸士君 is the world's cutest baby in both English and Japanese.

## Other details good to know for developers
I've also tested some of this for the OTEL flow (at least for span attributes) here.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves handling of non-ASCII characters in JSON serialization and adds tests for Japanese text handling.
> 
>   - **Behavior**:
>     - In `json.py`, `json_str_of_obj` now uses `ensure_ascii=False` to handle non-ASCII characters.
>   - **Tests**:
>     - Added `test_japanese` in `test_snowflake_feedback_evaluation.py` to verify Japanese text handling in Snowflake feedback.
>     - Added `test_japanese` in `test_otel_tru_basic.py` to verify Japanese text handling in OTEL TruBasic app.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 4a334222f6c373721d6e3b5d81c6c6ddf0e39a17. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->