### PR TITLE
SDK: Map Span attributes to dataset_spec for Run + misc fixes

### DIFF
--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -416,9 +416,22 @@ class Run(BaseModel):
             latest_invocation.completion_status
             and latest_invocation.completion_status.status
         ):
-            return RunStatus(
-                "INVOCATION_" + latest_invocation.completion_status.status
-            )
+            completion_status = latest_invocation.completion_status.status
+            if completion_status == Run.CompletionStatusStatus.COMPLETED:
+                return RunStatus.INVOCATION_COMPLETED
+            elif (
+                completion_status
+                == Run.CompletionStatusStatus.PARTIALLY_COMPLETED
+            ):
+                return RunStatus.INVOCATION_PARTIALLY_COMPLETED
+            elif completion_status == Run.CompletionStatusStatus.FAILED:
+                return RunStatus.FAILED
+            else:
+                logger.warning(
+                    f"Unknown completion status {completion_status} for invocation {latest_invocation.id}"
+                )
+                return RunStatus.UNKNOWN
+
         current_ingested_records_count = (
             self._read_spans_count_from_event_table(span_type="record_root")
         )

--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -6,7 +6,7 @@ import json
 import logging
 import re
 import time
-from typing import Any, ClassVar, Dict, List, Optional, Type
+from typing import Any, ClassVar, Dict, List, Optional, Set, Type
 import uuid
 
 import pandas as pd
@@ -30,13 +30,9 @@ def _get_all_span_attribute_key_constants(cls: Type, prefix: str) -> List[str]:
                     curr, f"{curr_name}"
                 )
             elif curr_name == curr_name.upper():
-                ret += [f"{prefix}.{curr_name}"]
+                ret += [f"{prefix + '.' if prefix else ''}{curr_name}"]
     ret = list(set(ret))
-    ret = [
-        field
-        for field in ret
-        if not (field.startswith("SpanType") or field.startswith("."))
-    ]
+    ret = [field for field in ret if not (field.startswith("SpanType"))]
 
     ret += [
         field.replace(
@@ -53,7 +49,7 @@ def get_all_span_attribute_key_constants() -> set[str]:
 
 
 # Reserved fields (case-insensitive) for dataset specification directly maps to OTEL Span attributes
-DATASET_RESERVED_FIELDS: set = {
+DATASET_RESERVED_FIELDS: Set[str] = {
     field.lower() for field in get_all_span_attribute_key_constants()
 }
 

--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -377,6 +377,7 @@ class Run(BaseModel):
         return current_run_status in [
             RunStatus.CREATED,
             RunStatus.INVOCATION_PARTIALLY_COMPLETED,
+            RunStatus.FAILED,
             RunStatus.UNKNOWN,
         ]
 
@@ -649,7 +650,7 @@ class Run(BaseModel):
         current_status = self.get_status()
         logger.info(f"Current run status: {current_status}")
         if not self._can_start_new_invocation(current_status):
-            return f"Cannot start a new invocation when in run status: {current_status}. Valid statuses are: {RunStatus.CREATED}, {RunStatus.INVOCATION_PARTIALLY_COMPLETED}."
+            return f"Cannot start a new invocation when in run status: {current_status}. Valid statuses are: {RunStatus.CREATED}, {RunStatus.INVOCATION_PARTIALLY_COMPLETED}, or {RunStatus.FAILED}."
 
         if input_df is None:
             logger.info(

--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -615,13 +615,14 @@ class Run(BaseModel):
         if (
             invocation_completion_status == Run.CompletionStatusStatus.COMPLETED
             or invocation_completion_status
+            == Run.CompletionStatusStatus.PARTIALLY_COMPLETED
         ) and not any(
             status == "IN_PROGRESS"
             for status in computation_sproc_query_ids_to_query_status.values()
         ):
             return RunStatus.PARTIALLY_COMPLETED
 
-        logger.warning("Cannot determin run status")
+        logger.warning("Cannot determine run status")
 
         return RunStatus.UNKNOWN
 

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -745,6 +745,7 @@ trulens.core.run:
     RunStatus: enum.EnumType
     SUPPORTED_ENTRY_TYPES: builtins.list
     SupportedEntryType: enum.EnumType
+    get_all_span_attribute_key_constants: builtins.function
     validate_dataset_spec: builtins.function
 trulens.core.run.Run:
   __bases__:


### PR DESCRIPTION
# Description

based on decisions made in https://docs.google.com/document/d/1xZUigVVaY1b8LuHsFJJD7Pyl1iaXId__UOB-QMLRXuI/edit?tab=t.0

I also snuck in several fixes discovered during e2e tests.
## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Map dataset reserved fields to OTEL Span attributes and update invocation status handling in `run.py`.
> 
>   - **Behavior**:
>     - Map dataset reserved fields to OTEL Span attributes in `run.py`.
>     - Add `get_all_span_attribute_key_constants()` to retrieve span attribute keys.
>     - Update `_compute_latest_invocation_status()` to handle `PARTIALLY_COMPLETED` and `FAILED` statuses.
>   - **Tests**:
>     - Update `api.trulens.3.11.yaml` to reflect new function `get_all_span_attribute_key_constants`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for f149998c242a6069799e20c5edb883b4e45c739c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->