### PR TITLE
Fix double quotes issue in run operation system function / method

### DIFF
--- a/src/connectors/snowflake/trulens/connectors/snowflake/dao/run.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/dao/run.py
@@ -6,6 +6,7 @@ import pandas as pd
 from snowflake.snowpark import Session
 from snowflake.snowpark.row import Row
 from trulens.connectors.snowflake.dao.enums import SourceType
+from trulens.connectors.snowflake.dao.sql_utils import double_quote_identifier
 from trulens.connectors.snowflake.dao.sql_utils import execute_query
 from trulens.core.run import SUPPORTED_ENTRY_TYPES
 from trulens.core.run import SupportedEntryType
@@ -79,7 +80,7 @@ class RunDao:
         """
         # Build the request payload dictionary.
         req_payload = {
-            "object_name": object_name,
+            "object_name": double_quote_identifier(object_name),
             "object_type": object_type,
             "run_name": run_name,
             "description": description,
@@ -157,7 +158,7 @@ class RunDao:
             A pandas DataFrame containing the run metadata.
         """
         req_payload = {
-            "object_name": object_name,
+            "object_name": double_quote_identifier(object_name),
             "object_type": object_type,
             "run_name": run_name,
         }
@@ -193,7 +194,10 @@ class RunDao:
         Returns:
             A pandas DataFrame containing all run metadata.
         """
-        req_payload = {"object_name": object_name, "object_type": object_type}
+        req_payload = {
+            "object_name": double_quote_identifier(object_name),
+            "object_type": object_type,
+        }
         req_payload_json = json.dumps(req_payload)
         query = AIML_RUN_OPS_SYS_FUNC_TEMPLATE.format(method=METHOD_LIST)
 
@@ -242,8 +246,8 @@ class RunDao:
         """
 
         # Build the payload dictionary.
-        payload = {
-            "object_name": object_name,
+        req_payload = {
+            "object_name": double_quote_identifier(object_name),
             "object_type": object_type,
             "run_name": run_name,
             "invocation_field_masks": invocation_field_masks,
@@ -255,9 +259,10 @@ class RunDao:
             "update_description": "false",
         }
         if object_version is not None:
-            payload["object_version"] = object_version
+            req_payload["object_version"] = object_version
 
-        req_payload_json = json.dumps(payload)
+        req_payload_json = json.dumps(req_payload)
+
         query = AIML_RUN_OPS_SYS_FUNC_TEMPLATE.format(method="UPDATE")
 
         logger.debug(
@@ -370,13 +375,14 @@ class RunDao:
         """
         req_payload = {
             "run_name": run_name,
-            "object_name": object_name,
+            "object_name": double_quote_identifier(object_name),
             "object_type": object_type,
         }
         if object_version:
             req_payload["object_version"] = object_version
 
         req_payload_json = json.dumps(req_payload)
+
         query = AIML_RUN_OPS_SYS_FUNC_TEMPLATE.format(method=METHOD_DELETE)
 
         logger.debug(

--- a/src/connectors/snowflake/trulens/connectors/snowflake/dao/sql_utils.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/dao/sql_utils.py
@@ -21,6 +21,18 @@ def escape_quotes(unescaped: str) -> str:
     return unescaped.replace(DOUBLE_QUOTE, DOUBLE_QUOTE + DOUBLE_QUOTE)
 
 
+def double_quote_identifier(identifier: str) -> str:
+    """Double quotes the identifier to preserve it as-is in SQL.
+
+    Args:
+        identifier (str): The identifier to double quote.
+
+    Returns:
+        str: The double quoted identifier.
+    """
+    return DOUBLE_QUOTE + escape_quotes(identifier) + DOUBLE_QUOTE
+
+
 def execute_query(
     session: Session,
     query: str,

--- a/tests/e2e/test_snowflake_agents_and_runs.py
+++ b/tests/e2e/test_snowflake_agents_and_runs.py
@@ -12,7 +12,7 @@ from tests.unit.test_otel_tru_custom import TestApp
 from tests.util.snowflake_test_case import SnowflakeTestCase
 
 
-class TestSnowflakeExternalAgentDao(SnowflakeTestCase):
+class TestSnowflakeAgentsAndRuns(SnowflakeTestCase):
     logger = logging.getLogger(__name__)
 
     @staticmethod
@@ -167,6 +167,7 @@ class TestSnowflakeExternalAgentDao(SnowflakeTestCase):
         app = TestApp()
 
         TEST_APP_NAME = f"custom_app_{datetime.now().strftime('%Y%m%d%H%M%S')}"
+
         tru_recorder = TruApp(
             app,
             app_name=TEST_APP_NAME,
@@ -245,7 +246,7 @@ class TestSnowflakeExternalAgentDao(SnowflakeTestCase):
             run_name=TEST_RUN_NAME,
             description="desc_1",
             dataset_name=test_table_name,
-            dataset_spec={"INPUT": "col1"},
+            dataset_spec={"gibberish": "col1"},
         )
         with self.assertRaises(ValueError):
             tru_recorder.add_run(run_config=invalid_dataset_spec_run_config)
@@ -268,15 +269,18 @@ class TestSnowflakeExternalAgentDao(SnowflakeTestCase):
         )
         run_2 = tru_recorder.add_run(run_config=run_config_2)
 
-        with self.assertRaises(Exception):
-            tru_recorder.add_run(run_config=run_config_2)  # run already exists
+        run_2_ = tru_recorder.add_run(
+            run_config=run_config_2
+        )  # run already exists
+
+        self.assertEqual(run_2.run_name, run_2_.run_name)
 
         runs = tru_recorder.list_runs()
-        self.assertIn("test_run_1", [run.run_name for run in runs])
+        self.assertIn(TEST_RUN_NAME, [run.run_name for run in runs])
         self.assertIn("test_run_2", [run.run_name for run in runs])
 
         # test run deletion
         run_2.delete()
         runs = tru_recorder.list_runs()
-        self.assertIn("test_run_1", [run.run_name for run in runs])
+        self.assertIn(TEST_RUN_NAME, [run.run_name for run in runs])
         self.assertNotIn("test_run_2", [run.run_name for run in runs])

--- a/tests/unit/test_snowflake_external_agent_dao.py
+++ b/tests/unit/test_snowflake_external_agent_dao.py
@@ -7,6 +7,9 @@ import pytest
 try:
     from trulens.connectors.snowflake.dao.enums import ObjectType
     from trulens.connectors.snowflake.dao.external_agent import ExternalAgentDao
+    from trulens.connectors.snowflake.dao.sql_utils import (
+        double_quote_identifier,
+    )
     from trulens.connectors.snowflake.dao.sql_utils import escape_quotes
 
 
@@ -145,3 +148,14 @@ class TestExternalAgentDao(unittest.TestCase):
         )
         self.assertEqual(escape_quotes('""""'), '""""""""')
         self.assertEqual(escape_quotes(""), "")
+
+    def test_double_quote_identifier(self):
+        self.assertEqual(double_quote_identifier("hello"), '"hello"')
+        self.assertEqual(
+            double_quote_identifier("hello world"), '"hello world"'
+        )
+        self.assertEqual(
+            double_quote_identifier('hello "world"'), '"hello ""world"""'
+        )
+        self.assertEqual(double_quote_identifier('""""'), '""""""""')
+        self.assertEqual(double_quote_identifier(""), '""')

--- a/tests/unit/test_snowflake_external_agent_dao.py
+++ b/tests/unit/test_snowflake_external_agent_dao.py
@@ -157,5 +157,5 @@ class TestExternalAgentDao(unittest.TestCase):
         self.assertEqual(
             double_quote_identifier('hello "world"'), '"hello ""world"""'
         )
-        self.assertEqual(double_quote_identifier('""""'), '""""""""')
+        self.assertEqual(double_quote_identifier('""""'), '""""""""""')
         self.assertEqual(double_quote_identifier(""), '""')

--- a/tests/unit/test_snowflake_run_dao.py
+++ b/tests/unit/test_snowflake_run_dao.py
@@ -5,10 +5,13 @@ from unittest.mock import patch
 
 import pandas as pd
 import pytest
-from trulens.connectors.snowflake.dao.sql_utils import double_quote_identifier
 
 try:
     from trulens.connectors.snowflake.dao.run import RunDao
+    from trulens.connectors.snowflake.dao.sql_utils import (
+        double_quote_identifier,
+    )
+
 except Exception:
     RunDao = None
 

--- a/tests/unit/test_snowflake_run_dao.py
+++ b/tests/unit/test_snowflake_run_dao.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pandas as pd
 import pytest
+from trulens.connectors.snowflake.dao.sql_utils import double_quote_identifier
 
 try:
     from trulens.connectors.snowflake.dao.run import RunDao
@@ -48,7 +49,7 @@ class TestRunDao(unittest.TestCase):
         dataset_spec = {"col1": "col1"}
 
         req_payload = {
-            "object_name": object_name,
+            "object_name": double_quote_identifier(object_name),
             "object_type": object_type,
             "object_version": object_version,
             "run_name": run_name,
@@ -122,7 +123,7 @@ class TestRunDao(unittest.TestCase):
     def test_delete_run(self, mock_execute_query):
         req_payload = {
             "run_name": "my_run",
-            "object_name": "MY_AGENT",
+            "object_name": double_quote_identifier("MY_AGENT"),
             "object_type": "EXTERNAL AGENT",
         }
         req_payload_json = json.dumps(req_payload)

--- a/tests/util/snowflake_test_case.py
+++ b/tests/util/snowflake_test_case.py
@@ -121,13 +121,13 @@ class SnowflakeTestCase(TestCase):
     def create_and_use_schema(
         self, schema_name: str, append_uuid: bool = False
     ) -> str:
-        schema_name = schema_name.upper()
-        if append_uuid:
-            schema_name = (
-                f"{schema_name}__{str(uuid.uuid4()).replace('-', '_')}"
-            )
-        self._schema = schema_name
-        self.run_query("CREATE SCHEMA IDENTIFIER(?)", [schema_name])
-        self._snowflake_schemas_to_delete.add(schema_name)
-        self._snowpark_session.use_schema(schema_name)
+        # schema_name = schema_name.upper()
+        # if append_uuid:
+        #     schema_name = (
+        #         f"{schema_name}__{str(uuid.uuid4()).replace('-', '_')}"
+        #     )
+        # self._schema = schema_name
+        # self.run_query("CREATE SCHEMA IDENTIFIER(?)", [schema_name])
+        # self._snowflake_schemas_to_delete.add(schema_name)
+        self._snowpark_session.use_schema("E2E")
         return schema_name

--- a/tests/util/snowflake_test_case.py
+++ b/tests/util/snowflake_test_case.py
@@ -121,13 +121,13 @@ class SnowflakeTestCase(TestCase):
     def create_and_use_schema(
         self, schema_name: str, append_uuid: bool = False
     ) -> str:
-        # schema_name = schema_name.upper()
-        # if append_uuid:
-        #     schema_name = (
-        #         f"{schema_name}__{str(uuid.uuid4()).replace('-', '_')}"
-        #     )
-        # self._schema = schema_name
-        # self.run_query("CREATE SCHEMA IDENTIFIER(?)", [schema_name])
-        # self._snowflake_schemas_to_delete.add(schema_name)
-        self._snowpark_session.use_schema("E2E")
+        schema_name = schema_name.upper()
+        if append_uuid:
+            schema_name = (
+                f"{schema_name}__{str(uuid.uuid4()).replace('-', '_')}"
+            )
+        self._schema = schema_name
+        self.run_query("CREATE SCHEMA IDENTIFIER(?)", [schema_name])
+        self._snowflake_schemas_to_delete.add(schema_name)
+        self._snowpark_session.use_schema(schema_name)
         return schema_name


### PR DESCRIPTION
# Description

we need to ensure the double-quoted `object_name` is passed into as-is to Run operation, given they are created with double quotes like below

`CREATE EXTERNAL AGENT IDENTIFIER('"{escaped_name}"') WITH VERSION "{version}`


This fix should allow users to pass in the `object_name` as-is without converting to upper cases explicitly on the client side.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix handling of double-quoted identifiers in Snowflake operations by introducing `double_quote_identifier()` and updating relevant methods and tests.
> 
>   - **Behavior**:
>     - Use `double_quote_identifier()` in `create_new_run`, `get_run`, `list_all_runs`, `_update_run`, and `delete_run` in `run.py` to ensure `object_name` is passed as-is.
>     - Introduce `double_quote_identifier()` in `sql_utils.py` to double quote identifiers for SQL.
>   - **Tests**:
>     - Update `test_create_new_run` and `test_delete_run` in `test_snowflake_run_dao.py` to use `double_quote_identifier()`.
>     - Add `test_double_quote_identifier` in `test_snowflake_external_agent_dao.py` and `test_snowflake_run_dao.py` to verify quoting behavior.
>     - Modify `test_list_runs_after_adding` in `test_snowflake_agents_and_runs.py` to check for existing runs without raising exceptions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for c06060b1613a6e49ec37313c80a06617fc066bf3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->