### PR TITLE
Require newer versions of OTEL packages.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,6 @@ env-tests:
 		jsondiff \
 		nbconvert \
 		nbformat \
-		opentelemetry-sdk \
-		opentelemetry-proto \
 		pre-commit \
 		pytest \
 		pytest-azurepipelines \


### PR DESCRIPTION
# Description
Require newer versions of OTEL packages.

Also stop having the OTEL packages installed as part of the test environment as that may have been masking the problem.

## Other details good to know for developers


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
