### PR TITLE
Make get_run work with an existing app

### DIFF
--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -1764,9 +1764,7 @@ you use the `%s` wrapper to make sure `%s` does get instrumented. `%s` method
             run_metadata_df,
             {
                 "app": self,
-                "main_method_name": self.main_method_name or ""
-                if self.main_method_name
-                else "",
+                "main_method_name": self.main_method_name or "",
                 "run_dao": self.snowflake_run_dao,
                 "tru_session": self.session,
             },

--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -1764,7 +1764,7 @@ you use the `%s` wrapper to make sure `%s` does get instrumented. `%s` method
             run_metadata_df,
             {
                 "app": self,
-                "main_method_name": self.main_method_name
+                "main_method_name": self.main_method_name or ""
                 if self.main_method_name
                 else "",
                 "run_dao": self.snowflake_run_dao,

--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -1764,7 +1764,9 @@ you use the `%s` wrapper to make sure `%s` does get instrumented. `%s` method
             run_metadata_df,
             {
                 "app": self,
-                "main_method_name": self.main_method_name,
+                "main_method_name": self.main_method_name
+                if self.main_method_name
+                else "",
                 "run_dao": self.snowflake_run_dao,
                 "tru_session": self.session,
             },


### PR DESCRIPTION
# Description

Fix `get_run` in `app.py` to handle `None` `main_method_name` by defaulting to an empty string.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `get_run` in `app.py` to handle `None` `main_method_name` by defaulting to an empty string.
> 
>   - **Behavior**:
>     - Fix `get_run` in `app.py` to handle cases where `main_method_name` is `None` by defaulting to an empty string.
>   - **Functions**:
>     - Modify `get_run` in `app.py` to use `self.main_method_name if self.main_method_name else ""` for `main_method_name`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 016400b26ff44929e67cb1f3f02d2a05573b9b2e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->