### PR TITLE
Run compute metric returning statuses instead of async job 

### DIFF
--- a/examples/experimental/otel_exporter.ipynb
+++ b/examples/experimental/otel_exporter.ipynb
@@ -158,7 +158,7 @@
     "\n",
     "from trulens.apps.app import TruApp\n",
     "\n",
-    "APP_NAME = f\"{os.getlogin()}'s test app\"\n",
+    "APP_NAME = f\"{os.getlogin()} test app\"\n",
     "APP_VERSION = str(datetime.now())\n",
     "\n",
     "test_app = TestApp()\n",
@@ -257,7 +257,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "trulens_3_11",
+   "display_name": "trulens",
    "language": "python",
    "name": "python3"
   },

--- a/src/connectors/snowflake/trulens/connectors/snowflake/dao/external_agent.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/dao/external_agent.py
@@ -10,9 +10,8 @@ logger = logging.getLogger(__name__)
 
 class ExternalAgentDao:
     """Data Access Object (DAO) layer for managing External Agents in Snowflake.
-    We currently enclose all names in double quotes to preserve the passed in string as-is when converting to SQL identifiers.
+    We currently use unquoted object identifiers when converting to SQL identifiers.
     https://docs.snowflake.com/en/sql-reference/identifiers-syntax
-    double quotes in the passed in string will be escaped with an additional double quote
     """
 
     def __init__(self, snowpark_session: Session):

--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -386,7 +386,7 @@ class Run(BaseModel):
             RunStatus.COMPUTATION_IN_PROGRESS,
             RunStatus.COMPLETED,
             RunStatus.PARTIALLY_COMPLETED,
-            RunStatus.UNKNOWN,  # TODO: verify if this is allowed behavior
+            RunStatus.FAILED,
         ]
 
     def _is_invocation_started(self, run: Run) -> bool:
@@ -799,7 +799,7 @@ class Run(BaseModel):
         logger.info(f"Current run status: {run_status}")
         if not self._can_start_new_metric_computation(run_status):
             return f"""Cannot start a new metric computation when in run status: {run_status}. Valid statuses are: {RunStatus.INVOCATION_COMPLETED}, {RunStatus.INVOCATION_PARTIALLY_COMPLETED},
-        {RunStatus.COMPUTATION_IN_PROGRESS}, {RunStatus.COMPLETED}, {RunStatus.PARTIALLY_COMPLETED}."""
+        {RunStatus.COMPUTATION_IN_PROGRESS}, {RunStatus.COMPLETED}, {RunStatus.PARTIALLY_COMPLETED}, {RunStatus.FAILED}."""
 
         async_job = self.run_dao.call_compute_metrics_query(
             metrics=metrics,

--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -793,7 +793,7 @@ class Run(BaseModel):
             logger.info("Run is created, invocation started.")
             return self._compute_latest_invocation_status(run)
 
-    def compute_metrics(self, metrics: List[str]):
+    def compute_metrics(self, metrics: List[str]) -> str:
         run_status = self.get_status()
 
         logger.info(f"Current run status: {run_status}")
@@ -830,7 +830,7 @@ class Run(BaseModel):
         )
 
         logger.info("Metrics computation job started")
-        return async_job
+        return "Metrics computation in progress."
 
     def cancel(self):
         raise NotImplementedError("cancel is not implemented yet.")


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue that can be
included in the release announcement. Please also include relevant motivation
and context.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `compute_metrics` in `run.py` now returns a status message, and `ExternalAgentDao` uses unquoted SQL identifiers.
> 
>   - **Behavior**:
>     - `compute_metrics` in `run.py` now returns a status message instead of an async job object.
>     - Updates valid statuses for starting new metric computation to include `RunStatus.FAILED` in `run.py`.
>   - **Misc**:
>     - `ExternalAgentDao` in `external_agent.py` now uses unquoted object identifiers for SQL identifiers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for ebb57f85938fa935e47cb1224ac991c73c53e33e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->