### PR TITLE
TruLens 1.4.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens"
-version = "1.4.4"
+version = "1.4.5"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/langchain/pyproject.toml
+++ b/src/apps/langchain/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-langchain"
-version = "1.4.4"
+version = "1.4.5"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/llamaindex/pyproject.toml
+++ b/src/apps/llamaindex/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-llamaindex"
-version = "1.4.4"
+version = "1.4.5"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/nemo/pyproject.toml
+++ b/src/apps/nemo/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-nemo"
-version = "1.4.4"
+version = "1.4.5"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/benchmark/pyproject.toml
+++ b/src/benchmark/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-benchmark"
-version = "1.4.4"
+version = "1.4.5"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/connectors/snowflake/meta.yaml
+++ b/src/connectors/snowflake/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trulens-connectors-snowflake" %}
-{% set version = "1.4.4" %}
+{% set version = "1.4.5" %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +11,7 @@ source:
   {% else %}
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-connectors-snowflake/#files
-  sha256: 36a620513ef82c63325ba4f8a65bfbd06278d9a13605efef8de179c9f44199b3
+  sha256: 19142fff8418697dc2a94f0c44a7ed96ab3b5cb07f08d369c03f4bf509e23e62
   {% endif %}
 
 build:

--- a/src/connectors/snowflake/pyproject.toml
+++ b/src/connectors/snowflake/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-connectors-snowflake"
-version = "1.4.4"
+version = "1.4.5"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trulens-core" %}
-{% set version = "1.4.4" %}
+{% set version = "1.4.5" %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +11,7 @@ source:
   {% else %}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-core/#files
-  sha256: ab23bdfd75c301a954c3ce51af505640bd0f3e9f2729f2c9d5fd7427ccf2a247
+  sha256: fcde45a2927f47e366a4dd84d68f469bc50679fdcfe712e59389f18376b79d99
   {% endif %}
 
 build:

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-core"
-version = "1.4.4"
+version = "1.4.5"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",
@@ -45,7 +45,7 @@ importlib-resources = "^6.0"
 opentelemetry-api = ">=1.0.23"
 opentelemetry-sdk = ">=1.0.23"
 opentelemetry-proto = ">=1.0.23"
-trulens-otel-semconv = { version = "^1.4.4" }
+trulens-otel-semconv = { version = "^1.4.5" }
 
 [tool.poetry.group.tqdm]
 optional = true

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trulens-dashboard" %}
-{% set version = "1.4.4" %}
+{% set version = "1.4.5" %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +11,7 @@ source:
   {% else %}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-dashboard/#files
-  sha256: 257929e79fd177a7f66de21ce9a678f53c41a3c44ddaa65ee1c4d2ebe88dd8d2
+  sha256: 5b9c1dc29531f3199ce6536d8ea3e6a728d96678f4882da41e4326754c204c7b
   {% endif %}
 
 build:

--- a/src/dashboard/pyproject.toml
+++ b/src/dashboard/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-dashboard"
-version = "1.4.4"
+version = "1.4.5"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/feedback/meta.yaml
+++ b/src/feedback/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trulens-feedback" %}
-{% set version = "1.4.4" %}
+{% set version = "1.4.5" %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +11,7 @@ source:
   {% else %}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-feedback/#files
-  sha256: 37e9eb6d60d7de6107fc564eb375dc1557f59a9a5cddd7a84395b2fe743f5fd2
+  sha256: 8cd3aeb6b4bb04855eeae6d03eee4693cde45333e3f084421275b02e5a030d33
   {% endif %}
 
 build:

--- a/src/feedback/pyproject.toml
+++ b/src/feedback/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-feedback"
-version = "1.4.4"
+version = "1.4.5"
 description = "A TruLens extension package implementing feedback functions for LLM App evaluation."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/hotspots/pyproject.toml
+++ b/src/hotspots/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-hotspots"
-version = "1.4.4"
+version = "1.4.5"
 description = "Library and command-line tool to list features lowering your evaluation score."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/otel/semconv/meta.yaml
+++ b/src/otel/semconv/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trulens-otel-semconv" %}
-{% set version = "1.4.4" %}
+{% set version = "1.4.5" %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +11,7 @@ source:
   {% else %}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-otel-semconv/#files
-  sha256: 6a098c730103b57cca9462ee0ecf46616d11951da01028d8b75771b10f4730b6
+  sha256: a1ce2200d1bc4afba1a371e4969522b60a2f4e82e7f476a5c574ebc1317aafd9
   {% endif %}
 
 build:

--- a/src/otel/semconv/pyproject.toml
+++ b/src/otel/semconv/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-otel-semconv"
-version = "1.4.4"
+version = "1.4.5"
 description = "Semantic conventions for spans produced by TruLens."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/bedrock/pyproject.toml
+++ b/src/providers/bedrock/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-bedrock"
-version = "1.4.4"
+version = "1.4.5"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trulens-providers-cortex" %}
-{% set version = "1.4.4" %}
+{% set version = "1.4.5" %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +11,7 @@ source:
   {% else %}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-providers-cortex/#files
-  sha256: 9938ea5cb7cc056c1d8aec9fed6567b6f701a29548fa42e0cf4888fbc6c9df7d
+  sha256: 141aa22a1017f1e526687828ee62a2e9ddbed0013ea3f777e9f8f18a289a2675
   {% endif %}
 
 build:

--- a/src/providers/cortex/pyproject.toml
+++ b/src/providers/cortex/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-cortex"
-version = "1.4.4"
+version = "1.4.5"
 description = "A TruLens extension package adding Snowflake Cortex support for LLM App evaluation."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/huggingface/pyproject.toml
+++ b/src/providers/huggingface/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-huggingface"
-version = "1.4.4"
+version = "1.4.5"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/langchain/pyproject.toml
+++ b/src/providers/langchain/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-langchain"
-version = "1.4.4"
+version = "1.4.5"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/litellm/pyproject.toml
+++ b/src/providers/litellm/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-litellm"
-version = "1.4.4"
+version = "1.4.5"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/openai/pyproject.toml
+++ b/src/providers/openai/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-openai"
-version = "1.4.4"
+version = "1.4.5"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/trulens_eval/pyproject.toml
+++ b/src/trulens_eval/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens_eval"
-version = "1.4.4"
+version = "1.4.5"
 description = "Backwards-compatibility package for API of trulens_eval<1.0.0 using API of trulens-*>=1.0.0."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",


### PR DESCRIPTION
# Description

## What's Changed
* Fix double quotes issue in run operation system function / method by @sfc-gh-dhuang in https://github.com/truera/trulens/pull/1853
* Get E2E tests running (yes, not even working just running). by @sfc-gh-dkurokawa in https://github.com/truera/trulens/pull/1850
* Create load test. by @sfc-gh-dkurokawa in https://github.com/truera/trulens/pull/1854
* Require newer versions of OTEL packages. by @sfc-gh-dkurokawa in https://github.com/truera/trulens/pull/1855
* Update Snowflake OTEL E2E tests to use Snowflake runs. by @sfc-gh-dkurokawa in https://github.com/truera/trulens/pull/1849
* SDK - app/ snowflake object name case resolution and fixing span attributes validation in dataset_spec by @sfc-gh-dhuang in https://github.com/truera/trulens/pull/1856
* Make CUJ work with local LLM by @sfc-gh-pdharmana in https://github.com/truera/trulens/pull/1858
* Remove mention of cortex guard tokens. by @sfc-gh-dkurokawa in https://github.com/truera/trulens/pull/1860
* Remove requirement for ALTER SESSION as we don't need it anymore. by @sfc-gh-dkurokawa in https://github.com/truera/trulens/pull/1865
* Call feedbacks with feedback.__call__ by @sfc-gh-chu in https://github.com/truera/trulens/pull/1864
* Update latest cortex cost table by @sfc-gh-dhuang in https://github.com/truera/trulens/pull/1863
* Run compute metric returning statuses instead of async job  by @sfc-gh-dhuang in https://github.com/truera/trulens/pull/1866


**Full Changelog**: https://github.com/truera/trulens/compare/trulens-1.4.4...trulens-1.4.5
## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Bump version from 1.4.4 to 1.4.5 across multiple components, updating `pyproject.toml` and `meta.yaml` files, including SHA256 checksums.
> 
>   - **Version Update**:
>     - Bump version from `1.4.4` to `1.4.5` in `pyproject.toml` and `meta.yaml` files across multiple components including `trulens`, `trulens-apps-langchain`, `trulens-apps-llamaindex`, `trulens-apps-nemo`, `trulens-benchmark`, `trulens-connectors-snowflake`, `trulens-core`, `trulens-dashboard`, `trulens-feedback`, `trulens-hotspots`, `trulens-otel-semconv`, `trulens-providers-bedrock`, `trulens-providers-cortex`, `trulens-providers-huggingface`, `trulens-providers-langchain`, `trulens-providers-litellm`, `trulens-providers-openai`, and `trulens_eval`.
>     - Update SHA256 checksums in `meta.yaml` files for `trulens-connectors-snowflake`, `trulens-core`, `trulens-dashboard`, `trulens-feedback`, `trulens-otel-semconv`, and `trulens-providers-cortex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 910b78fc666eadc3d3a705920ca4d92b6feabf2f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->