### PR TITLE
SDK: Fix run metadata field masks logic and expose description and label as optional and update-able fields 

### DIFF
--- a/src/connectors/snowflake/trulens/connectors/snowflake/dao/external_agent.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/dao/external_agent.py
@@ -111,8 +111,9 @@ class ExternalAgentDao:
 
         return resolved_name in agents["name"].values
 
-    def list_agent_versions(self, resolved_name: str) -> pandas.DataFrame:
+    def list_agent_versions(self, name: str) -> pandas.DataFrame:
         """Retrieve all versions of a specific External Agent."""
+        resolved_name = name.upper()
         query = f"""SHOW VERSIONS IN EXTERNAL AGENT "{resolved_name}";"""
 
         rows = execute_query(self.session, query)

--- a/src/connectors/snowflake/trulens/connectors/snowflake/dao/run.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/dao/run.py
@@ -335,7 +335,7 @@ class RunDao:
 
         for key, value in field_updates.items():
             parts = key.split(".")
-            logger.error("danny parts: %s", parts)
+
             if parts[0] in SUPPORTED_ENTRY_TYPES:
                 group = parts[0]
                 if len(parts) < 3:

--- a/src/connectors/snowflake/trulens/connectors/snowflake/dao/run.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/dao/run.py
@@ -398,7 +398,7 @@ class RunDao:
     ) -> None:
         """
         Consolidated upsert method for run metadata entries.
-        Supported entry types: "invocations", "computations", "metrics".
+        Supported entry types: "invocations", "computations", "metrics" and also entity level fields like "description", "run_status".
 
         This method retrieves the current run metadata, merges new fields with any existing
         entry (if present), and then pushes the updated run metadata via _update_run.

--- a/src/connectors/snowflake/trulens/connectors/snowflake/dao/run.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/dao/run.py
@@ -466,7 +466,7 @@ class RunDao:
             f"non-map field masks: {non_map_field_masks}"
         )
 
-        update_desrciption = "description" in field_updates
+        update_description = "description" in field_updates
         description = field_updates.get("description", None)
 
         update_run_status = "run_status" in field_updates
@@ -481,7 +481,7 @@ class RunDao:
             metric_field_masks=metric_field_masks,
             computation_field_masks=computation_field_masks,
             updated_run_metadata=updated_run_metadata,
-            update_description=update_desrciption,
+            update_description=update_description,
             description=description,
             update_run_status=update_run_status,
             run_status=run_status,

--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -82,11 +82,7 @@ class SupportedEntryType(str, Enum):
     METRICS = "metrics"
 
 
-SUPPORTED_ENTRY_TYPES = [
-    SupportedEntryType.INVOCATIONS,
-    SupportedEntryType.COMPUTATIONS,
-    SupportedEntryType.METRICS,
-]
+SUPPORTED_ENTRY_TYPES = [e.value for e in SupportedEntryType]
 
 
 def validate_dataset_spec(
@@ -443,7 +439,7 @@ class Run(BaseModel):
         ):
             # happy case, add end time and update status
             self.run_dao.upsert_run_metadata_fields(
-                entry_type=SupportedEntryType.INVOCATIONS,
+                entry_type=SupportedEntryType.INVOCATIONS.value,
                 entry_id=latest_invocation.id,
                 input_records_count=latest_invocation.input_records_count,
                 start_time_ms=latest_invocation.start_time_ms,
@@ -468,7 +464,7 @@ class Run(BaseModel):
             # inconclusive case, timeout reached and add end time and update completion status in DPO
             logger.warning("Invocation timeout reached and concluded")
             self.run_dao.upsert_run_metadata_fields(
-                entry_type=SupportedEntryType.INVOCATIONS,
+                entry_type=SupportedEntryType.INVOCATIONS.value,
                 entry_id=latest_invocation.id,
                 input_records_count=latest_invocation.input_records_count,
                 start_time_ms=latest_invocation.start_time_ms,
@@ -527,7 +523,7 @@ class Run(BaseModel):
         # all computations are done, update DPO computations metadata
         for computation in all_computations:
             self.run_dao.upsert_run_metadata_fields(
-                entry_type=SupportedEntryType.COMPUTATIONS,
+                entry_type=SupportedEntryType.COMPUTATIONS.value,
                 entry_id=computation.id,
                 query_id=computation.query_id,
                 start_time_ms=computation.start_time_ms,
@@ -571,7 +567,7 @@ class Run(BaseModel):
                         )
 
                         self.run_dao.upsert_run_metadata_fields(
-                            entry_type=SupportedEntryType.METRICS,
+                            entry_type=SupportedEntryType.METRICS.value,
                             entry_id=metric_metatada_id,
                             computation_id=computation.id,
                             name=row["METRIC"],
@@ -591,7 +587,7 @@ class Run(BaseModel):
                         )
 
                         self.run_dao.upsert_run_metadata_fields(
-                            entry_type=SupportedEntryType.METRICS,
+                            entry_type=SupportedEntryType.METRICS.value,
                             entry_id=metric_metatada_id,
                             computation_id=computation.id,
                             name=row["METRIC"],
@@ -688,7 +684,7 @@ class Run(BaseModel):
         )
 
         self.run_dao.upsert_run_metadata_fields(
-            entry_type=SupportedEntryType.INVOCATIONS,
+            entry_type=SupportedEntryType.INVOCATIONS.value,
             entry_id=invocation_metadata_id,
             start_time_ms=start_time_ms,
             end_time_ms=0,  # required field
@@ -741,7 +737,7 @@ class Run(BaseModel):
             )
 
             self.run_dao.upsert_run_metadata_fields(
-                entry_type=SupportedEntryType.INVOCATIONS,
+                entry_type=SupportedEntryType.INVOCATIONS.value,
                 entry_id=invocation_metadata_id,
                 start_time_ms=start_time_ms,
                 input_records_count=input_records_count,
@@ -821,7 +817,7 @@ class Run(BaseModel):
         computation_start_time_ms = self._get_current_time_in_ms()
 
         self.run_dao.upsert_run_metadata_fields(
-            entry_type=SupportedEntryType.COMPUTATIONS,
+            entry_type=SupportedEntryType.COMPUTATIONS.value,
             entry_id=computation_metadata_id,
             query_id=query_id,
             start_time_ms=computation_start_time_ms,

--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -343,9 +343,13 @@ class Run(BaseModel):
         if run_metadata_df.empty:
             raise ValueError(f"Run {self.run_name} not found.")
 
-        return json.loads(
+        raw_json = json.loads(
             list(run_metadata_df.to_dict(orient="records")[0].values())[0]
         )
+
+        # remove / hide entity-level run_status field to avoid customer's confusion
+        raw_json.pop("run_status", None)
+        return raw_json
 
     def delete(self) -> None:
         """
@@ -655,7 +659,6 @@ class Run(BaseModel):
             logger.info(
                 "No input dataframe provided. Fetching input data from source."
             )
-            # TODO: update the source_info.source_type to 'TABLE'
             rows = self.run_dao.session.sql(
                 f"SELECT * FROM {self.source_info.name}"
             ).collect()

--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -840,7 +840,22 @@ class Run(BaseModel):
         """
         Only description and label are allowed to be updated at the moment.
         """
-        raise NotImplementedError("update is not implemented yet.")
+        update_fields = {}
+        if description is not None:
+            logger.info(f"Updating run description to {description}")
+            update_fields["description"] = description
+        if label is not None:
+            logger.info(f"Updating run label to {label}")
+            update_fields["labels"] = [label]
+
+        if update_fields:
+            self.run_dao.upsert_run_metadata_fields(
+                run_name=self.run_name,
+                object_name=self.object_name,
+                object_type=self.object_type,
+                object_version=self.object_version,
+                **update_fields,
+            )
 
     @classmethod
     def from_metadata_df(


### PR DESCRIPTION
# Description
1. Fix field masks logic and allow both description and label to be optional
## Other details good to know for developers

Run DPO ref: https://github.com/snowflakedb/snowflake/blob/main/Snowfort/tests/llm_evaluations/ref/test_run_create_get.ref.yaml

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes field masks logic in `RunDao` and allows `description` and `label` fields to be optional and update-able, with new tests added for validation.
> 
>   - **Behavior**:
>     - Fixes field masks logic in `RunDao` class in `run.py`.
>     - Allows `description` and `label` fields in `RunDao.create_new_run` and `RunDao._update_run` to be optional and update-able.
>     - Updates `Run.describe()` to hide `run_status` field from the returned metadata.
>   - **Functions**:
>     - Adds `_set_nested_value` and `_update_run_metadata_field_masks` to `RunDao` in `run.py` for handling nested dictionary updates and field masks.
>     - Modifies `upsert_run_metadata_fields` in `run.py` to support entity-level field updates and improve field mask handling.
>   - **Tests**:
>     - Adds unit tests in `test_snowflake_run_dao.py` for `_set_nested_value` and `_update_run_metadata_field_masks` functions.
>     - Tests `upsert_run_metadata_fields` for various update scenarios in `test_snowflake_run_dao.py`.
>     - Updates `list_agent_versions` in `external_agent.py` to use `name.upper()` for `resolved_name`.
>   - **Misc**:
>     - Renames `entry_type` to `entry_type.value` in multiple methods in `run.py` and `external_agent.py`.
>     - Removes `run_status` from the output of `describe()` in `run.py` to avoid customer confusion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 38937a653be792bbd84e58834001c3b0b438601f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->