### PR TITLE
Fix MySQL setup

### DIFF
--- a/src/core/trulens/core/database/migrations/versions/4_set_ff_id_not_null.py
+++ b/src/core/trulens/core/database/migrations/versions/4_set_ff_id_not_null.py
@@ -6,6 +6,7 @@ Create Date: 2024-08-16 12:44:05.560492
 """
 
 from alembic import op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "4"
@@ -24,6 +25,7 @@ def upgrade(config) -> None:
     with op.batch_alter_table(prefix + "feedbacks") as batch_op:
         batch_op.alter_column(
             "feedback_definition_id",
+            existing_type=sa.VARCHAR(length=1024),
             nullable=False,
         )
     # ### end Alembic commands ###
@@ -36,6 +38,7 @@ def downgrade(config) -> None:
     with op.batch_alter_table(prefix + "feedbacks") as batch_op:
         batch_op.alter_column(
             "feedback_definition_id",
+            existing_type=sa.VARCHAR(length=1024),
             nullable=True,
         )
     # ### end Alembic commands ###

--- a/src/core/trulens/core/database/migrations/versions/7_app_name_version_not_null.py
+++ b/src/core/trulens/core/database/migrations/versions/7_app_name_version_not_null.py
@@ -6,6 +6,7 @@ Create Date: 2024-08-27 11:09:26
 """
 
 from alembic import op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "7"
@@ -24,10 +25,12 @@ def upgrade(config) -> None:
     with op.batch_alter_table(prefix + "apps") as batch_op:
         batch_op.alter_column(
             "app_name",
+            existing_type=sa.VARCHAR(length=1024),
             nullable=False,
         )
         batch_op.alter_column(
             "app_version",
+            existing_type=sa.VARCHAR(length=1024),
             nullable=False,
         )
     # ### end Alembic commands ###
@@ -43,10 +46,12 @@ def downgrade(config) -> None:
     with op.batch_alter_table(prefix + "apps") as batch_op:
         batch_op.alter_column(
             "app_name",
+            existing_type=sa.VARCHAR(length=1024),
             nullable=True,
         )
         batch_op.alter_column(
             "app_version",
+            existing_type=sa.VARCHAR(length=1024),
             nullable=True,
         )
     # ### end Alembic commands ###


### PR DESCRIPTION
When installing Trulens over MySQL we get this error: alembic.util.exc.CommandError: All MySQL CHANGE/MODIFY COLUMN operations require the existing type.

this patch fixes that error.

# Description

When deploying in a MySQL database the following error will appear
`All MySQL CHANGE/MODIFY COLUMN operations require the existing type.`

That can be fixed by providing the existing type into the batch_op.alter_column calls.


## Type of change

- [ X ] Bug fix (non-breaking change which fixes an issue)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes MySQL migration error by specifying existing column types in Alembic `alter_column` calls.
> 
>   - **Bug Fix**:
>     - Fixes MySQL error "All MySQL CHANGE/MODIFY COLUMN operations require the existing type" in Alembic migrations.
>     - Adds `existing_type=sa.VARCHAR(length=1024)` to `alter_column` calls in `4_set_ff_id_not_null.py` and `7_app_name_version_not_null.py`.
>   - **Files Affected**:
>     - `4_set_ff_id_not_null.py`: Updates `feedback_definition_id` column.
>     - `7_app_name_version_not_null.py`: Updates `app_name` and `app_version` columns.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 27c51ce23f9a5c22e3f8fbe95ea281e260d1db0d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->