### PR TITLE
bump otel version

### DIFF
--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -27,9 +27,9 @@ requirements:
   run:
     - python >=3.9,<3.12
     - trulens-otel-semconv >=1.0.0,<2.0.0
-    - opentelemetry-api >=1.0.0,<2.0.0
-    - opentelemetry-sdk >=1.0.0,<2.0.0
-    - opentelemetry-proto >=1.0.0,<2.0.0
+    - opentelemetry-api >=1.23.0
+    - opentelemetry-sdk >=1.23.0
+    - opentelemetry-proto >=1.23.0
     - numpy >=1.23
     - munch >=2.5.0,<3.0.0
     - dill >=0.3.8,<0.4.0

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -42,9 +42,9 @@ alembic = "^1.8.1"
 nest-asyncio = "^1.5"
 python-dotenv = ">=0.21,<2.0"
 importlib-resources = "^6.0"
-opentelemetry-api = ">=1.0.23"
-opentelemetry-sdk = ">=1.0.23"
-opentelemetry-proto = ">=1.0.23"
+opentelemetry-api = ">=1.23.0"
+opentelemetry-sdk = ">=1.23.0"
+opentelemetry-proto = ">=1.23.0"
 trulens-otel-semconv = { version = "^1.4.5" }
 
 [tool.poetry.group.tqdm]


### PR DESCRIPTION
# Description

Bumps otel version to 1.23.0 across conda build and pyproject files

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump OpenTelemetry dependencies to version 1.23.0 in `meta.yaml` and `pyproject.toml`.
> 
>   - **Dependencies**:
>     - Bump `opentelemetry-api`, `opentelemetry-sdk`, and `opentelemetry-proto` to version `1.23.0` in `meta.yaml` and `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for acb0bf67211901f4e00117685de5c1de549c380d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->