### PR TITLE
[SNOW-1983345] SDK: app deletion and delete current version 

### DIFF
--- a/src/connectors/snowflake/trulens/connectors/snowflake/dao/external_agent.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/dao/external_agent.py
@@ -89,12 +89,11 @@ class ExternalAgentDao:
 
         versions_df = self.list_agent_versions(name)
 
-        print("gg")
-        print(versions_df)
-
         if not versions_df.empty:
+            found_last = False
             for _, row in versions_df.iterrows():
                 if "LAST" in row["aliases"]:
+                    found_last = True
                     current_version = row["name"]
                     if "DEFAULT" in row["aliases"]:
                         raise ValueError(
@@ -109,6 +108,12 @@ class ExternalAgentDao:
                     logger.info(
                         f"Dropped current version {current_version} from External Agent {name}."
                     )
+                    break
+
+            if not found_last:
+                raise ValueError(
+                    f"No version with 'LAST' alias found for External Agent {name}."
+                )
         else:
             raise ValueError(f"No versions found for External Agent {name}.")
 

--- a/src/connectors/snowflake/trulens/connectors/snowflake/dao/external_agent.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/dao/external_agent.py
@@ -118,11 +118,13 @@ class ExternalAgentDao:
         logger.info("Retrieved list of External Agents.")
         return result_df
 
-    def check_agent_exists(self, resolved_name: str) -> bool:
+    def check_agent_exists(self, name: str) -> bool:
         """Check if an External Agent exists."""
         agents = self._list_agents()
         if agents.empty or "name" not in agents.columns:
             return False
+
+        resolved_name = name.upper()
         logger.info(f"Checking if External Agent {resolved_name} exists.")
 
         return resolved_name in agents["name"].values

--- a/src/connectors/snowflake/trulens/connectors/snowflake/dao/external_agent.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/dao/external_agent.py
@@ -84,13 +84,29 @@ class ExternalAgentDao:
             f"Added version {version} to External Agent {resolved_name}."
         )
 
-    def drop_version(self, name: str, version: str) -> None:
+    def _get_current_version(self, name: str) -> str:
+        """Retrieve the current version of an External Agent."""
+        versions_df = self.list_agent_versions(name)
+
+        if not versions_df.empty:
+            for _, row in versions_df.iterrows():
+                if "LAST" in row["aliases"]:
+                    current_version = row["name"]
+                    return current_version
+
+        raise ValueError(f"No versions found for External Agent {name}.")
+
+    def drop_current_version(self, name: str) -> None:
         """Drop a specific version from an External Agent."""
+
+        current_version = self._get_current_version(name)
         resolved_name = name.upper()
-        query = f"""ALTER EXTERNAL AGENT if exists "{resolved_name}" DROP VERSION "{version}";"""
+        query = f"""ALTER EXTERNAL AGENT if exists "{resolved_name}" DROP VERSION "{current_version}";"""
 
         execute_query(self.session, query)
-        logger.info(f"Dropped version {version} from External Agent {name}.")
+        logger.info(
+            f"Dropped current version {current_version} from External Agent {name}."
+        )
 
     def _list_agents(self) -> pandas.DataFrame:
         """Retrieve a list of all External Agents."""

--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -1805,10 +1805,17 @@ you use the `%s` wrapper to make sure `%s` does get instrumented. `%s` method
             )
         return runs
 
-    def delete_snowflake_app(self) -> None:
-        """Delete the snowflake App (managing object) in snowflake, if applicable."""
+    def delete(self) -> None:
+        """Delete the snowflake App (external agent) in snowflake. All versions will be removed"""
         self._check_snowflake_dao()
         self.snowflake_app_dao.drop_agent(self.snowflake_object_name)
+
+    def delete_version(self) -> None:
+        """Delete the current version of the snowflake App (external agent) in snowflake.
+        Only the non-default version can be deleted.
+        """
+        self._check_snowflake_dao()
+        self.snowflake_app_dao.drop_current_version(self.snowflake_object_name)
 
     def run(self, run_name: str):
         if self.session.experimental_feature(

--- a/tests/e2e/test_snowflake_agents_and_runs.py
+++ b/tests/e2e/test_snowflake_agents_and_runs.py
@@ -83,7 +83,9 @@ class TestSnowflakeAgentsAndRuns(SnowflakeTestCase):
         self.assertIsNotNone(tru_recorder.snowflake_run_dao)
 
         self.assertEqual(tru_recorder.snowflake_object_type, "EXTERNAL AGENT")
-        self.assertEqual(tru_recorder.snowflake_object_name, TEST_APP_NAME)
+        self.assertEqual(
+            tru_recorder.snowflake_object_name, TEST_APP_NAME.upper()
+        )
 
         self.assertTrue(
             tru_recorder.snowflake_app_dao.check_agent_exists(TEST_APP_NAME)
@@ -180,7 +182,9 @@ class TestSnowflakeAgentsAndRuns(SnowflakeTestCase):
         self.assertIsNotNone(tru_recorder.snowflake_run_dao)
 
         self.assertEqual(tru_recorder.snowflake_object_type, "EXTERNAL AGENT")
-        self.assertEqual(tru_recorder.snowflake_object_name, TEST_APP_NAME)
+        self.assertEqual(
+            tru_recorder.snowflake_object_name, TEST_APP_NAME.upper()
+        )
 
         self.assertTrue(
             tru_recorder.snowflake_app_dao.check_agent_exists(TEST_APP_NAME)

--- a/tests/e2e/test_snowflake_agents_and_runs.py
+++ b/tests/e2e/test_snowflake_agents_and_runs.py
@@ -97,7 +97,7 @@ class TestSnowflakeAgentsAndRuns(SnowflakeTestCase):
             "v1", versions_df["name"].values
         )  # version is uppercased in snowflake
 
-        tru_recorder.delete_snowflake_app()
+        tru_recorder.delete()
 
         self.assertFalse(
             tru_recorder.snowflake_app_dao.check_agent_exists(TEST_APP_NAME)
@@ -221,7 +221,7 @@ class TestSnowflakeAgentsAndRuns(SnowflakeTestCase):
 
         self.assertDictEqual(run.model_dump(), new_run.model_dump())
 
-        tru_recorder.delete_snowflake_app()  # cleanup external agent after test
+        tru_recorder.delete()  # cleanup external agent after test
 
     def test_list_runs_after_adding(self):
         app = TestApp()

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -4,7 +4,7 @@ trulens:
   lows: {}
 trulens.benchmark:
   __class__: builtins.module
-  __version__: 1.4.2
+  __version__: 1.4.4
   highs: {}
   lows:
     __version__: builtins.str
@@ -60,7 +60,7 @@ trulens.benchmark.test_cases:
     generate_summeval_groundedness_golden_set: builtins.function
 trulens.core:
   __class__: builtins.module
-  __version__: 1.4.2
+  __version__: 1.4.4
   highs:
     Feedback: pydantic._internal._model_construction.ModelMetaclass
     FeedbackMode: enum.EnumType
@@ -115,7 +115,8 @@ trulens.core.app.App:
     awith_record: builtins.function
     connector: builtins.property
     db: builtins.property
-    delete_snowflake_app: builtins.function
+    delete: builtins.function
+    delete_version: builtins.function
     dummy_record: builtins.function
     feedback_definitions: typing.Sequence[builtins.str]
     feedback_mode: trulens.core.schema.feedback.FeedbackMode
@@ -1829,7 +1830,7 @@ trulens.core.utils.trulens.Other:
   attributes: {}
 trulens.dashboard:
   __class__: builtins.module
-  __version__: 1.4.2
+  __version__: 1.4.4
   highs:
     run_dashboard: builtins.function
     run_dashboard_sis: builtins.function
@@ -2117,7 +2118,7 @@ trulens.dashboard.ux.styles.ResultCategoryType:
     value: enum.property
 trulens.feedback:
   __class__: builtins.module
-  __version__: 1.4.2
+  __version__: 1.4.4
   highs:
     Embeddings: pydantic._internal._model_construction.ModelMetaclass
     GroundTruthAggregator: pydantic._internal._model_construction.ModelMetaclass
@@ -3027,7 +3028,7 @@ trulens.feedback.v2.provider.base.Provider:
     tru_class_info: trulens.core.utils.pyschema.Class
 trulens.hotspots:
   __class__: builtins.module
-  __version__: 1.4.2
+  __version__: 1.4.4
   highs:
     HotspotsConfig: builtins.type
     get_skipped_columns: builtins.function

--- a/tests/unit/static/golden/api.trulens_eval.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens_eval.3.11.yaml
@@ -908,7 +908,8 @@ trulens_eval.TruApp:
     continue_session: builtins.staticmethod
     copy: builtins.function
     db: builtins.property
-    delete_snowflake_app: builtins.function
+    delete: builtins.function
+    delete_version: builtins.function
     dict: builtins.function
     dummy_record: builtins.function
     feedback_definitions: typing.Sequence[builtins.str]
@@ -1020,7 +1021,8 @@ trulens_eval.TruBasicApp:
     continue_session: builtins.staticmethod
     copy: builtins.function
     db: builtins.property
-    delete_snowflake_app: builtins.function
+    delete: builtins.function
+    delete_version: builtins.function
     dict: builtins.function
     dummy_record: builtins.function
     feedback_definitions: typing.Sequence[builtins.str]
@@ -1132,7 +1134,8 @@ trulens_eval.TruChain:
     continue_session: builtins.staticmethod
     copy: builtins.function
     db: builtins.property
-    delete_snowflake_app: builtins.function
+    delete: builtins.function
+    delete_version: builtins.function
     dict: builtins.function
     dummy_record: builtins.function
     feedback_definitions: typing.Sequence[builtins.str]
@@ -1242,7 +1245,8 @@ trulens_eval.TruCustomApp:
     continue_session: builtins.staticmethod
     copy: builtins.function
     db: builtins.property
-    delete_snowflake_app: builtins.function
+    delete: builtins.function
+    delete_version: builtins.function
     dict: builtins.function
     dummy_record: builtins.function
     feedback_definitions: typing.Sequence[builtins.str]
@@ -1353,7 +1357,8 @@ trulens_eval.TruLlama:
     continue_session: builtins.staticmethod
     copy: builtins.function
     db: builtins.property
-    delete_snowflake_app: builtins.function
+    delete: builtins.function
+    delete_version: builtins.function
     dict: builtins.function
     dummy_record: builtins.function
     feedback_definitions: typing.Sequence[builtins.str]
@@ -1464,7 +1469,8 @@ trulens_eval.TruRails:
     continue_session: builtins.staticmethod
     copy: builtins.function
     db: builtins.property
-    delete_snowflake_app: builtins.function
+    delete: builtins.function
+    delete_version: builtins.function
     dict: builtins.function
     dummy_record: builtins.function
     feedback_definitions: typing.Sequence[builtins.str]
@@ -1576,7 +1582,8 @@ trulens_eval.TruVirtual:
     continue_session: builtins.staticmethod
     copy: builtins.function
     db: builtins.property
-    delete_snowflake_app: builtins.function
+    delete: builtins.function
+    delete_version: builtins.function
     dict: builtins.function
     dummy_record: builtins.function
     feedback_definitions: typing.Sequence[builtins.str]
@@ -1719,7 +1726,8 @@ trulens_eval.app.App:
     continue_session: builtins.staticmethod
     copy: builtins.function
     db: builtins.property
-    delete_snowflake_app: builtins.function
+    delete: builtins.function
+    delete_version: builtins.function
     dict: builtins.function
     dummy_record: builtins.function
     feedback_definitions: typing.Sequence[builtins.str]
@@ -7194,7 +7202,8 @@ trulens_eval.tru_basic_app.TruBasicApp:
     continue_session: builtins.staticmethod
     copy: builtins.function
     db: builtins.property
-    delete_snowflake_app: builtins.function
+    delete: builtins.function
+    delete_version: builtins.function
     dict: builtins.function
     dummy_record: builtins.function
     feedback_definitions: typing.Sequence[builtins.str]
@@ -7350,7 +7359,8 @@ trulens_eval.tru_chain.TruChain:
     continue_session: builtins.staticmethod
     copy: builtins.function
     db: builtins.property
-    delete_snowflake_app: builtins.function
+    delete: builtins.function
+    delete_version: builtins.function
     dict: builtins.function
     dummy_record: builtins.function
     feedback_definitions: typing.Sequence[builtins.str]
@@ -7468,7 +7478,8 @@ trulens_eval.tru_custom_app.TruCustomApp:
     continue_session: builtins.staticmethod
     copy: builtins.function
     db: builtins.property
-    delete_snowflake_app: builtins.function
+    delete: builtins.function
+    delete_version: builtins.function
     dict: builtins.function
     dummy_record: builtins.function
     feedback_definitions: typing.Sequence[builtins.str]
@@ -7610,7 +7621,8 @@ trulens_eval.tru_llama.TruLlama:
     continue_session: builtins.staticmethod
     copy: builtins.function
     db: builtins.property
-    delete_snowflake_app: builtins.function
+    delete: builtins.function
+    delete_version: builtins.function
     dict: builtins.function
     dummy_record: builtins.function
     feedback_definitions: typing.Sequence[builtins.str]
@@ -7787,7 +7799,8 @@ trulens_eval.tru_rails.TruRails:
     continue_session: builtins.staticmethod
     copy: builtins.function
     db: builtins.property
-    delete_snowflake_app: builtins.function
+    delete: builtins.function
+    delete_version: builtins.function
     dict: builtins.function
     dummy_record: builtins.function
     feedback_definitions: typing.Sequence[builtins.str]
@@ -7907,7 +7920,8 @@ trulens_eval.tru_virtual.TruVirtual:
     continue_session: builtins.staticmethod
     copy: builtins.function
     db: builtins.property
-    delete_snowflake_app: builtins.function
+    delete: builtins.function
+    delete_version: builtins.function
     dict: builtins.function
     dummy_record: builtins.function
     feedback_definitions: typing.Sequence[builtins.str]

--- a/tests/unit/test_snowflake_external_agent_dao.py
+++ b/tests/unit/test_snowflake_external_agent_dao.py
@@ -23,8 +23,7 @@ class DummyRow:
         return self._d
 
 
-# @pytest.mark.snowflake
-@pytest.mark.optional
+@pytest.mark.snowflake
 class TestExternalAgentDao(unittest.TestCase):
     def setUp(self):
         if ExternalAgentDao is None:


### PR DESCRIPTION
# Description

JIRA: https://snowflakecomputing.atlassian.net/browse/SNOW-1983345

Implement app deletion and delete_version(). 

`delete_version()` currently will only remove the latest version of the external agent, and will fail with error msg if the current version is the only/default version.
## Other details good to know for developers
Fix e2e test suite `test_snowflake_agents_and_runs`

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add functionality to delete current non-default version of Snowflake app and rename related functions for clarity.
> 
>   - **Behavior**:
>     - `delete()` in `app.py` now deletes the Snowflake app and all its versions.
>     - `delete_version()` in `app.py` deletes the current non-default version of the Snowflake app.
>     - `drop_current_version()` in `external_agent.py` deletes the current version if not default, raises error if default.
>   - **Tests**:
>     - Added `test_drop_current_version` and `test_drop_default_version_raise` in `test_snowflake_external_agent_dao.py`.
>     - Updated `test_tru_app_snowflake_agent_initialization` and `test_tru_app_multiple_versions` in `test_snowflake_agents_and_runs.py`.
>   - **Renames**:
>     - `delete_snowflake_app()` to `delete()`.
>     - `drop_version()` to `drop_current_version()`.
>   - **Misc**:
>     - Updated version in `api.trulens.3.11.yaml` and `api.trulens_eval.3.11.yaml` from 1.4.2 to 1.4.4.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for fee4e7416be130cf51011063179274d968806c19. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->