### PR TITLE
[SNOW-1956008] SDK: implement run.cancel() and cancellation logic

### DIFF
--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -796,10 +796,21 @@ class Run(BaseModel):
             logger.info(
                 "Run is created, invocation done, and computation started."
             )
+            if self._is_cancelled():
+                logger.warning(
+                    "Run was cancelled when computation in progress."
+                )
+                return RunStatus.PARTIALLY_COMPLETED
+
             return self._compute_overall_computations_status(run)
 
         else:
             logger.info("Run is created, invocation started.")
+
+            if self._is_cancelled():
+                logger.warning("Run was cancelled when invocation in progress.")
+                return RunStatus.INVOCATION_PARTIALLY_COMPLETED
+
             return self._compute_latest_invocation_status(run)
 
     def compute_metrics(self, metrics: List[str]) -> str:

--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -492,6 +492,9 @@ class Run(BaseModel):
             return RunStatus.INVOCATION_PARTIALLY_COMPLETED
 
         else:
+            if self._is_cancelled():
+                logger.warning("Run was cancelled when invocation in progress.")
+                return RunStatus.INVOCATION_PARTIALLY_COMPLETED
             return (
                 RunStatus.INVOCATION_IN_PROGRESS
                 if latest_invocation.end_time_ms == 0
@@ -527,6 +530,11 @@ class Run(BaseModel):
                 logger.info(
                     f"Computation {computation.id} is still running or being queued."
                 )
+                if self._is_cancelled():
+                    logger.warning(
+                        "Run was cancelled when computation in progress."
+                    )
+                    return RunStatus.PARTIALLY_COMPLETED
                 # Returning early to avoid unnecessary checks as long as at least one computation is still running
                 return RunStatus.COMPUTATION_IN_PROGRESS
             computation_sproc_query_ids_to_query_status[query_id] = query_status
@@ -796,20 +804,11 @@ class Run(BaseModel):
             logger.info(
                 "Run is created, invocation done, and computation started."
             )
-            if self._is_cancelled():
-                logger.warning(
-                    "Run was cancelled when computation in progress."
-                )
-                return RunStatus.PARTIALLY_COMPLETED
 
             return self._compute_overall_computations_status(run)
 
         else:
             logger.info("Run is created, invocation started.")
-
-            if self._is_cancelled():
-                logger.warning("Run was cancelled when invocation in progress.")
-                return RunStatus.INVOCATION_PARTIALLY_COMPLETED
 
             return self._compute_latest_invocation_status(run)
 

--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -858,6 +858,10 @@ class Run(BaseModel):
         return raw_json.get("run_status") == "CANCELLED"
 
     def cancel(self):
+        if self._is_cancelled():
+            logger.warning(f"Run {self.run_name} is already cancelled.")
+            return
+
         update_fields = {"run_status": "CANCELLED"}
 
         self.run_dao.upsert_run_metadata_fields(

--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -362,6 +362,10 @@ class Run(BaseModel):
         """
         Check if the run is in a state that allows starting a new invocation.
         """
+        if self._is_cancelled():
+            logger.warning("Cannot start a new invocation for a cancelled run.")
+            return False
+
         return current_run_status in [
             RunStatus.CREATED,
             RunStatus.INVOCATION_PARTIALLY_COMPLETED,
@@ -375,6 +379,12 @@ class Run(BaseModel):
         """
         Check if the run is in a state that allows starting a new metric computation.
         """
+        if self._is_cancelled():
+            logger.warning(
+                "Cannot start a new metric computation for a cancelled run."
+            )
+            return False
+
         if current_run_status == RunStatus.COMPUTATION_IN_PROGRESS:
             logger.warning(
                 "Previous computation(s) still in progress. Starting another new metric computation when computation is in progress."

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -4,7 +4,7 @@ trulens:
   lows: {}
 trulens.benchmark:
   __class__: builtins.module
-  __version__: 1.4.2
+  __version__: 1.4.4
   highs: {}
   lows:
     __version__: builtins.str
@@ -60,7 +60,7 @@ trulens.benchmark.test_cases:
     generate_summeval_groundedness_golden_set: builtins.function
 trulens.core:
   __class__: builtins.module
-  __version__: 1.4.2
+  __version__: 1.4.4
   highs:
     Feedback: pydantic._internal._model_construction.ModelMetaclass
     FeedbackMode: enum.EnumType
@@ -773,6 +773,7 @@ trulens.core.run.Run:
     run_dao: typing.Any
     run_metadata: trulens.core.run.Run.RunMetadata
     run_name: builtins.str
+    run_status: typing.Optional[builtins.str, builtins.NoneType]
     source_info: trulens.core.run.Run.SourceInfo
     start: builtins.function
     tru_session: typing.Any
@@ -795,6 +796,7 @@ trulens.core.run.RunStatus:
   - enum.Enum
   __class__: enum.EnumType
   attributes:
+    CANCELLED: trulens.core.run.RunStatus
     COMPLETED: trulens.core.run.RunStatus
     COMPUTATION_IN_PROGRESS: trulens.core.run.RunStatus
     CREATED: trulens.core.run.RunStatus
@@ -1829,7 +1831,7 @@ trulens.core.utils.trulens.Other:
   attributes: {}
 trulens.dashboard:
   __class__: builtins.module
-  __version__: 1.4.2
+  __version__: 1.4.4
   highs:
     run_dashboard: builtins.function
     run_dashboard_sis: builtins.function
@@ -2117,7 +2119,7 @@ trulens.dashboard.ux.styles.ResultCategoryType:
     value: enum.property
 trulens.feedback:
   __class__: builtins.module
-  __version__: 1.4.2
+  __version__: 1.4.4
   highs:
     Embeddings: pydantic._internal._model_construction.ModelMetaclass
     GroundTruthAggregator: pydantic._internal._model_construction.ModelMetaclass
@@ -3027,7 +3029,7 @@ trulens.feedback.v2.provider.base.Provider:
     tru_class_info: trulens.core.utils.pyschema.Class
 trulens.hotspots:
   __class__: builtins.module
-  __version__: 1.4.2
+  __version__: 1.4.4
   highs:
     HotspotsConfig: builtins.type
     get_skipped_columns: builtins.function


### PR DESCRIPTION
# Description
JIRA: https://snowflakecomputing.atlassian.net/browse/SNOW-1956008
Implement run cancellation logc.

Currently, a cancelled run will block any further users' actions - i.e. users are not allowed to call `run.start()` nor `run.compute_metrics(...)` once the run has been cancelled.

We also now explicitly return `CANCELLED` status to users from `run.get_status()`   
## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add run cancellation feature to SDK, updating `Run` class and `RunStatus` enum, with tests to verify behavior.
> 
>   - **Behavior**:
>     - Implement `cancel()` method in `Run` class to set `run_status` to `CANCELLED`.
>     - Update `RunStatus` enum to include `CANCELLED`.
>     - Prevent `start()` and `compute_metrics()` in `Run` from executing if `run_status` is `CANCELLED`.
>     - `get_status()` in `Run` returns `CANCELLED` if run is cancelled.
>   - **Tests**:
>     - Add `test_run_cancellation()` in `test_snowflake_agents_and_runs.py` to verify cancellation logic.
>     - Ensure `start()` and `compute_metrics()` return appropriate messages when run is cancelled.
>   - **Misc**:
>     - Update `api.trulens.3.11.yaml` to reflect changes in `RunStatus` and `Run` attributes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 12b835a8208e945d3e31d9ffad27146d80901649. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->