### PR TITLE
Fix azure openai e2e tests

### DIFF
--- a/tests/e2e/test_endpoints.py
+++ b/tests/e2e/test_endpoints.py
@@ -267,7 +267,6 @@ class TestEndpoints(test_utils.TruTestCase):
     def test_litellm_openai_azure(self):
         """Check that cost tracking works for openai models through litellm."""
 
-        os.environ["OPENAI_API_VERSION"] = "2023-07-01-preview"
         os.environ["OPENAI_API_TYPE"] = "azure"
 
         # Have to delete litellm endpoint singleton as it may have been created

--- a/tests/e2e/test_endpoints.py
+++ b/tests/e2e/test_endpoints.py
@@ -44,9 +44,10 @@ class TestEndpoints(test_utils.TruTestCase):
             # "AWS_SECRET_ACCESS_KEY",
             # "AWS_SESSION_TOKEN",
             # for azure openai tests
+            "AZURE_OPENAI_DEPLOYMENT",
             "AZURE_OPENAI_API_KEY",
             "AZURE_OPENAI_ENDPOINT",
-            "AZURE_OPENAI_DEPLOYMENT_NAME",
+            "OPENAI_API_VERSION",
             # for snowflake cortex
             "SNOWFLAKE_ACCOUNT",
             "SNOWFLAKE_USER",
@@ -254,8 +255,10 @@ class TestEndpoints(test_utils.TruTestCase):
         OpenAIEndpoint.delete_instances()
 
         provider = AzureOpenAI(
-            model_engine=AzureOpenAI.DEFAULT_MODEL_ENGINE,
-            deployment_name=os.environ["AZURE_OPENAI_DEPLOYMENT_NAME"],
+            deployment_name=os.environ["AZURE_OPENAI_DEPLOYMENT"],  # gpt-4o
+            api_key=os.environ["AZURE_OPENAI_API_KEY"],
+            azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+            api_version=os.environ["OPENAI_API_VERSION"],
         )
 
         self._test_llm_provider_endpoint(provider)
@@ -276,7 +279,7 @@ class TestEndpoints(test_utils.TruTestCase):
         from trulens.providers.litellm import LiteLLM
 
         provider = LiteLLM(
-            f"azure/{os.environ['AZURE_OPENAI_DEPLOYMENT_NAME']}",
+            f"azure/{os.environ['AZURE_OPENAI_DEPLOYMENT']}",
             completion_kwargs=dict(
                 api_base=os.environ["AZURE_OPENAI_ENDPOINT"]
             ),


### PR DESCRIPTION
# Description

Fix E2E tests to take Azure openai creds from env variables 

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Azure OpenAI E2E tests by updating environment variables and provider initialization in `test_endpoints.py`.
> 
>   - **Environment Variables**:
>     - Replace `AZURE_OPENAI_DEPLOYMENT_NAME` with `AZURE_OPENAI_DEPLOYMENT` in `setUp()` and `test_litellm_openai_azure()`.
>     - Add `OPENAI_API_VERSION` to `setUp()` for Azure OpenAI tests.
>   - **Provider Initialization**:
>     - Update `AzureOpenAI` initialization in `test_openai_azure()` to use `AZURE_OPENAI_DEPLOYMENT`, `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, and `OPENAI_API_VERSION`.
>     - Update `LiteLLM` initialization in `test_litellm_openai_azure()` to use `AZURE_OPENAI_DEPLOYMENT` and `AZURE_OPENAI_ENDPOINT`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 06330c8d939db61ebc98e4619f608a6566406df1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->