### PR TITLE
Fix litellm e2e tests with Azure Openai

### DIFF
--- a/src/providers/litellm/trulens/providers/litellm/provider.py
+++ b/src/providers/litellm/trulens/providers/litellm/provider.py
@@ -57,11 +57,8 @@ class LiteLLM(llm_provider.LLMProvider):
             completion_kwargs = {}
 
         if model_engine.startswith("azure/") and (
-            completion_kwargs is None
-            or (
-                "api_base" not in completion_kwargs
-                and not os.getenv("AZURE_API_BASE")
-            )
+            "api_base" not in completion_kwargs
+            and not os.getenv("AZURE_API_BASE")
         ):
             raise ValueError(
                 "Azure model engine requires 'api_base' parameter to litellm completions. "

--- a/src/providers/litellm/trulens/providers/litellm/provider.py
+++ b/src/providers/litellm/trulens/providers/litellm/provider.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import ClassVar, Dict, Optional, Sequence
 
 import pydantic
@@ -56,20 +57,24 @@ class LiteLLM(llm_provider.LLMProvider):
             completion_kwargs = {}
 
         if model_engine.startswith("azure/") and (
-            completion_kwargs is None or "api_base" not in completion_kwargs
+            completion_kwargs is None
+            or (
+                "api_base" not in completion_kwargs
+                and not os.getenv("AZURE_API_BASE")
+            )
         ):
             raise ValueError(
                 "Azure model engine requires 'api_base' parameter to litellm completions. "
                 "Provide it to LiteLLM provider in the 'completion_kwargs' parameter:"
                 """
-```python
-provider = LiteLLM(
-    "azure/your_deployment_name",
-    completion_kwargs={
-        "api_base": "https://yourendpoint.openai.azure.com/"
-    }
-)
-```
+                ```python
+                provider = LiteLLM(
+                    "azure/your_deployment_name",
+                    completion_kwargs={
+                        "api_base": "https://yourendpoint.openai.azure.com/"
+                    }
+                )
+                ```
                 """
             )
 

--- a/tests/e2e/test_endpoints.py
+++ b/tests/e2e/test_endpoints.py
@@ -284,9 +284,6 @@ class TestEndpoints(test_utils.TruTestCase):
 
         provider = LiteLLM(
             f"azure/{os.environ['AZURE_OPENAI_DEPLOYMENT']}",
-            completion_kwargs=dict(
-                api_base=os.environ["AZURE_OPENAI_ENDPOINT"],
-            ),
         )
 
         self._test_llm_provider_endpoint(provider)

--- a/tests/e2e/test_endpoints.py
+++ b/tests/e2e/test_endpoints.py
@@ -37,7 +37,7 @@ class TestEndpoints(test_utils.TruTestCase):
             # for non-azure openai tests
             "OPENAI_API_KEY",
             # for huggingface tests
-            # "HUGGINGFACE_API_KEY",
+            "HUGGINGFACE_API_KEY",
             # for bedrock tests # no current keys available for bedrock
             # "AWS_REGION_NAME",
             # "AWS_ACCESS_KEY_ID",


### PR DESCRIPTION
# Description

Fix LiteLLM usage w/ azure openai in e2e tests

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes Azure OpenAI integration in LiteLLM e2e tests by checking `AZURE_API_BASE` environment variable and updating test cases.
> 
>   - **Behavior**:
>     - In `provider.py`, `LiteLLM` now checks `AZURE_API_BASE` environment variable if `api_base` is not in `completion_kwargs`.
>     - Raises `ValueError` if `api_base` is missing for Azure models.
>   - **Tests**:
>     - In `test_endpoints.py`, `test_openai_azure` and `test_litellm_openai_azure` updated to set `AZURE_API_BASE` from `AZURE_OPENAI_ENDPOINT`.
>     - `test_litellm_openai_azure` no longer sets `completion_kwargs` for `LiteLLM` provider.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 41d2687c4b4bb5d0c5d3948f97b81436bf551052. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->