### PR TITLE
Doc string spelling

### DIFF
--- a/src/feedback/trulens/feedback/groundtruth.py
+++ b/src/feedback/trulens/feedback/groundtruth.py
@@ -243,7 +243,7 @@ class GroundTruthAgreement(
         response: str,
     ) -> Union[float, Tuple[float, Dict[str, str]]]:
         """
-        Uses OpenAI's Chat GPT Model. A function that that measures
+        Uses OpenAI's Chat GPT Model. A function that measures
         similarity to ground truth. A second template is given to Chat GPT
         with a prompt that the original response is correct, and measures
         whether previous Chat GPT's response is similar.


### PR DESCRIPTION
# Description

Spelling error corrected in doc string.

## Other details good to know for developers
-
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes a spelling error in the docstring of `agreement_measure` in `groundtruth.py`.
> 
>   - **Docstring Correction**:
>     - Fixes a spelling error in the docstring of `agreement_measure` in `groundtruth.py`. Changed "A function that that measures" to "A function that measures".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for b6ff4ea6b468161a69d4019ee8fc23f20a3aca8b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->