### PR TITLE
Update poetry to trulens 1.4.8

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -9134,7 +9134,7 @@ reference = "pypi-public"
 
 [[package]]
 name = "trulens-apps-langchain"
-version = "1.4.6"
+version = "1.4.8"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -9153,7 +9153,7 @@ url = "src/apps/langchain"
 
 [[package]]
 name = "trulens-apps-llamaindex"
-version = "1.4.6"
+version = "1.4.8"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -9176,7 +9176,7 @@ url = "src/apps/llamaindex"
 
 [[package]]
 name = "trulens-apps-nemo"
-version = "1.4.6"
+version = "1.4.8"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9,<3.13"
@@ -9199,7 +9199,7 @@ url = "src/apps/nemo"
 
 [[package]]
 name = "trulens-benchmark"
-version = "1.4.6"
+version = "1.4.8"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -9216,7 +9216,7 @@ url = "src/benchmark"
 
 [[package]]
 name = "trulens-connectors-snowflake"
-version = "1.4.6"
+version = "1.4.8"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9,<3.12"
@@ -9234,7 +9234,7 @@ url = "src/connectors/snowflake"
 
 [[package]]
 name = "trulens-core"
-version = "1.4.6"
+version = "1.4.8"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -9258,7 +9258,7 @@ python-dotenv = ">=0.21,<2.0"
 requests = "^2.31"
 rich = "^13.6.0"
 sqlalchemy = "^2.0"
-trulens-otel-semconv = "^1.4.6"
+trulens-otel-semconv = "^1.4.8"
 typing_extensions = "^4.9"
 
 [package.source]
@@ -9267,7 +9267,7 @@ url = "src/core"
 
 [[package]]
 name = "trulens-dashboard"
-version = "1.4.6"
+version = "1.4.8"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9,!=3.9.7"
@@ -9296,7 +9296,7 @@ url = "src/dashboard"
 
 [[package]]
 name = "trulens-eval"
-version = "1.4.6"
+version = "1.4.8"
 description = "Backwards-compatibility package for API of trulens_eval<1.0.0 using API of trulens-*>=1.0.0."
 optional = false
 python-versions = "^3.9,!=3.9.7"
@@ -9314,7 +9314,7 @@ url = "src/trulens_eval"
 
 [[package]]
 name = "trulens-feedback"
-version = "1.4.6"
+version = "1.4.8"
 description = "A TruLens extension package implementing feedback functions for LLM App evaluation."
 optional = false
 python-versions = "^3.9"
@@ -9336,7 +9336,7 @@ url = "src/feedback"
 
 [[package]]
 name = "trulens-hotspots"
-version = "1.4.6"
+version = "1.4.8"
 description = "Library and command-line tool to list features lowering your evaluation score."
 optional = false
 python-versions = "^3.9"
@@ -9355,7 +9355,7 @@ url = "src/hotspots"
 
 [[package]]
 name = "trulens-otel-semconv"
-version = "1.4.6"
+version = "1.4.8"
 description = "Semantic conventions for spans produced by TruLens."
 optional = false
 python-versions = "^3.9"
@@ -9371,7 +9371,7 @@ url = "src/otel/semconv"
 
 [[package]]
 name = "trulens-providers-bedrock"
-version = "1.4.6"
+version = "1.4.8"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -9390,7 +9390,7 @@ url = "src/providers/bedrock"
 
 [[package]]
 name = "trulens-providers-cortex"
-version = "1.4.6"
+version = "1.4.8"
 description = "A TruLens extension package adding Snowflake Cortex support for LLM App evaluation."
 optional = false
 python-versions = "^3.9,<3.12"
@@ -9411,7 +9411,7 @@ url = "src/providers/cortex"
 
 [[package]]
 name = "trulens-providers-huggingface"
-version = "1.4.6"
+version = "1.4.8"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -9433,7 +9433,7 @@ url = "src/providers/huggingface"
 
 [[package]]
 name = "trulens-providers-langchain"
-version = "1.4.6"
+version = "1.4.8"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -9451,7 +9451,7 @@ url = "src/providers/langchain"
 
 [[package]]
 name = "trulens-providers-litellm"
-version = "1.4.6"
+version = "1.4.8"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -9469,7 +9469,7 @@ url = "src/providers/litellm"
 
 [[package]]
 name = "trulens-providers-openai"
-version = "1.4.6"
+version = "1.4.8"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"


### PR DESCRIPTION
# Description

- Update `poetry.lock` to use latest trulens library (version 1.4.8, released 4/3/2025)

## Other details good to know for developers

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
