### PR TITLE
[SNOW-2031737] Refresh symbolic links for notebooks to test

### DIFF
--- a/tests/docs_notebooks/notebooks_to_test/langchain_faiss_example.ipynb
+++ b/tests/docs_notebooks/notebooks_to_test/langchain_faiss_example.ipynb
@@ -1,1 +1,1 @@
-../../../examples/expositional/vector-dbs/faiss/langchain_faiss_example.ipynb
+../../../examples/expositional/vector_stores/faiss/langchain_faiss_example.ipynb

--- a/tests/docs_notebooks/notebooks_to_test/langchain_instrumentation.ipynb
+++ b/tests/docs_notebooks/notebooks_to_test/langchain_instrumentation.ipynb
@@ -1,1 +1,0 @@
-../../../docs/trulens/tracking/instrumentation/langchain.ipynb

--- a/tests/docs_notebooks/notebooks_to_test/llama_index_instrumentation.ipynb
+++ b/tests/docs_notebooks/notebooks_to_test/llama_index_instrumentation.ipynb
@@ -1,1 +1,0 @@
-../../../docs/trulens/tracking/instrumentation/llama_index.ipynb

--- a/tests/docs_notebooks/notebooks_to_test/logging.ipynb
+++ b/tests/docs_notebooks/notebooks_to_test/logging.ipynb
@@ -1,1 +1,1 @@
-../../../docs/trulens/tracking/logging/logging.ipynb
+../../../docs/component_guides/logging/logging.ipynb

--- a/tests/docs_notebooks/notebooks_to_test/trulens_instrumentation.ipynb
+++ b/tests/docs_notebooks/notebooks_to_test/trulens_instrumentation.ipynb
@@ -1,1 +1,0 @@
-../../../docs/trulens/tracking/instrumentation/index.ipynb


### PR DESCRIPTION
# Description

See [SNOW-2031737](https://snowflakecomputing.atlassian.net/browse/SNOW-2031737) - fixing broken symbolic links that cause issues when running `make format`

## Other details good to know for developers

- Remove sym links to deleted notebooks (these have been replaced with Markdown files)
  - `tests/docs_notebooks/notebooks_to_test/langchain_instrumentation.ipynb`
  - `tests/docs_notebooks/notebooks_to_test/llama_index_instrumentation.ipynb`
  - `tests/docs_notebooks/notebooks_to_test/trulens_instrumentation.ipynb`
- Fix sym links to notebooks that have been moved:
  - `tests/docs_notebooks/notebooks_to_test/langchain_faiss_example.ipynb`
  - `tests/docs_notebooks/notebooks_to_test/logging.ipynb`

Broken format call:
![Broken format call](https://github.com/user-attachments/assets/c215f378-d30d-4396-b328-5791ce24398e)

Fixed format call:
![Fixed format call](https://github.com/user-attachments/assets/12f8216c-ddc8-4d37-ab9a-a3021d925f21)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
