### PR TITLE
Handle missing cortex costtracking response 

### DIFF
--- a/src/providers/cortex/trulens/providers/cortex/endpoint.py
+++ b/src/providers/cortex/trulens/providers/cortex/endpoint.py
@@ -18,6 +18,8 @@ pp = pprint.PrettyPrinter()
 class CortexCostComputer:
     @staticmethod
     def handle_response(response: Any) -> Dict[str, Any]:
+        model = "undefined"
+        usage = {}
         for curr in response:
             data = json.loads(curr.data)
             choice = data["choices"][0]
@@ -25,6 +27,7 @@ class CortexCostComputer:
                 model = data["model"]
                 usage = data["usage"]
                 break
+
         endpoint = CortexEndpoint()
         callback = CortexCallback(endpoint=endpoint)
         return {

--- a/src/providers/cortex/trulens/providers/cortex/endpoint.py
+++ b/src/providers/cortex/trulens/providers/cortex/endpoint.py
@@ -18,7 +18,7 @@ pp = pprint.PrettyPrinter()
 class CortexCostComputer:
     @staticmethod
     def handle_response(response: Any) -> Dict[str, Any]:
-        model = "undefined"
+        model = None
         usage = {}
         for curr in response:
             data = json.loads(curr.data)
@@ -27,7 +27,8 @@ class CortexCostComputer:
                 model = data["model"]
                 usage = data["usage"]
                 break
-
+        if model is None:
+            return {}
         endpoint = CortexEndpoint()
         callback = CortexCallback(endpoint=endpoint)
         return {


### PR DESCRIPTION
# Description
Handle case of missing cost tracking data resulting in 

```python
local variable 'model' referenced before assignment
```

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
