### PR TITLE
[SNOW-2005231, SNOW-2033054, SNOW-2033730] Deflake E2E pipeline issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,8 @@ build: $(POETRY_DIRS)
 
 build-with-zip-wheels:
 	# Increase timeout for http requests to avoid issues with slow downloads
-	export POETRY_HTTP_TIMEOUT=2400
+	# See https://github.com/python-poetry/poetry/blob/master/src/poetry/utils/constants.py
+	export POETRY_REQUESTS_TIMEOUT=60
 
 	rm -rf ./dist \
 		&& rm -rf ./src/core/trulens/data/snowflake_stage_zips \

--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ build: $(POETRY_DIRS)
 
 build-with-zip-wheels:
 	# Increase timeout for http requests to avoid issues with slow downloads
-	POETRY_HTTP_TIMEOUT=1200
+	export POETRY_HTTP_TIMEOUT=1200
 
 	rm -rf ./dist \
 		&& rm -rf ./src/core/trulens/data/snowflake_stage_zips \

--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,9 @@ build: $(POETRY_DIRS)
 	done
 
 build-with-zip-wheels:
+	# Increase timeout for http requests to avoid issues with slow downloads
+	POETRY_HTTP_TIMEOUT=1200
+
 	rm -rf ./dist \
 		&& rm -rf ./src/core/trulens/data/snowflake_stage_zips \
 		&& make build \

--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ build: $(POETRY_DIRS)
 
 build-with-zip-wheels:
 	# Increase timeout for http requests to avoid issues with slow downloads
-	export POETRY_HTTP_TIMEOUT=1200
+	export POETRY_HTTP_TIMEOUT=2400
 
 	rm -rf ./dist \
 		&& rm -rf ./src/core/trulens/data/snowflake_stage_zips \

--- a/Makefile
+++ b/Makefile
@@ -275,10 +275,6 @@ build: $(POETRY_DIRS)
 	done
 
 build-with-zip-wheels:
-	# Increase timeout for http requests to avoid issues with slow downloads
-	# See https://github.com/python-poetry/poetry/blob/master/src/poetry/utils/constants.py
-	export POETRY_REQUESTS_TIMEOUT=60
-
 	rm -rf ./dist \
 		&& rm -rf ./src/core/trulens/data/snowflake_stage_zips \
 		&& make build \

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -55,7 +55,8 @@ pipeline {
                     poetry config requests.max-retries 3
                     poetry config virtualenvs.create false
                     # NOTE: See known race condition issue: https://github.com/python-poetry/poetry/issues/8159
-                    poetry config installer.parallel false
+                    # TODO: temp re-allowing parallel installs to test if the issue is resolved
+                    # poetry config installer.parallel false
 
                     poetry run pip install pip==24.1.2
                     poetry run python --version

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         docker {
             label 'regular-memory-node-c7'
             image 'python:3.11'
-            reuseNode false
+            reuseNode true
             alwaysPull false
             args '-u root'
         }
@@ -54,12 +54,8 @@ pipeline {
 
                     poetry config requests.max-retries 3
                     poetry config virtualenvs.create false
-                    # See open race condition issue: https://github.com/python-poetry/poetry/issues/8159
+                    # NOTE: See known race condition issue: https://github.com/python-poetry/poetry/issues/8159
                     poetry config installer.parallel false
-
-                    # NOTE: temp print poetry config to confirm
-                    echo "Poetry config PREPARE:"
-                    poetry config --list
 
                     poetry run pip install pip==24.1.2
                     poetry run python --version
@@ -80,26 +76,14 @@ pipeline {
             }
         }
         stage('Test Suites') {
-            parallel {
-            // stages {
+            // NOTE: As of PR#1904, we run test suites sequentially to avoid a known race condition with Poetry installs (see issue linked above).
+            // TODO: Consider re-enabling parallelism after the issue is resolved, or if we find a better workaround (e.g. provisioning identical, fully separated containers for each stage).
+            stages {
                 stage('e2e') {
-                    agent {
-                        docker {
-                            label 'regular-memory-node-c7'
-                            image 'python:3.11'
-                            reuseNode false
-                            alwaysPull false
-                            args '-u root'
-                        }
-                    }
                     steps {
                         withVault(vault_settings) {
                             sh label: 'Run Optional "e2e" Test Suite', script: '''
                                 set -e
-
-                                # NOTE: temp print poetry config to confirm
-                                echo "Poetry config E2E:"
-                                poetry config --list
 
                                 make test-e2e-optional
                             '''
@@ -107,23 +91,10 @@ pipeline {
                     }
                 }
                 stage('notebook') {
-                    agent {
-                        docker {
-                            label 'regular-memory-node-c7'
-                            image 'python:3.11'
-                            reuseNode false
-                            alwaysPull false
-                            args '-u root'
-                        }
-                    }
                     steps {
                         withVault(vault_settings) {
-                            sh label: 'Run Optional "test" Test Suite', script: '''
+                            sh label: 'Run Optional "notebook" Test Suite', script: '''
                                 set -e
-
-                                # NOTE: temp print poetry config to confirm
-                                echo "Poetry config E2E:"
-                                poetry config --list
 
                                 make test-notebook-optional
                             '''

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -83,7 +83,7 @@ pipeline {
                     steps {
                         // NOTE:  As of PR#1904, this is a temporary workaround to ensure we are still able to run both e2e and notebook stages even if one fails (while sequential).
                         // We will revisit this once we re-enable parallelism.
-                        catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             withVault(vault_settings) {
                                 sh label: 'Run Optional "e2e" Test Suite', script: '''
                                     set -e

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         docker {
             label 'regular-memory-node-c7'
             image 'python:3.11'
-            reuseNode false
+            reuseNode true
             alwaysPull false
             args '-u root'
         }
@@ -80,18 +80,9 @@ pipeline {
             }
         }
         stage('Test Suites') {
-            parallel {
-            // stages {
+            // parallel {
+            stages {
                 stage('e2e') {
-                    agent {
-                        docker {
-                            label 'regular-memory-node-c7'
-                            image 'python:3.11'
-                            reuseNode false
-                            alwaysPull false
-                            args '-u root'
-                        }
-                    }
                     steps {
                         withVault(vault_settings) {
                             sh label: 'Run Optional "e2e" Test Suite', script: '''
@@ -107,15 +98,6 @@ pipeline {
                     }
                 }
                 stage('notebook') {
-                    agent {
-                        docker {
-                            label 'regular-memory-node-c7'
-                            image 'python:3.11'
-                            reuseNode false
-                            alwaysPull false
-                            args '-u root'
-                        }
-                    }
                     steps {
                         withVault(vault_settings) {
                             sh label: 'Run Optional "test" Test Suite', script: '''

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -56,10 +56,6 @@ pipeline {
                     poetry config virtualenvs.create false
 
                     # NOTE: temp print poetry config to confirm
-                    echo "Poetry env path:"
-                    poetry env info --path
-
-                    # NOTE: temp print poetry config to confirm
                     echo "Poetry config PREPARE:"
                     poetry config --list
 
@@ -90,11 +86,7 @@ pipeline {
                                 set -e
 
                                 # NOTE: temp print poetry config to confirm
-                                echo "Poetry env path:"
-                                poetry env info --path
-
-                                # NOTE: temp print poetry config to confirm
-                                echo "Poetry config PREPARE:"
+                                echo "Poetry config E2E:"
                                 poetry config --list
 
                                 make test-e2e-optional
@@ -109,11 +101,7 @@ pipeline {
                                 set -e
 
                                 # NOTE: temp print poetry config to confirm
-                                echo "Poetry env path:"
-                                poetry env info --path
-
-                                # NOTE: temp print poetry config to confirm
-                                echo "Poetry config PREPARE:"
+                                echo "Poetry config NOTEBOOK:"
                                 poetry config --list
 
                                 make test-notebook-optional

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -56,7 +56,8 @@ pipeline {
                     poetry env remove --all
 
                     poetry config requests.max-retries 3
-                    poetry config virtualenvs.create false
+                    poetry config virtualenvs.create true
+                    poetry config virtualenvs.in-project true
 
                     # NOTE: temp print poetry config to confirm
                     echo "Poetry config PREPARE:"

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -29,12 +29,13 @@ pipeline {
             alwaysPull false
             args '-u root'
         }
-        environment {
-            // NOTE: Increase timeout for HTTP requests to avoid issues with slow downloads
-            // See: https://github.com/python-poetry/poetry/blob/master/src/poetry/utils/constants.py
-            POETRY_REQUESTS_TIMEOUT=120
-            POETRY_REQUESTS_MAX_RETRIES=3
-        }
+    }
+
+    environment {
+        // NOTE: Increase timeout for HTTP requests to avoid issues with slow downloads
+        // See: https://github.com/python-poetry/poetry/blob/master/src/poetry/utils/constants.py
+        POETRY_REQUESTS_TIMEOUT=120
+        POETRY_REQUESTS_MAX_RETRIES=3
     }
 
     options {

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -80,38 +80,38 @@ pipeline {
             }
         }
         stage('Test Suites') {
-            parallel {
-                stage('e2e') {
-                    steps {
-                        withVault(vault_settings) {
-                            sh label: 'Run Optional "e2e" Test Suite', script: '''
-                                set -e
+            // parallel {
+            stage('e2e') {
+                steps {
+                    withVault(vault_settings) {
+                        sh label: 'Run Optional "e2e" Test Suite', script: '''
+                            set -e
 
-                                # NOTE: temp print poetry config to confirm
-                                echo "Poetry config E2E:"
-                                poetry config --list
+                            # NOTE: temp print poetry config to confirm
+                            echo "Poetry config E2E:"
+                            poetry config --list
 
-                                make test-e2e-optional
-                            '''
-                        }
-                    }
-                }
-                stage('notebook') {
-                    steps {
-                        withVault(vault_settings) {
-                            sh label: 'Run Optional "test" Test Suite', script: '''
-                                set -e
-
-                                # NOTE: temp print poetry config to confirm
-                                echo "Poetry config E2E:"
-                                poetry config --list
-
-                                make test-notebook-optional
-                            '''
-                        }
+                            make test-e2e-optional
+                        '''
                     }
                 }
             }
+            stage('notebook') {
+                steps {
+                    withVault(vault_settings) {
+                        sh label: 'Run Optional "test" Test Suite', script: '''
+                            set -e
+
+                            # NOTE: temp print poetry config to confirm
+                            echo "Poetry config E2E:"
+                            poetry config --list
+
+                            make test-notebook-optional
+                        '''
+                    }
+                }
+            }
+            // }
         }
     }
 }

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         docker {
             label 'regular-memory-node-c7'
             image 'python:3.11'
-            reuseNode true
+            reuseNode false
             alwaysPull false
             args '-u root'
         }
@@ -83,6 +83,15 @@ pipeline {
             // parallel {
             stages {
                 stage('e2e') {
+                    agent {
+                        docker {
+                            label 'regular-memory-node-c7'
+                            image 'python:3.11'
+                            reuseNode false
+                            alwaysPull false
+                            args '-u root'
+                        }
+                    }
                     steps {
                         withVault(vault_settings) {
                             sh label: 'Run Optional "e2e" Test Suite', script: '''
@@ -98,6 +107,15 @@ pipeline {
                     }
                 }
                 stage('notebook') {
+                    agent {
+                        docker {
+                            label 'regular-memory-node-c7'
+                            image 'python:3.11'
+                            reuseNode false
+                            alwaysPull false
+                            args '-u root'
+                        }
+                    }
                     steps {
                         withVault(vault_settings) {
                             sh label: 'Run Optional "test" Test Suite', script: '''

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -54,9 +54,7 @@ pipeline {
 
                     poetry config requests.max-retries 3
                     poetry config virtualenvs.create false
-                    # NOTE: See known race condition issue: https://github.com/python-poetry/poetry/issues/8159
-                    # TODO: temp re-allowing parallel installs to test if the issue is resolved
-                    # poetry config installer.parallel false
+                    # NOTE: See known race condition issue: https://github.com/python-poetry/poetry/issues/8159, potential workaround: `poetry config installer.parallel false`
 
                     poetry run pip install pip==24.1.2
                     poetry run python --version
@@ -78,11 +76,11 @@ pipeline {
         }
         stage('Test Suites') {
             // NOTE: As of PR#1904, we now run test suites sequentially to avoid a known race condition with parallel Poetry installs (see issue linked above).
-            // TODO: Consider re-enabling parallelism after the issue is resolved, or if we find a better workaround (e.g. provisioning identical, fully separated containers for each stage).
+            // TODO: Re-enable parallel CI stages with fully separated nodes (SNOW-2034894).
             stages {
                 stage('e2e') {
                     steps {
-                        // NOTE:  As of PR#1904, this is a temporary workaround to ensure we are still able to run both e2e and notebook stages even if one fails (while sequential).
+                        // NOTE: As of PR#1904, this is a temporary workaround to ensure we are still able to run both e2e and notebook stages even if one fails (while sequential).
                         // We will revisit this once we re-enable parallelism.
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             withVault(vault_settings) {

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -35,7 +35,6 @@ pipeline {
         // NOTE: Increase timeout for HTTP requests to avoid issues with slow downloads
         // See: https://github.com/python-poetry/poetry/blob/master/src/poetry/utils/constants.py
         POETRY_REQUESTS_TIMEOUT=120
-        // POETRY_REQUESTS_MAX_RETRIES=3
     }
 
     options {
@@ -53,17 +52,8 @@ pipeline {
                     ln -s /root/.local/bin/poetry /usr/local/bin/poetry
                     echo "Using $(python --version) ($(which python)) $(poetry -V)"
 
-                    # ALERT: temp disable to test overall env
-                    # NOTE: Increase timeout for HTTP requests to avoid issues with slow downloads
-                    # See: https://github.com/python-poetry/poetry/blob/master/src/poetry/utils/constants.py
-                    # export POETRY_REQUESTS_TIMEOUT=120
-                    # export POETRY_REQUESTS_MAX_RETRIES=3
-
-                    echo "env PREPARE:"
-                    printenv
-
                     poetry config requests.max-retries 3
-                    poetry config virtualenvs.create false
+                    poetry config virtualenvs.create true
 
                     # NOTE: temp print poetry config to confirm
                     echo "Poetry config PREPARE:"
@@ -95,9 +85,6 @@ pipeline {
                             sh label: 'Run Optional "e2e" Test Suite', script: '''
                                 set -e
 
-                                echo "env E2E:"
-                                printenv
-
                                 # NOTE: temp print poetry config to confirm
                                 echo "Poetry config E2E:"
                                 poetry config --list
@@ -112,9 +99,6 @@ pipeline {
                         withVault(vault_settings) {
                             sh label: 'Run Optional "test" Test Suite', script: '''
                                 set -e
-
-                                echo "env NOTEBOOK:"
-                                printenv
 
                                 # NOTE: temp print poetry config to confirm
                                 echo "Poetry config NOTEBOOK:"

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -76,17 +76,21 @@ pipeline {
             }
         }
         stage('Test Suites') {
-            // NOTE: As of PR#1904, we run test suites sequentially to avoid a known race condition with Poetry installs (see issue linked above).
+            // NOTE: As of PR#1904, we now run test suites sequentially to avoid a known race condition with parallel Poetry installs (see issue linked above).
             // TODO: Consider re-enabling parallelism after the issue is resolved, or if we find a better workaround (e.g. provisioning identical, fully separated containers for each stage).
             stages {
                 stage('e2e') {
                     steps {
-                        withVault(vault_settings) {
-                            sh label: 'Run Optional "e2e" Test Suite', script: '''
-                                set -e
+                        // NOTE:  As of PR#1904, this is a temporary workaround to ensure we are still able to run both e2e and notebook stages even if one fails (while sequential).
+                        // We will revisit this once we re-enable parallelism.
+                        catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
+                            withVault(vault_settings) {
+                                sh label: 'Run Optional "e2e" Test Suite', script: '''
+                                    set -e
 
-                                make test-e2e-optional
-                            '''
+                                    make test-e2e-optional
+                                '''
+                            }
                         }
                     }
                 }

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -54,7 +54,6 @@ pipeline {
 
                     poetry config requests.max-retries 3
                     poetry config virtualenvs.create false
-                    # NOTE: See known race condition issue: https://github.com/python-poetry/poetry/issues/8159, potential workaround: `poetry config installer.parallel false`
 
                     poetry run pip install pip==24.1.2
                     poetry run python --version
@@ -75,8 +74,9 @@ pipeline {
             }
         }
         stage('Test Suites') {
-            // NOTE: As of PR#1904, we now run test suites sequentially to avoid a known race condition with parallel Poetry installs (see issue linked above).
-            // TODO: Re-enable parallel CI stages with fully separated nodes (SNOW-2034894).
+            // NOTE: As of PR#1904, we now run test suites sequentially to avoid a known race condition with parallel CI Poetry installs (https://github.com/python-poetry/poetry/issues/8159).
+            // NOTE: Another proposed workaround is to set `poetry config installer.parallel false`, but this would (1) slow down all CI jobs and (2) does not fix the issue with parallel CI stages.
+            // TODO(SNOW-2034894): Re-enable parallel CI stages with fully separated nodes.
             stages {
                 stage('e2e') {
                     steps {

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -29,6 +29,12 @@ pipeline {
             alwaysPull false
             args '-u root'
         }
+        environment {
+            // NOTE: Increase timeout for HTTP requests to avoid issues with slow downloads
+            // See: https://github.com/python-poetry/poetry/blob/master/src/poetry/utils/constants.py
+            POETRY_REQUESTS_TIMEOUT=120
+            POETRY_REQUESTS_MAX_RETRIES=3
+        }
     }
 
     options {
@@ -46,12 +52,18 @@ pipeline {
                     ln -s /root/.local/bin/poetry /usr/local/bin/poetry
                     echo "Using $(python --version) ($(which python)) $(poetry -V)"
 
+                    # ALERT: temp disable to test overall env
                     # NOTE: Increase timeout for HTTP requests to avoid issues with slow downloads
                     # See: https://github.com/python-poetry/poetry/blob/master/src/poetry/utils/constants.py
-                    export POETRY_REQUESTS_TIMEOUT=120
-                    export POETRY_REQUESTS_MAX_RETRIES=3
+                    # export POETRY_REQUESTS_TIMEOUT=120
+                    # export POETRY_REQUESTS_MAX_RETRIES=3
 
                     poetry config virtualenvs.create false
+
+                    # NOTE: temp print poetry config to confirm
+                    echo "Poetry config PREPARE:"
+                    poetry config --list
+
                     poetry run pip install pip==24.1.2
                     poetry run python --version
                     poetry run pip --version
@@ -77,6 +89,11 @@ pipeline {
                         withVault(vault_settings) {
                             sh label: 'Run Optional "e2e" Test Suite', script: '''
                                 set -e
+
+                                # NOTE: temp print poetry config to confirm
+                                echo "Poetry config E2E:"
+                                poetry config --list
+
                                 make test-e2e-optional
                             '''
                         }
@@ -87,6 +104,11 @@ pipeline {
                         withVault(vault_settings) {
                             sh label: 'Run Optional "test" Test Suite', script: '''
                                 set -e
+
+                                # NOTE: temp print poetry config to confirm
+                                echo "Poetry config NOTEBOOK:"
+                                poetry config --list
+
                                 make test-notebook-optional
                             '''
                         }

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                     echo "Using $(python --version) ($(which python)) $(poetry -V)"
 
                     # NOTE: Increase timeout for HTTP requests to avoid issues with slow downloads
-	                # See: https://github.com/python-poetry/poetry/blob/master/src/poetry/utils/constants.py
+                    # See: https://github.com/python-poetry/poetry/blob/master/src/poetry/utils/constants.py
                     export POETRY_REQUESTS_TIMEOUT=120
 
                     poetry config virtualenvs.create false

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -81,37 +81,38 @@ pipeline {
         }
         stage('Test Suites') {
             // parallel {
-            stage('e2e') {
-                steps {
-                    withVault(vault_settings) {
-                        sh label: 'Run Optional "e2e" Test Suite', script: '''
-                            set -e
+            stages {
+                stage('e2e') {
+                    steps {
+                        withVault(vault_settings) {
+                            sh label: 'Run Optional "e2e" Test Suite', script: '''
+                                set -e
 
-                            # NOTE: temp print poetry config to confirm
-                            echo "Poetry config E2E:"
-                            poetry config --list
+                                # NOTE: temp print poetry config to confirm
+                                echo "Poetry config E2E:"
+                                poetry config --list
 
-                            make test-e2e-optional
-                        '''
+                                make test-e2e-optional
+                            '''
+                        }
+                    }
+                }
+                stage('notebook') {
+                    steps {
+                        withVault(vault_settings) {
+                            sh label: 'Run Optional "test" Test Suite', script: '''
+                                set -e
+
+                                # NOTE: temp print poetry config to confirm
+                                echo "Poetry config E2E:"
+                                poetry config --list
+
+                                make test-notebook-optional
+                            '''
+                        }
                     }
                 }
             }
-            stage('notebook') {
-                steps {
-                    withVault(vault_settings) {
-                        sh label: 'Run Optional "test" Test Suite', script: '''
-                            set -e
-
-                            # NOTE: temp print poetry config to confirm
-                            echo "Poetry config E2E:"
-                            poetry config --list
-
-                            make test-notebook-optional
-                        '''
-                    }
-                }
-            }
-            // }
         }
     }
 }

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -49,6 +49,7 @@ pipeline {
                     # NOTE: Increase timeout for HTTP requests to avoid issues with slow downloads
                     # See: https://github.com/python-poetry/poetry/blob/master/src/poetry/utils/constants.py
                     export POETRY_REQUESTS_TIMEOUT=120
+                    export POETRY_REQUESTS_MAX_RETRIES=3
 
                     poetry config virtualenvs.create false
                     poetry run pip install pip==24.1.2

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -45,6 +45,11 @@ pipeline {
                     curl -sSL https://install.python-poetry.org | python3 -
                     ln -s /root/.local/bin/poetry /usr/local/bin/poetry
                     echo "Using $(python --version) ($(which python)) $(poetry -V)"
+
+                    # NOTE: Increase timeout for HTTP requests to avoid issues with slow downloads
+	                # See: https://github.com/python-poetry/poetry/blob/master/src/poetry/utils/constants.py
+                    export POETRY_REQUESTS_TIMEOUT=120
+
                     poetry config virtualenvs.create false
                     poetry run pip install pip==24.1.2
                     poetry run python --version

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -52,6 +52,9 @@ pipeline {
                     ln -s /root/.local/bin/poetry /usr/local/bin/poetry
                     echo "Using $(python --version) ($(which python)) $(poetry -V)"
 
+                    # NOTE: temp remove venvs
+                    poetry env remove --all
+
                     poetry config requests.max-retries 3
                     poetry config virtualenvs.create false
 
@@ -85,6 +88,9 @@ pipeline {
                             sh label: 'Run Optional "e2e" Test Suite', script: '''
                                 set -e
 
+                                # NOTE: temp remove venvs
+                                poetry env remove --all
+
                                 # NOTE: temp print poetry config to confirm
                                 echo "Poetry config E2E:"
                                 poetry config --list
@@ -100,8 +106,11 @@ pipeline {
                             sh label: 'Run Optional "test" Test Suite', script: '''
                                 set -e
 
+                                # NOTE: temp remove venvs
+                                poetry env remove --all
+
                                 # NOTE: temp print poetry config to confirm
-                                echo "Poetry config NOTEBOOK:"
+                                echo "Poetry config E2E:"
                                 poetry config --list
 
                                 make test-notebook-optional

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -59,6 +59,9 @@ pipeline {
                     # export POETRY_REQUESTS_TIMEOUT=120
                     # export POETRY_REQUESTS_MAX_RETRIES=3
 
+                    echo "env PREPARE:"
+                    printenv
+
                     poetry config virtualenvs.create false
 
                     # NOTE: temp print poetry config to confirm
@@ -91,6 +94,9 @@ pipeline {
                             sh label: 'Run Optional "e2e" Test Suite', script: '''
                                 set -e
 
+                                echo "env E2E:"
+                                printenv
+
                                 # NOTE: temp print poetry config to confirm
                                 echo "Poetry config E2E:"
                                 poetry config --list
@@ -105,6 +111,9 @@ pipeline {
                         withVault(vault_settings) {
                             sh label: 'Run Optional "test" Test Suite', script: '''
                                 set -e
+
+                                echo "env NOTEBOOK:"
+                                printenv
 
                                 # NOTE: temp print poetry config to confirm
                                 echo "Poetry config NOTEBOOK:"

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         // NOTE: Increase timeout for HTTP requests to avoid issues with slow downloads
         // See: https://github.com/python-poetry/poetry/blob/master/src/poetry/utils/constants.py
         POETRY_REQUESTS_TIMEOUT=120
-        POETRY_REQUESTS_MAX_RETRIES=3
+        // POETRY_REQUESTS_MAX_RETRIES=3
     }
 
     options {
@@ -62,6 +62,7 @@ pipeline {
                     echo "env PREPARE:"
                     printenv
 
+                    poetry config requests.max-retries 3
                     poetry config virtualenvs.create false
 
                     # NOTE: temp print poetry config to confirm

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -52,12 +52,10 @@ pipeline {
                     ln -s /root/.local/bin/poetry /usr/local/bin/poetry
                     echo "Using $(python --version) ($(which python)) $(poetry -V)"
 
-                    # NOTE: temp remove venvs
-                    poetry env remove --all
-
                     poetry config requests.max-retries 3
-                    poetry config virtualenvs.create true
-                    poetry config virtualenvs.in-project true
+                    poetry config virtualenvs.create false
+                    # See open race condition issue: https://github.com/python-poetry/poetry/issues/8159
+                    poetry config installer.parallel false
 
                     # NOTE: temp print poetry config to confirm
                     echo "Poetry config PREPARE:"
@@ -89,9 +87,6 @@ pipeline {
                             sh label: 'Run Optional "e2e" Test Suite', script: '''
                                 set -e
 
-                                # NOTE: temp remove venvs
-                                poetry env remove --all
-
                                 # NOTE: temp print poetry config to confirm
                                 echo "Poetry config E2E:"
                                 poetry config --list
@@ -106,9 +101,6 @@ pipeline {
                         withVault(vault_settings) {
                             sh label: 'Run Optional "test" Test Suite', script: '''
                                 set -e
-
-                                # NOTE: temp remove venvs
-                                poetry env remove --all
 
                                 # NOTE: temp print poetry config to confirm
                                 echo "Poetry config E2E:"

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -84,7 +84,13 @@ pipeline {
             // stages {
                 stage('e2e') {
                     agent {
-                        label 'regular-memory-node-c7'
+                        docker {
+                            label 'regular-memory-node-c7'
+                            image 'python:3.11'
+                            reuseNode false
+                            alwaysPull false
+                            args '-u root'
+                        }
                     }
                     steps {
                         withVault(vault_settings) {
@@ -102,7 +108,13 @@ pipeline {
                 }
                 stage('notebook') {
                     agent {
-                        label 'regular-memory-node-c7'
+                        docker {
+                            label 'regular-memory-node-c7'
+                            image 'python:3.11'
+                            reuseNode false
+                            alwaysPull false
+                            args '-u root'
+                        }
                     }
                     steps {
                         withVault(vault_settings) {

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -53,7 +53,11 @@ pipeline {
                     echo "Using $(python --version) ($(which python)) $(poetry -V)"
 
                     poetry config requests.max-retries 3
-                    poetry config virtualenvs.create true
+                    poetry config virtualenvs.create false
+
+                    # NOTE: temp print poetry config to confirm
+                    echo "Poetry env path:"
+                    poetry env info --path
 
                     # NOTE: temp print poetry config to confirm
                     echo "Poetry config PREPARE:"
@@ -86,7 +90,11 @@ pipeline {
                                 set -e
 
                                 # NOTE: temp print poetry config to confirm
-                                echo "Poetry config E2E:"
+                                echo "Poetry env path:"
+                                poetry env info --path
+
+                                # NOTE: temp print poetry config to confirm
+                                echo "Poetry config PREPARE:"
                                 poetry config --list
 
                                 make test-e2e-optional
@@ -101,7 +109,11 @@ pipeline {
                                 set -e
 
                                 # NOTE: temp print poetry config to confirm
-                                echo "Poetry config NOTEBOOK:"
+                                echo "Poetry env path:"
+                                poetry env info --path
+
+                                # NOTE: temp print poetry config to confirm
+                                echo "Poetry config PREPARE:"
                                 poetry config --list
 
                                 make test-notebook-optional

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -80,8 +80,8 @@ pipeline {
             }
         }
         stage('Test Suites') {
-            // parallel {
-            stages {
+            parallel {
+            // stages {
                 stage('e2e') {
                     agent {
                         docker {

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -80,9 +80,12 @@ pipeline {
             }
         }
         stage('Test Suites') {
-            // parallel {
-            stages {
+            parallel {
+            // stages {
                 stage('e2e') {
+                    agent {
+                        label "e2e"
+                    }
                     steps {
                         withVault(vault_settings) {
                             sh label: 'Run Optional "e2e" Test Suite', script: '''
@@ -98,6 +101,9 @@ pipeline {
                     }
                 }
                 stage('notebook') {
+                    agent {
+                        label "notebook"
+                    }
                     steps {
                         withVault(vault_settings) {
                             sh label: 'Run Optional "test" Test Suite', script: '''

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         docker {
             label 'regular-memory-node-c7'
             image 'python:3.11'
-            reuseNode true
+            reuseNode false
             alwaysPull false
             args '-u root'
         }

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -84,7 +84,7 @@ pipeline {
             // stages {
                 stage('e2e') {
                     agent {
-                        label "e2e"
+                        label 'regular-memory-node-c7'
                     }
                     steps {
                         withVault(vault_settings) {
@@ -102,7 +102,7 @@ pipeline {
                 }
                 stage('notebook') {
                     agent {
-                        label "notebook"
+                        label 'regular-memory-node-c7'
                     }
                     steps {
                         withVault(vault_settings) {


### PR DESCRIPTION
# Description

See [SNOW-2005231](https://snowflakecomputing.atlassian.net/browse/SNOW-2005231), [SNOW-2033054](https://snowflakecomputing.atlassian.net/browse/SNOW-2033054) and [SNOW-2033730](https://snowflakecomputing.atlassian.net/browse/SNOW-2033730).

- Increase Poetry HTTP request timeout from 15s (default) to 120s to help reduce flakiness for larger library/package downloads. This typically causes issues with larger packages, notably `numpy`, `xgboost`, `nvidia-nccl-cu12`, etc.
- Increase Poetry max retries from 0 (default) to 3 to help reduce flakiness during unstable connections.
- Work around a known race condition issue: https://github.com/python-poetry/poetry/issues/8159
  - Make Jenkinsfile test suite stages (`e2e` and `notebook`) sequential due to resource contention from parallel installs

## Other details good to know for developers

Tested via iterative pipeline runs, confirmed reduction in pipeline flakiness failures during `prepare` , `e2e` and `notebook` stages. 

See: [Build #32](https://snow-ml-001.jenkinsdev1.us-west-2.aws-dev.app.snowflake.com/job/TruLens%20E2E%20Tests/view/change-requests/job/PR-1904/32/). NOTE: Remaining failures are due to either missing credentials or LLM response randomness (to be addressed in [SNOW-2005227](https://snowflakecomputing.atlassian.net/browse/SNOW-2005227)).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Increase Poetry timeout and retries, and run test stages sequentially in `Jenkinsfile` to deflake E2E pipeline.
> 
>   - **Behavior**:
>     - Increase `POETRY_REQUESTS_TIMEOUT` to 120s in `Jenkinsfile` to reduce download flakiness.
>     - Set `poetry config requests.max-retries` to 3 to handle unstable connections.
>     - Run `e2e` and `notebook` test stages sequentially in `Jenkinsfile` to avoid race conditions.
>   - **Misc**:
>     - Add comments in `Jenkinsfile` explaining changes and workarounds for known issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 16d98ea9612794b7bc4dbe52a9acb90856a8cbbe. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->