### PR TITLE
[E2E] Revert temporary change for e2e testing

### DIFF
--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -92,10 +92,10 @@ pipeline {
                         // We will revisit this once we re-enable parallelism.
                         catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                             withVault(vault_settings) {
-                                sh label: 'Run "e2e" Test Suite', script: '''
+                                sh label: 'Run optional "e2e" Test Suite', script: '''
                                     set -e
 
-                                    make test-e2e-all
+                                    make test-e2e-optional
                                 '''
                             }
                         }
@@ -118,10 +118,10 @@ pipeline {
                 stage('notebook') {
                     steps {
                         withVault(vault_settings) {
-                            sh label: 'Run pipeline "notebook" Test Suite', script: '''
+                            sh label: 'Run optional "notebook" Test Suite', script: '''
                                 set -e
 
-                                make test-notebook-all
+                                make test-notebook-optional
                             '''
                         }
                     }


### PR DESCRIPTION
# Description

Revert temporary change from `make test-e2e-all` to `make test-e2e-optional` and `make test-notebook-all` to `make test-notebook-optional` from #1910.

## Other details good to know for developers

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts Jenkins pipeline to run optional e2e and notebook test suites instead of full test suites in `tests/Jenkinsfile`.
> 
>   - **Jenkins Pipeline (`tests/Jenkinsfile`)**:
>     - Reverts test suite commands in 'e2e' and 'notebook' stages to use `make test-e2e-optional` and `make test-notebook-optional` instead of `make test-e2e-all` and `make test-notebook-all`.
>     - Updates shell script labels to reflect running optional test suites.
>     - No changes to test logic or other pipeline stages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 3c7136fe1650eb455669149ff5f3d0d4119d5e4b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->