### PR TITLE
Fix `test_deprecation.py`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ env-tests-optional: env env-tests
 		chromadb \
 	 	faiss-cpu \
 		langchain-openai \
+		'langchain-core<0.3.52' \
 		llama-index-embeddings-huggingface \
 		llama-index-embeddings-openai \
 		unstructured


### PR DESCRIPTION
# Description
The `Makefile`'s `test-env-optional` overrides the `poetry.lock` file's `langchain-core` version and the `langchain-core` package was recently updated where `__getattr__` is overwritten incorrectly causing some failures during a test.

Until they fix this, I've pinned the `langchain-core` version to a lower one.

## Other details good to know for developers

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
