### PR TITLE
Allow feedback `Selector` for OTEL selectors to have more options.

### DIFF
--- a/src/feedback/trulens/feedback/computer.py
+++ b/src/feedback/trulens/feedback/computer.py
@@ -113,8 +113,8 @@ class Selector:
         function_attribute: Optional[str] = None,
     ):
         if function_name is None and span_name is None and span_type is None:
-            _logger.warning(
-                "All of `function_name`, `span_name`, and `span_type` are None, this `Selector` will apply to apply to all spans."
+            raise ValueError(
+                "Must specify at least one of `function_name`, `span_name`, or `span_type`!"
             )
         if (
             sum([

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -4,7 +4,7 @@ trulens:
   lows: {}
 trulens.benchmark:
   __class__: builtins.module
-  __version__: 1.4.8
+  __version__: 1.4.9
   highs: {}
   lows:
     __version__: builtins.str
@@ -60,7 +60,7 @@ trulens.benchmark.test_cases:
     generate_summeval_groundedness_golden_set: builtins.function
 trulens.core:
   __class__: builtins.module
-  __version__: 1.4.8
+  __version__: 1.4.9
   highs:
     Feedback: pydantic._internal._model_construction.ModelMetaclass
     FeedbackMode: enum.EnumType
@@ -1832,7 +1832,7 @@ trulens.core.utils.trulens.Other:
   attributes: {}
 trulens.dashboard:
   __class__: builtins.module
-  __version__: 1.4.8
+  __version__: 1.4.9
   highs:
     run_dashboard: builtins.function
     run_dashboard_sis: builtins.function
@@ -2120,7 +2120,7 @@ trulens.dashboard.ux.styles.ResultCategoryType:
     value: enum.property
 trulens.feedback:
   __class__: builtins.module
-  __version__: 1.4.8
+  __version__: 1.4.9
   highs:
     Embeddings: pydantic._internal._model_construction.ModelMetaclass
     GroundTruthAggregator: pydantic._internal._model_construction.ModelMetaclass
@@ -2159,6 +2159,12 @@ trulens.feedback.computer.Selector:
   __class__: builtins.type
   attributes:
     describes_same_spans: builtins.function
+    function_attribute: builtins.NoneType
+    function_name: builtins.NoneType
+    matches_span: builtins.function
+    process_span: builtins.function
+    span_attribute: builtins.NoneType
+    span_attributes_processor: builtins.NoneType
     span_name: builtins.NoneType
     span_type: builtins.NoneType
 trulens.feedback.dummy:
@@ -3034,7 +3040,7 @@ trulens.feedback.v2.provider.base.Provider:
     tru_class_info: trulens.core.utils.pyschema.Class
 trulens.hotspots:
   __class__: builtins.module
-  __version__: 1.4.8
+  __version__: 1.4.9
   highs:
     HotspotsConfig: builtins.type
     get_skipped_columns: builtins.function

--- a/tests/unit/test_otel_feedback_computation.py
+++ b/tests/unit/test_otel_feedback_computation.py
@@ -2,7 +2,7 @@
 Tests for OTEL Feedback Computation.
 """
 
-from typing import List
+from typing import List, Optional
 
 import pandas as pd
 import pytest
@@ -15,7 +15,6 @@ from trulens.feedback.computer import Selector
 from trulens.feedback.computer import _compute_feedback
 from trulens.feedback.computer import _flatten_inputs
 from trulens.feedback.computer import _group_kwargs_by_selectors
-from trulens.feedback.computer import _row_matches_selector
 from trulens.feedback.computer import _validate_unflattened_inputs
 from trulens.feedback.computer import compute_feedback_by_span_group
 from trulens.otel.semconv.trace import SpanAttributes
@@ -217,6 +216,110 @@ class TestOtelFeedbackComputation(OtelTestCase):
                 f"blah{expected_case_number[i]}",
             )
 
+    def test_Selector__matches_function_name(self) -> None:
+        def _test_matches_function_name(
+            selector_function_name: Optional[str],
+            actual_function_name: Optional[str],
+            match_expected: bool,
+        ):
+            selector = Selector(
+                function_name=selector_function_name, span_attribute="Z"
+            )
+            if match_expected:
+                self.assertTrue(
+                    selector._matches_function_name(actual_function_name)
+                )
+            else:
+                self.assertFalse(
+                    selector._matches_function_name(actual_function_name)
+                )
+
+        _test_matches_function_name("AA.BB.CC", "AA.BB.CC", True)
+        _test_matches_function_name("BB.CC", "AA.BB.CC", True)
+        _test_matches_function_name("CC", "AA.BB.CC", True)
+        _test_matches_function_name(None, "AA.BB.CC", True)
+        _test_matches_function_name("AAA.BB.CC", "AA.BB.CC", False)
+        _test_matches_function_name("AA.BB.CCC", "AA.BB.CC", False)
+        _test_matches_function_name("A.BB.CC", "AA.BB.CC", False)
+        _test_matches_function_name("B.CC", "AA.BB.CC", False)
+        _test_matches_function_name("C", "AA.BB.CC", False)
+        _test_matches_function_name("AA.BB.CC", None, False)
+        selector = Selector(span_name="AA.BB.CC", span_attribute="Z")
+        self.assertTrue(selector._matches_function_name("AA.BB.CC"))
+        self.assertTrue(selector._matches_function_name("X"))
+        self.assertTrue(selector._matches_function_name(None))
+
+    def test_Selector_matches_spans(self) -> None:
+        selector = Selector(
+            function_name="AA.BB.CC",
+            span_name="XX.YY.ZZ",
+            span_type="span_type",
+            span_attribute="Z",
+        )
+        self.assertTrue(
+            selector.matches_span({
+                SpanAttributes.CALL.FUNCTION: "AA.BB.CC",
+                SpanAttributes.SPAN_TYPE: "span_type",
+                "name": "XX.YY.ZZ",
+            })
+        )
+        self.assertFalse(
+            selector.matches_span({
+                SpanAttributes.SPAN_TYPE: "span_type",
+                "name": "XX.YY.ZZ",
+            })
+        )
+        self.assertFalse(
+            selector.matches_span({
+                SpanAttributes.CALL.FUNCTION: "AA.BB.CC",
+                "name": "XX.YY.ZZ",
+            })
+        )
+        self.assertFalse(
+            selector.matches_span({
+                SpanAttributes.CALL.FUNCTION: "AA.BB.CC",
+                SpanAttributes.SPAN_TYPE: "span_type",
+            })
+        )
+        self.assertTrue(
+            Selector(span_attribute="Z").matches_span({
+                SpanAttributes.CALL.FUNCTION: "AA.BB.CC",
+                SpanAttributes.SPAN_TYPE: "span_type",
+                "name": "XX.YY.ZZ",
+            })
+        )
+        self.assertTrue(Selector(span_attribute="Z").matches_span({}))
+
+    def test_Selector_process_span(self) -> None:
+        self.assertEqual(
+            Selector(
+                span_attributes_processor=lambda attributes: "z"
+            ).process_span({}),
+            "z",
+        )
+        self.assertEqual(Selector(span_attribute="Z").process_span({}), None)
+        self.assertEqual(
+            Selector(span_attribute="Z").process_span({"Z": "z"}), "z"
+        )
+        self.assertEqual(
+            Selector(function_attribute="return").process_span({}), None
+        )
+        self.assertEqual(
+            Selector(function_attribute="return").process_span({
+                SpanAttributes.CALL.RETURN: "z"
+            }),
+            "z",
+        )
+        self.assertEqual(
+            Selector(function_attribute="arg1").process_span({}), None
+        )
+        self.assertEqual(
+            Selector(function_attribute="arg1").process_span({
+                f"{SpanAttributes.CALL.KWARGS}.arg1": "z"
+            }),
+            "z",
+        )
+
     def test__group_kwargs_by_selectors(self) -> None:
         # Test empty case.
         self.assertEqual([], _group_kwargs_by_selectors({}))
@@ -253,46 +356,6 @@ class TestOtelFeedbackComputation(OtelTestCase):
                 ("input5",),
             ],
             sorted(_group_kwargs_by_selectors(kwarg_to_selector)),
-        )
-
-    def test__row_matches_selector(self) -> None:
-        self.assertTrue(
-            _row_matches_selector({}, Selector(span_attribute="span_attribute"))
-        )
-        self.assertTrue(
-            _row_matches_selector(
-                {
-                    "name": "span_name",
-                    SpanAttributes.SPAN_TYPE: "span_type",
-                },
-                Selector(
-                    span_name="span_name",
-                    span_type="span_type",
-                    span_attribute="span_attribute",
-                ),
-            )
-        )
-        self.assertFalse(
-            _row_matches_selector(
-                {
-                    "name": "span_name",
-                    SpanAttributes.SPAN_TYPE: "span_type",
-                },
-                Selector(
-                    span_name="span_name2",
-                    span_type="span_type",
-                    span_attribute="span_attribute",
-                ),
-            )
-        )
-        self.assertTrue(
-            _row_matches_selector(
-                {
-                    "name": "span_name",
-                    SpanAttributes.SPAN_TYPE: "span_type",
-                },
-                Selector(span_attribute="span_attribute"),
-            )
         )
 
     def test__validate_unflattened_inputs(self) -> None:

--- a/tests/unit/test_otel_feedback_computation.py
+++ b/tests/unit/test_otel_feedback_computation.py
@@ -216,6 +216,14 @@ class TestOtelFeedbackComputation(OtelTestCase):
                 f"blah{expected_case_number[i]}",
             )
 
+    def test_Selector__split_function_name(self) -> None:
+        self.assertEqual(
+            Selector._split_function_name("a.B.c"), ["a", "B", "c"]
+        )
+        self.assertEqual(
+            Selector._split_function_name("a.py::B::c"), ["a.py", "B", "c"]
+        )
+
     def test_Selector__matches_function_name(self) -> None:
         def _test_matches_function_name(
             selector_function_name: Optional[str],


### PR DESCRIPTION
# Description
Allow feedback `Selector` to have more options. Namely, to determine relevant spans it can use any of:
1. span_name
2. span_type
3. function_name

And to map a span to the feedback function input it uses exactly one of:
1. span_attribute
2. function_attribute (i.e. one of the kwargs or "return")
3. function that takes in span attribute dictionary and returns the value.

## Other details good to know for developers
This follows the agreement between @sfc-gh-dkurokawa , @sfc-gh-jreini , and Anubhav.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances `Selector` in `computer.py` to support more span selection and processing options, with updated tests and version bump to 1.4.9.
> 
>   - **Behavior**:
>     - `Selector` class in `computer.py` now supports `function_name`, `span_name`, and `span_type` for span selection.
>     - Introduces `span_attributes_processor`, `span_attribute`, and `function_attribute` for processing span attributes.
>     - Adds validation in `Selector.__init__` to ensure correct field usage.
>   - **Functions**:
>     - Adds `matches_span` and `process_span` methods to `Selector` for span matching and processing.
>     - Removes `_row_matches_selector` function from `computer.py`.
>   - **Tests**:
>     - Adds tests for `Selector` methods in `test_otel_feedback_computation.py`.
>     - Updates `test_compute_feedback_by_span_group` to use new `Selector` functionality.
>   - **Misc**:
>     - Updates version to 1.4.9 in `api.trulens.3.11.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for b2e89a6e13f0f6a1d260be512dfeb46008280ded. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->