### PR TITLE
Increase Cortex complete timeout to 60s for tests.

### DIFF
--- a/src/providers/cortex/trulens/providers/cortex/provider.py
+++ b/src/providers/cortex/trulens/providers/cortex/provider.py
@@ -93,6 +93,7 @@ class Cortex(
         self,
         snowpark_session: Optional[Session] = None,
         model_engine: Optional[str] = None,
+        retry_timeout: Optional[float] = None,
         *args,
         **kwargs: Dict,
     ):
@@ -105,6 +106,8 @@ class Cortex(
         self_kwargs["endpoint"] = cortex_endpoint.CortexEndpoint(
             *args, **kwargs
         )
+
+        self_kwargs["retry_timeout"] = retry_timeout
 
         if snowpark_session is None or pyschema_utils.is_noserio(
             snowpark_session
@@ -151,6 +154,7 @@ class Cortex(
             options=options,
             session=self.snowpark_session,
             stream=False,
+            timeout=self.retry_timeout,
         )
         if Version(snowflake.ml.version.VERSION) >= Version("1.7.1"):
             return completion_res

--- a/src/providers/cortex/trulens/providers/cortex/provider.py
+++ b/src/providers/cortex/trulens/providers/cortex/provider.py
@@ -29,6 +29,7 @@ class Cortex(
     model_engine: str
     endpoint: cortex_endpoint.CortexEndpoint
     snowpark_session: Session
+    retry_timeout: Optional[float]
 
     """Snowflake's Cortex COMPLETE endpoint. Defaults to `llama3.1-8b`.
 

--- a/tests/e2e/data/staged_packages.ipynb
+++ b/tests/e2e/data/staged_packages.ipynb
@@ -176,7 +176,7 @@
     "tru_session = TruSession(connector=connector)\n",
     "\n",
     "# Set up feedback functions.\n",
-    "relevance = Cortex(snowpark_session).relevance\n",
+    "relevance = Cortex(snowpark_session, retry_timeout=60).relevance\n",
     "f_regular = Feedback(relevance).on_input_output()\n",
     "f_snowflake = SnowflakeFeedback(relevance).on_input_output()\n",
     "feedbacks = [\n",

--- a/tests/e2e/test_otel_costs.py
+++ b/tests/e2e/test_otel_costs.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, List
+from typing import Any
 import unittest
 
 from langchain_community.chat_models import ChatSnowflakeCortex
@@ -34,6 +34,7 @@ class _TestCortexApp:
             model="mistral-large2",
             prompt=query,
             session=self._snowpark_session,
+            timeout=60,
         )
 
 
@@ -84,7 +85,6 @@ class TestOtelCosts(OtelTestCase):
     def _test_tru_custom_app(
         self,
         app: Any,
-        cost_functions: List[str],
         model: str,
         currency: str,
         num_expected_spans: int = 1,
@@ -141,7 +141,6 @@ class TestOtelCosts(OtelTestCase):
     def test_tru_custom_app_cortex(self):
         self._test_tru_custom_app(
             _TestCortexApp(),
-            ["snowflake.cortex._sse_client.SSEClient.events"],
             "mistral-large2",
             "Snowflake credits",
         )
@@ -149,9 +148,6 @@ class TestOtelCosts(OtelTestCase):
     def test_tru_custom_app_openai(self):
         self._test_tru_custom_app(
             _TestOpenAIApp(),
-            [
-                "openai.resources.chat.completions.completions.Completions.create"
-            ],
             "gpt-3.5-turbo-0125",
             "USD",
         )
@@ -160,10 +156,6 @@ class TestOtelCosts(OtelTestCase):
         model = "gpt-3.5-turbo-0125"
         self._test_tru_custom_app(
             _TestLiteLLMApp(model),
-            [
-                "openai.resources.chat.completions.completions.Completions.create",
-                "litellm.main.completion",
-            ],
             model,
             "USD",
             num_expected_spans=2,
@@ -175,7 +167,6 @@ class TestOtelCosts(OtelTestCase):
         model = "gemini/gemini-2.0-flash-exp"
         self._test_tru_custom_app(
             _TestLiteLLMApp(model),
-            ["litellm.main.completion"],
             model,
             "USD",
             num_expected_spans=2,
@@ -188,7 +179,6 @@ class TestOtelCosts(OtelTestCase):
         model = "huggingface/meta-llama/Meta-Llama-3.1-8B-Instruct"
         self._test_tru_custom_app(
             _TestLiteLLMApp(model),
-            ["litellm.main.completion"],
             model,
             "USD",
             num_expected_spans=2,

--- a/tests/e2e/test_snowflake_feedback_evaluation.py
+++ b/tests/e2e/test_snowflake_feedback_evaluation.py
@@ -51,7 +51,9 @@ class TestSnowflakeFeedbackEvaluation(SnowflakeTestCase):
         self,
     ) -> core_feedback.SnowflakeFeedback:
         return core_feedback.SnowflakeFeedback(
-            cortex_provider.Cortex(self._snowpark_session).relevance
+            cortex_provider.Cortex(
+                self._snowpark_session, retry_timeout=60
+            ).relevance
         ).on_input_output()
 
     def _start_evaluator_as_snowflake(self, session: core_session.TruSession):


### PR DESCRIPTION
# Description
Increase Cortex complete timeout to 60s for tests.

It's unclear what the default is as the documentation is kinda lacking but I'm imagining it doesn't retry. I've made it 60s as of the last four failed e2e test runs on main, three of them were caused due to Cortex complete not working for w/e reason.

## Other details good to know for developers


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase Cortex completion timeout to 60 seconds in tests and remove unused imports and parameters.
> 
>   - **Behavior**:
>     - Increase `retry_timeout` to 60s in `Cortex` class in `provider.py`.
>     - Set `timeout=60` in `respond_to_query` in `test_otel_costs.py`.
>     - Pass `retry_timeout=60` to `Cortex` in `test_snowflake_feedback_evaluation.py`.
>   - **Tests**:
>     - Remove unused `List` import and `cost_functions` parameter in `test_otel_costs.py`.
>     - Remove unused imports in `test_otel_costs.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 1b01a421ab41d84c86613bd3095b48825c8065f2. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->