### PR TITLE
 Update OTEL semantic convention in `EVAL_ROOT` to hold more info about feedback function metadata.

### DIFF
--- a/src/otel/semconv/trulens/otel/semconv/trace.py
+++ b/src/otel/semconv/trulens/otel/semconv/trace.py
@@ -158,7 +158,8 @@ class SpanAttributes:
         Metadata of arguments of the feedback function. This is a scope, and
         not an attribute by itself. E.g. If the function has an argument `x`
         that came from the span attribute "xyz" directly, then we would have
-        `ARGS_SPAN_ATTRIBUTE + ".x"` with value "xyz".
+        `ARGS_SPAN_ATTRIBUTE + ".x"` with value "xyz". If a span attribute was
+        not used directly, then this is not set.
         """
 
         ERROR = base + ".error"

--- a/src/otel/semconv/trulens/otel/semconv/trace.py
+++ b/src/otel/semconv/trulens/otel/semconv/trace.py
@@ -153,8 +153,9 @@ class SpanAttributes:
 
         ARGS_SPAN_ATTRIBUTE = base + ".args_metadata.span_attribute"
         """
-        Mapping of argument name to the attribute of the span that provided it.
-        Note that this is a scope, and not an attribute by itself.
+        Mapping of argument name to the full span attribute name of the span
+        that provided it. Note that this is a scope, and not an attribute by
+        itself.
 
         E.g. If the function has an argument `x` that came directly from the
         span attribute "xyz", then we would have `ARGS_SPAN_ATTRIBUTE + ".x"`

--- a/src/otel/semconv/trulens/otel/semconv/trace.py
+++ b/src/otel/semconv/trulens/otel/semconv/trace.py
@@ -139,6 +139,28 @@ class SpanAttributes:
 
         base = BASE_SCOPE + ".eval_root"
 
+        METRIC_NAME = base + ".metric_name"
+        """Name of the feedback definition being evaluated."""
+
+        SPAN_GROUP = base + ".span_group"
+        """The span group of the inputs to this metric."""
+
+        ARGS_SPAN_ID = base + ".args_metadata.span_id"
+        """
+        Metadata of arguments of the feedback function. This is a scope, and
+        not an attribute by itself. E.g. If the function has an argument `x`
+        that came from a span with span_id "abc", then we would have
+        `ARGS_SPAN_ID + ".x"` with value "abc".
+        """
+
+        ARGS_SPAN_ATTRIBUTE = base + ".args_metadata.span_attribute"
+        """
+        Metadata of arguments of the feedback function. This is a scope, and
+        not an attribute by itself. E.g. If the function has an argument `x`
+        that came from the span attribute "xyz" directly, then we would have
+        `ARGS_SPAN_ATTRIBUTE + ".x"` with value "xyz".
+        """
+
         ERROR = base + ".error"
         """Error raised during evaluation."""
 

--- a/src/otel/semconv/trulens/otel/semconv/trace.py
+++ b/src/otel/semconv/trulens/otel/semconv/trace.py
@@ -139,27 +139,27 @@ class SpanAttributes:
 
         base = BASE_SCOPE + ".eval_root"
 
-        METRIC_NAME = base + ".metric_name"
-        """Name of the feedback definition being evaluated."""
-
         SPAN_GROUP = base + ".span_group"
         """The span group of the inputs to this metric."""
 
         ARGS_SPAN_ID = base + ".args_metadata.span_id"
         """
-        Metadata of arguments of the feedback function. This is a scope, and
-        not an attribute by itself. E.g. If the function has an argument `x`
-        that came from a span with span_id "abc", then we would have
-        `ARGS_SPAN_ID + ".x"` with value "abc".
+        Mapping of argument name to the ID of the span that provided it. Note
+        that this is a scope, and not an attribute by itself.
+
+        E.g. If the function has an argument `x` that came from a span with ID
+        "abc", then we would have `ARGS_SPAN_ID + ".x"` with value "abc".
         """
 
         ARGS_SPAN_ATTRIBUTE = base + ".args_metadata.span_attribute"
         """
-        Metadata of arguments of the feedback function. This is a scope, and
-        not an attribute by itself. E.g. If the function has an argument `x`
-        that came from the span attribute "xyz" directly, then we would have
-        `ARGS_SPAN_ATTRIBUTE + ".x"` with value "xyz". If a span attribute was
-        not used directly, then this is not set.
+        Mapping of argument name to the attribute of the span that provided it.
+        Note that this is a scope, and not an attribute by itself.
+
+        E.g. If the function has an argument `x` that came directly from the
+        span attribute "xyz", then we would have `ARGS_SPAN_ATTRIBUTE + ".x"`
+        with value "xyz". If a span attribute was not used directly, then this
+        is not set.
         """
 
         ERROR = base + ".error"


### PR DESCRIPTION
# Description
 Update OTEL semantic convention in `EVAL_ROOT` to hold more info about feedback function metadata.

This is what we talked about in https://docs.google.com/document/d/1xZUigVVaY1b8LuHsFJJD7Pyl1iaXId__UOB-QMLRXuI/edit?tab=t.s0bansuhal2g#heading=h.r6raqrechyq0

## Other details good to know for developers

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `EVAL_ROOT` in `trace.py` to include additional attributes for feedback function metadata in OpenTelemetry spans.
> 
>   - **Behavior**:
>     - Update `EVAL_ROOT` in `trace.py` to include `SPAN_GROUP`, `ARGS_SPAN_ID`, and `ARGS_SPAN_ATTRIBUTE` for feedback function metadata.
>     - `SPAN_GROUP` indicates the span group of inputs to the metric.
>     - `ARGS_SPAN_ID` maps argument names to span IDs.
>     - `ARGS_SPAN_ATTRIBUTE` maps argument names to full span attribute names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 35a18112a7f8910eeb9bae93a03ba8bf8da1f51b. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->