### PR TITLE
Write app to App defn table in OTEL again.

### DIFF
--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -774,11 +774,14 @@ class App(
                     "No feedback evaluation and logging will occur."
                 )
 
-        otel_tracing_enabled = os.getenv(
+        if len(self.feedbacks) > 0 and os.getenv(
             "TRULENS_OTEL_TRACING", ""
-        ).lower() in ["1", "true"]
+        ).lower() in ["1", "true"]:
+            raise ValueError(
+                "Feedback logging is not supported with OpenTelemetry tracing enabled yet!"
+            )
 
-        if self.connector is not None and not otel_tracing_enabled:
+        if self.connector is not None:
             self.connector.add_app(app=self)
 
             if self.feedback_mode != feedback_schema.FeedbackMode.NONE:

--- a/tests/test.py
+++ b/tests/test.py
@@ -398,6 +398,9 @@ class WithJSONTestCase(TestCase):
 
         ps = str(path)
 
+        if ps in skips:
+            return
+
         self.assertIsInstance(j1, type(j2), ps)
 
         if isinstance(j1, serial_utils.JSON_BASES):

--- a/tests/unit/data/test_otel_apps_table/test_smoke.json
+++ b/tests/unit/data/test_otel_apps_table/test_smoke.json
@@ -1,0 +1,129 @@
+{
+    "tru_class_info": {
+        "name": "TruApp",
+        "module": {
+            "package_name": "trulens.apps",
+            "module_name": "trulens.apps.app"
+        },
+        "bases": [
+            {
+                "name": "TruApp",
+                "module": {
+                    "package_name": "trulens.apps",
+                    "module_name": "trulens.apps.app"
+                },
+                "bases": null
+            },
+            {
+                "name": "App",
+                "module": {
+                    "package_name": "trulens.core",
+                    "module_name": "trulens.core.app"
+                },
+                "bases": null
+            },
+            {
+                "name": "AppDefinition",
+                "module": {
+                    "package_name": "trulens.core.schema",
+                    "module_name": "trulens.core.schema.app"
+                },
+                "bases": null
+            },
+            {
+                "name": "WithClassInfo",
+                "module": {
+                    "package_name": "trulens.core.utils",
+                    "module_name": "trulens.core.utils.pyschema"
+                },
+                "bases": null
+            },
+            {
+                "name": "SerialModel",
+                "module": {
+                    "package_name": "trulens.core.utils",
+                    "module_name": "trulens.core.utils.serial"
+                },
+                "bases": null
+            },
+            {
+                "name": "BaseModel",
+                "module": {
+                    "package_name": "pydantic",
+                    "module_name": "pydantic.main"
+                },
+                "bases": null
+            },
+            {
+                "name": "WithInstrumentCallbacks",
+                "module": {
+                    "package_name": "trulens.core",
+                    "module_name": "trulens.core.instruments"
+                },
+                "bases": null
+            },
+            {
+                "name": "Hashable",
+                "module": {
+                    "package_name": "collections",
+                    "module_name": "collections.abc"
+                },
+                "bases": null
+            },
+            {
+                "name": "Generic",
+                "module": {
+                    "package_name": "",
+                    "module_name": "typing"
+                },
+                "bases": null
+            },
+            {
+                "name": "object",
+                "module": {
+                    "package_name": "",
+                    "module_name": "builtins"
+                },
+                "bases": null
+            }
+        ]
+    },
+    "app_id": "app_hash_aa05d4140efd2fd717a2961c517a769a",
+    "app_name": "MyCustomApp",
+    "app_version": "v1",
+    "tags": "-",
+    "metadata": {},
+    "feedback_definitions": [],
+    "feedback_mode": "with_app_thread",
+    "record_ingest_mode": "immediate",
+    "root_class": {
+        "name": "TestApp",
+        "module": {
+            "package_name": "tests.unit",
+            "module_name": "tests.unit.test_otel_tru_custom"
+        },
+        "bases": null
+    },
+    "app": {
+        "__tru_non_serialized_object": {
+            "cls": {
+                "name": "TestApp",
+                "module": {
+                    "package_name": "tests.unit",
+                    "module_name": "tests.unit.test_otel_tru_custom"
+                },
+                "bases": null
+            },
+            "id": 13277293264,
+            "init_bindings": null
+        }
+    },
+    "initial_app_loader_dump": null,
+    "app_extra_json": {},
+    "main_method_name": "respond_to_query",
+    "selector_check_warning": false,
+    "selector_nocheck": false,
+    "snowflake_object_type": null,
+    "snowflake_object_name": null,
+    "snowflake_object_version": null
+}

--- a/tests/unit/test_otel_apps_table.py
+++ b/tests/unit/test_otel_apps_table.py
@@ -1,0 +1,36 @@
+import json
+
+import pandas as pd
+import sqlalchemy as sa
+from trulens.apps.app import TruApp
+from trulens.core.session import TruSession
+
+import tests.unit.test_otel_tru_custom
+from tests.util.otel_test_case import OtelTestCase
+
+
+class TestOtelAppsTable(OtelTestCase):
+    @staticmethod
+    def _get_apps() -> pd.DataFrame:
+        db = TruSession().connector.db
+        with db.session.begin() as db_session:
+            q = sa.select(db.orm.AppDefinition)
+            return pd.read_sql(q, db_session.bind)
+
+    def test_smoke(self):
+        app = tests.unit.test_otel_tru_custom.TestApp()
+        TruApp(
+            app,
+            main_method=app.respond_to_query,
+            app_name="MyCustomApp",
+            app_version="v1",
+        )
+        rows = self._get_apps()
+        self.assertEqual(1, len(rows))
+        self.assertEqual("MyCustomApp", rows["app_name"].iloc[0])
+        self.assertEqual("v1", rows["app_version"].iloc[0])
+        self.assertGoldenJSONEqual(
+            json.loads(rows["app_json"].iloc[0]),
+            "tests/unit/data/test_otel_apps_table/test_smoke.json",
+            skips=["app_id", "app.__tru_non_serialized_object.id"],
+        )


### PR DESCRIPTION
# Description
Write app to App defn table in OTEL again.

There's no reason not to (I think?). As long as the tests pass it's probably fine to write it back again. This way the UI can use it as well.

## Other details good to know for developers

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reintroduce writing app data to App definition table in OTEL with conditions for Snowflake connectors and add tests for verification.
> 
>   - **Behavior**:
>     - Reintroduce writing app data to App definition table in OTEL in `_tru_post_init` in `app.py`.
>     - Skip writing if using Snowflake connector with OTEL tracing enabled.
>   - **Functions**:
>     - Add `_is_snowflake_connector` to check for Snowflake connector in `app.py`.
>   - **Tests**:
>     - Add `TestOtelAppsTable` in `test_otel_apps_table.py` to verify app data is written to OTEL table.
>     - Add `test_smoke.json` as golden file for test verification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 6e4580c6910ce0b8d1368e860c72611bb06b7f17. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->