### PR TITLE
Use the full function name for span attributes.

### DIFF
--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -39,10 +39,7 @@ import wrapt
 logger = logging.getLogger(__name__)
 
 
-def _get_func_name(func: Callable, get_only_func_name: bool) -> str:
-    if get_only_func_name:
-        return func.__name__
-
+def _get_func_name(func: Callable) -> str:
     if (
         hasattr(func, "__module__")
         and func.__module__
@@ -204,10 +201,8 @@ class instrument:
         )
         self.must_be_first_wrapper = kwargs.get("must_be_first_wrapper", False)
 
-    def __call__(
-        self, func: Callable, get_only_func_name: bool = True
-    ) -> Callable:
-        func_name = _get_func_name(func, get_only_func_name=get_only_func_name)
+    def __call__(self, func: Callable) -> Callable:
+        func_name = _get_func_name(func)
 
         @wrapt.decorator
         def sync_wrapper(func, instance, args, kwargs):


### PR DESCRIPTION
# Description
Use the full function name for span attributes.

This is a revert of just the `src/core/trulens/core/otel/instrument.py` file in https://github.com/truera/trulens/pull/1940 which breaks a lot of the tests. I'm not entirely sure how it was possible to submit given it broke the PR pipeline but `main` is now broken so need to revert for now. The PR which introduced the change otherwise is just adding a notebook so I assume it's fine.

## Other details good to know for developers

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts `instrument.py` to use full function names for span attributes, fixing broken tests.
> 
>   - **Revert Changes**:
>     - Revert `src/core/trulens/core/otel/instrument.py` to use full function names for span attributes.
>     - Remove `get_only_func_name` parameter from `_get_func_name` and `__call__` in `instrument` class.
>   - **Behavior**:
>     - Fixes broken tests by reverting to full function names for span attributes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for aef9152a88280d51e822bc205a0fd0372f3abfc3. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->