### PR TITLE
[Fix] Update latency from milliseconds to seconds

### DIFF
--- a/examples/experimental/test_otel_quickstart.ipynb
+++ b/examples/experimental/test_otel_quickstart.ipynb
@@ -339,13 +339,13 @@
     "    rag.query(\"Does Washington State have Starbucks on campus?\")\n",
     "\n",
     "with tru_rag2 as recording:\n",
-    "    rag.query(\n",
+    "    rag2.query(\n",
     "        \"What wave of coffee culture is Starbucks seen to represent in the United States?\"\n",
     "    )\n",
-    "    rag.query(\n",
+    "    rag2.query(\n",
     "        \"What wave of coffee culture is Starbucks seen to represent in the New Zealand?\"\n",
     "    )\n",
-    "    rag.query(\"Does Washington State have Starbucks on campus?\")"
+    "    rag2.query(\"Does Washington State have Starbucks on campus?\")"
    ]
   },
   {
@@ -391,52 +391,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "session.connector.db"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "session.connector.db.get_records_and_feedback"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "test_df, _ = session.get_records_and_feedback(app_name=\"RAG\")\n",
-    "# test_df\n",
-    "# test_df.insert(0, \"app_name\", test_df.pop(\"app_name\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df, feedback_col_names = session.connector.db._get_records_and_feedback_otel(\n",
-    "    app_name=\"OTEL-RAG\"\n",
-    ")\n",
-    "# df\n",
-    "# df.insert(0, \"app_name\", df.pop(\"app_name\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "from trulens.core.schema import app as app_schema\n",
-    "from trulens.dashboard import constants as dashboard_constants\n",
-    "from trulens.dashboard.utils import metadata_utils\n",
-    "from trulens.dashboard.utils.dashboard_utils import _factor_out_metadata\n",
     "\n",
     "app_name = \"OTEL-RAG\"\n",
     "app_ids = []\n",
@@ -444,6 +399,7 @@
     "    app_ids.append(\n",
     "        app_schema.AppDefinition._compute_app_id(app_name, app_version)\n",
     "    )\n",
+    "\n",
     "offset = None\n",
     "limit = 1000\n",
     "use_otel = True"
@@ -455,14 +411,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Without app_ids\n",
-    "records_df, feedback_col_names = session.connector.db.get_records_and_feedback(\n",
-    "    app_name=app_name,\n",
-    "    offset=offset,\n",
-    "    limit=limit,\n",
-    "    use_otel=True,\n",
+    "test_df, _ = session.get_records_and_feedback(app_name=app_name)\n",
+    "test_otel_df, feedback_col_names = (\n",
+    "    session.connector.db._get_records_and_feedback_otel(app_name=app_name)\n",
     ")\n",
-    "print(records_df.columns, len(records_df))"
+    "\n",
+    "# print(len(test_df) == len(test_otel_df))"
    ]
   },
   {
@@ -471,15 +425,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Without app_ids\n",
+    "records_df_no_app_ids, _ = session.connector.db.get_records_and_feedback(\n",
+    "    app_name=app_name,\n",
+    "    offset=offset,\n",
+    "    limit=limit,\n",
+    "    use_otel=use_otel,\n",
+    ")\n",
+    "\n",
     "# With app_ids\n",
-    "records_df, feedback_col_names = session.connector.db.get_records_and_feedback(\n",
+    "records_df_with_app_ids, _ = session.connector.db.get_records_and_feedback(\n",
     "    app_ids=app_ids,\n",
     "    app_name=app_name,\n",
     "    offset=offset,\n",
     "    limit=limit,\n",
-    "    use_otel=True,\n",
+    "    use_otel=use_otel,\n",
     ")\n",
-    "print(records_df.columns, len(records_df))  # should be equal to the above"
+    "\n",
+    "# print(records_df_no_app_ids == records_df_with_app_ids, len(records_df_no_app_ids) == len(records_df_with_app_ids))"
    ]
   },
   {
@@ -488,25 +451,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "records_df[\"record_metadata\"] = records_df[\"record_json\"].apply(\n",
-    "    lambda x: metadata_utils.flatten_metadata(x[\"meta\"])\n",
-    "    if isinstance(x[\"meta\"], dict)\n",
-    "    else {}\n",
-    ")\n",
-    "\n",
-    "records_df, _ = _factor_out_metadata(records_df, \"record_metadata\")\n",
-    "\n",
-    "if dashboard_constants.HIDE_RECORD_COL_NAME in records_df.columns:\n",
-    "    records_df[dashboard_constants.HIDE_RECORD_COL_NAME] = (\n",
-    "        records_df[dashboard_constants.HIDE_RECORD_COL_NAME] == \"True\"\n",
-    "    ).astype(bool)\n",
-    "records_df = records_df.replace({float(\"nan\"): None})\n",
-    "\n",
-    "feedback_col_names = [\n",
-    "    col for col in feedback_col_names if col in records_df.columns\n",
-    "]\n",
-    "\n",
-    "print(feedback_col_names)"
+    "records_df_with_app_ids.head(10)"
    ]
   }
  ],

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -1054,7 +1054,7 @@ class SQLAlchemyDB(core_db.DB):
                     record_events[record_id]["ts"] = event.start_timestamp
                     record_events[record_id]["latency"] = (
                         event.timestamp - event.start_timestamp
-                    ).total_seconds() * 1000
+                    ).total_seconds()
 
                 # Check if the span has cost info (tokens, cost, currency), and update record events
                 self._update_cost_info_otel(
@@ -1172,7 +1172,7 @@ class SQLAlchemyDB(core_db.DB):
                 perf_json = {
                     "start_time": record_data["ts"],
                     "end_time": record_data["ts"]
-                    + pd.Timedelta(milliseconds=record_data["latency"]),
+                    + pd.Timedelta(seconds=record_data["latency"]),
                 }
 
                 # Create record row

--- a/tests/unit/test_otel_get_records_and_feedback.py
+++ b/tests/unit/test_otel_get_records_and_feedback.py
@@ -398,7 +398,7 @@ class TestOtelGetRecordsAndFeedback(OtelTestCase):
                 self.STATIC_START_TIME,
             )
 
-            # Calculate expected latency in milliseconds
+            # Calculate expected latency in seconds
             start_time = datetime.fromisoformat(self.STATIC_START_TIME)
             end_time = datetime.fromisoformat(self.STATIC_END_TIME)
             expected_latency = (end_time - start_time).total_seconds()

--- a/tests/unit/test_otel_get_records_and_feedback.py
+++ b/tests/unit/test_otel_get_records_and_feedback.py
@@ -401,7 +401,7 @@ class TestOtelGetRecordsAndFeedback(OtelTestCase):
             # Calculate expected latency in milliseconds
             start_time = datetime.fromisoformat(self.STATIC_START_TIME)
             end_time = datetime.fromisoformat(self.STATIC_END_TIME)
-            expected_latency = (end_time - start_time).total_seconds() * 1000
+            expected_latency = (end_time - start_time).total_seconds()
             self.assertEqual(row["latency"], expected_latency)
 
             # Verify JSON fields


### PR DESCRIPTION
# Description

- Output latency in seconds instead of milliseconds to align with UI and pre-OTEL values.
- Clean up `test_otel_quickstart.ipynb` notebook

Before:

![Latency in milliseconds](https://github.com/user-attachments/assets/0a4fe3ff-e328-4ffd-a36a-d8d81ac94772)

After:

![Latency in seconds](https://github.com/user-attachments/assets/26ed4086-ae10-4cbe-86cb-a5bbb291515d)

## Other details good to know for developers

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change latency output from milliseconds to seconds in `SQLAlchemyDB` to align with UI and pre-OTEL values.
> 
>   - **Behavior**:
>     - Change latency calculation from milliseconds to seconds in `_get_records_and_feedback_otel` in `sqlalchemy.py`.
>     - Update `pd.Timedelta` creation to use seconds instead of milliseconds in `sqlalchemy.py`.
>   - **Tests**:
>     - Update `test_get_records_and_feedback_otel_static_rag_spans` in `test_otel_get_records_and_feedback.py` to expect latency in seconds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for bfd114e4e1c44891d285cb540e252d860eb8c42a. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->