### PR TITLE
Allow for feedbacks in OTEL and kick them off via a new `TruApp::compute_feedback` function.

### DIFF
--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -1905,12 +1905,8 @@ you use the `%s` wrapper to make sure `%s` does get instrumented. `%s` method
                 "This method is only supported for OTEL Tracing. Please enable OTEL tracing in the environment!"
             )
         # Get all events associated with this app name and version.
-        # TODO(this_pr): Use ID instead of name and version.
         # TODO(otel): Should probably handle the case where there are a lot of events with pagination.
-        events = self.connector.get_events(
-            app_name=self.app_name,
-            app_version=self.app_version,
-        )
+        events = self.connector.get_events(app_id=self.app_id)
         for feedback in self.feedbacks:
             compute_feedback_by_span_group(
                 events, feedback.name, feedback.imp, feedback.selectors

--- a/src/core/trulens/core/database/base.py
+++ b/src/core/trulens/core/database/base.py
@@ -461,3 +461,16 @@ class DB(serial_utils.SerialModel, abc.ABC, text_utils.WithIdentString):
             The id of the given event.
         """
         raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_events(self, app_id: str) -> List[event_schema.Event]:
+        """
+        Get all events from the database.
+
+        Args:
+            app_id: The app id to filter events by.
+
+        Returns:
+            A list of events associated with the provided app id.
+        """
+        raise NotImplementedError()

--- a/src/core/trulens/core/database/connector/base.py
+++ b/src/core/trulens/core/database/connector/base.py
@@ -434,3 +434,18 @@ class DBConnector(ABC, text_utils.WithIdentString):
             events: A list of events to add to the database.
         """
         return [self.add_event(event=event) for event in events]
+
+    def get_events(
+        self, app_name: str, app_version: str
+    ) -> List[event_schema.Event]:
+        """
+        Get all events from the database relating to an app name and version.
+
+        Args:
+            app_name: The app name to filter events by.
+            app_version: The app version to filter events by.
+
+        Returns:
+            A list of events associated with the provided app name and version.
+        """
+        return self.db.get_events(app_name, app_version)

--- a/src/core/trulens/core/database/connector/base.py
+++ b/src/core/trulens/core/database/connector/base.py
@@ -435,17 +435,14 @@ class DBConnector(ABC, text_utils.WithIdentString):
         """
         return [self.add_event(event=event) for event in events]
 
-    def get_events(
-        self, app_name: str, app_version: str
-    ) -> List[event_schema.Event]:
+    def get_events(self, app_id: str) -> List[event_schema.Event]:
         """
-        Get all events from the database relating to an app name and version.
+        Get all events from the database relating to an app.
 
         Args:
-            app_name: The app name to filter events by.
-            app_version: The app version to filter events by.
+            app_id: The app id to filter events by.
 
         Returns:
-            A list of events associated with the provided app name and version.
+            A list of events associated with the provided app id.
         """
-        return self.db.get_events(app_name, app_version)
+        return self.db.get_events(app_id)

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -1539,6 +1539,23 @@ class SQLAlchemyDB(core_db.DB):
             )
             return _event.event_id
 
+    def get_events(self, app_name: str, app_version: str) -> pd.DataFrame:
+        """See [DB.get_events][trulens.core.database.base.DB.get_events]."""
+        with self.session.begin() as session:
+            app_name_expr = self._json_extract_otel(
+                "record_attributes", SpanAttributes.APP_NAME
+            )
+            app_version_expr = self._json_extract_otel(
+                "record_attributes", SpanAttributes.APP_VERSION
+            )
+            q = sa.select(self.orm.Event).where(
+                sa.and_(
+                    app_name_expr == app_name,
+                    app_version_expr == app_version,
+                )
+            )
+            return pd.read_sql(q, session.bind)
+
 
 # Use this Perf for missing Perfs.
 # TODO: Migrate the database instead.

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -1539,21 +1539,13 @@ class SQLAlchemyDB(core_db.DB):
             )
             return _event.event_id
 
-    def get_events(self, app_name: str, app_version: str) -> pd.DataFrame:
+    def get_events(self, app_id: str) -> pd.DataFrame:
         """See [DB.get_events][trulens.core.database.base.DB.get_events]."""
         with self.session.begin() as session:
-            app_name_expr = self._json_extract_otel(
-                "record_attributes", SpanAttributes.APP_NAME
+            app_id_expr = self._json_extract_otel(
+                "record_attributes", SpanAttributes.APP_ID
             )
-            app_version_expr = self._json_extract_otel(
-                "record_attributes", SpanAttributes.APP_VERSION
-            )
-            q = sa.select(self.orm.Event).where(
-                sa.and_(
-                    app_name_expr == app_name,
-                    app_version_expr == app_version,
-                )
-            )
+            q = sa.select(self.orm.Event).where(app_id_expr == app_id)
             return pd.read_sql(q, session.bind)
 
 

--- a/src/core/trulens/core/feedback/feedback.py
+++ b/src/core/trulens/core/feedback/feedback.py
@@ -7,6 +7,7 @@ from inspect import signature
 import itertools
 import json
 import logging
+import os
 from pprint import pformat
 import traceback
 from typing import (
@@ -33,6 +34,7 @@ from rich.markdown import Markdown
 from rich.pretty import pretty_repr
 from trulens.core._utils import pycompat as pycompat_utils
 from trulens.core.feedback import endpoint as core_endpoint
+from trulens.core.feedback.selector import Selector
 from trulens.core.schema import app as app_schema
 from trulens.core.schema import base as base_schema
 from trulens.core.schema import feedback as feedback_schema
@@ -617,6 +619,10 @@ class Feedback(feedback_schema.FeedbackDefinition):
     # alias
     on_output = on_response
 
+    @staticmethod
+    def _otel_enabled() -> bool:
+        return os.getenv("TRULENS_OTEL_TRACING", "").lower() in ["1", "true"]
+
     def on(self, *args, **kwargs) -> Feedback:
         """
         Create a variant of `self` with the same implementation but the given
@@ -624,6 +630,34 @@ class Feedback(feedback_schema.FeedbackDefinition):
         name guessed and those provided as kwargs get their name from the kwargs
         key.
         """
+        if self._otel_enabled():
+            if len(args) != 1 or len(kwargs) > 0:
+                raise ValueError(
+                    "OTEL mode only supports a single positional argument to `on`."
+                )
+            selectors = args[0]
+            if not isinstance(selectors, dict):
+                raise ValueError(
+                    f"OTEL mode only supports dictionary selectors, not {type(selectors)}!"
+                )
+            sig = signature(self.imp)
+            feedback_function_parameters = set(sig.parameters.keys())
+            for k, v in selectors.items():
+                if not isinstance(k, str):
+                    raise ValueError(
+                        f"OTEL mode only supports string keys, not {type(k)}!"
+                    )
+                if k not in feedback_function_parameters:
+                    raise ValueError(
+                        f"Selector key {k} not found in feedback function parameters {feedback_function_parameters}!"
+                    )
+                if not isinstance(v, Selector):
+                    raise ValueError(
+                        f"OTEL mode only supports Selector values, not {type(v)}!"
+                    )
+            ret = self.model_copy()
+            ret.selectors = selectors
+            return ret
 
         new_selectors = self.selectors.copy()
 

--- a/src/core/trulens/core/feedback/feedback_function_input.py
+++ b/src/core/trulens/core/feedback/feedback_function_input.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass
+class FeedbackFunctionInput:
+    value: Optional[Any] = None
+    span_id: Optional[str] = None
+    span_attribute: Optional[str] = None

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -113,6 +113,7 @@ trulens.core.app.App:
     app_version: builtins.str
     awith_: builtins.function
     awith_record: builtins.function
+    compute_feedbacks: builtins.function
     connector: builtins.property
     db: builtins.property
     delete: builtins.function
@@ -247,6 +248,7 @@ trulens.core.database.base.DB:
     get_apps: builtins.function
     get_datasets: builtins.function
     get_db_revision: builtins.function
+    get_events: builtins.function
     get_feedback: builtins.function
     get_feedback_count_by_status: builtins.function
     get_feedback_defs: builtins.function
@@ -299,6 +301,7 @@ trulens.core.database.connector.base.DBConnector:
     delete_app: builtins.function
     get_app: builtins.function
     get_apps: builtins.function
+    get_events: builtins.function
     get_leaderboard: builtins.function
     get_records_and_feedback: builtins.function
     migrate_database: builtins.function
@@ -636,6 +639,19 @@ trulens.core.feedback.feedback.SnowflakeFeedback:
     supplied_name: typing.Optional[builtins.str, builtins.NoneType]
     temperature: typing.Optional[builtins.float, builtins.NoneType]
     tru_class_info: trulens.core.utils.pyschema.Class
+trulens.core.feedback.feedback_function_input:
+  __class__: builtins.module
+  highs: {}
+  lows:
+    FeedbackFunctionInput: builtins.type
+trulens.core.feedback.feedback_function_input.FeedbackFunctionInput:
+  __bases__:
+  - builtins.object
+  __class__: builtins.type
+  attributes:
+    span_attribute: builtins.NoneType
+    span_id: builtins.NoneType
+    value: builtins.NoneType
 trulens.core.feedback.provider:
   __class__: builtins.module
   highs: {}

--- a/tests/unit/test_otel_feedback_computation.py
+++ b/tests/unit/test_otel_feedback_computation.py
@@ -376,7 +376,6 @@ class TestOtelFeedbackComputation(OtelTestCase):
         tru_recorder.instrumented_invoke_main_method(
             run_name="test run",
             input_id="42",
-            ground_truth_output="Like attention but with more heads.",
             main_method_args=("What is multi-headed attention?",),
         )
         TruSession().force_flush()

--- a/tests/unit/test_otel_feedback_computation.py
+++ b/tests/unit/test_otel_feedback_computation.py
@@ -7,6 +7,7 @@ from typing import List
 import pandas as pd
 import pytest
 from trulens.apps.app import TruApp
+from trulens.core.feedback import Feedback
 from trulens.core.feedback.selector import Selector
 from trulens.core.otel.instrument import instrument
 from trulens.core.session import TruSession
@@ -337,4 +338,94 @@ class TestOtelFeedbackComputation(OtelTestCase):
                 (record_id, span_group, {"a": 1.1, "b": 2}),
             ],
             res,
+        )
+
+    def test_custom_feedback(self) -> None:
+        # Create feedback function.
+        def custom(input: str, output: str) -> float:
+            if (
+                input == "What is multi-headed attention?"
+                and output == "This is a mocked response for prompt 0."
+            ):
+                return 0.42
+            return 0.0
+
+        f_custom = Feedback(custom, name="custom").on({
+            "input": Selector(
+                span_type=SpanAttributes.SpanType.RECORD_ROOT,
+                span_attribute=SpanAttributes.RECORD_ROOT.INPUT,
+            ),
+            "output": Selector(
+                span_type=SpanAttributes.SpanType.RECORD_ROOT,
+                span_attribute=SpanAttributes.RECORD_ROOT.OUTPUT,
+            ),
+        })
+
+        # Create app.
+        rag_chain = (
+            tests.unit.test_otel_tru_chain.TestOtelTruChain._create_simple_rag()
+        )
+        tru_recorder = TruChain(
+            rag_chain,
+            app_name="Simple RAG",
+            app_version="v1",
+            main_method=rag_chain.invoke,
+            feedbacks=[f_custom],
+        )
+        # Record and invoke.
+        tru_recorder.instrumented_invoke_main_method(
+            run_name="test run",
+            input_id="42",
+            ground_truth_output="Like attention but with more heads.",
+            main_method_args=("What is multi-headed attention?",),
+        )
+        TruSession().force_flush()
+        # Compute feedback on record we just ingested.
+        num_events = len(self._get_events())
+        tru_recorder.compute_feedbacks()
+        TruSession().force_flush()
+        # Compare results to expected.
+        events = self._get_events()
+        self.assertEqual(num_events + 1, len(events))
+        self.assertEqual(
+            SpanAttributes.SpanType.RECORD_ROOT,
+            events.iloc[0]["record_attributes"][SpanAttributes.SPAN_TYPE],
+        )
+        record_root_span_id = events.iloc[0]["trace"]["span_id"]
+        last_event_record_attributes = events.iloc[-1]["record_attributes"]
+        self.assertEqual(
+            SpanAttributes.SpanType.EVAL_ROOT,
+            last_event_record_attributes[SpanAttributes.SPAN_TYPE],
+        )
+        self.assertEqual(
+            "custom",
+            last_event_record_attributes[SpanAttributes.EVAL.METRIC_NAME],
+        )
+        self.assertEqual(
+            0.42,
+            last_event_record_attributes[SpanAttributes.EVAL_ROOT.SCORE],
+        )
+        self.assertEqual(
+            record_root_span_id,
+            last_event_record_attributes[
+                SpanAttributes.EVAL_ROOT.ARGS_SPAN_ID + ".input"
+            ],
+        )
+        self.assertEqual(
+            SpanAttributes.RECORD_ROOT.INPUT,
+            last_event_record_attributes[
+                SpanAttributes.EVAL_ROOT.ARGS_SPAN_ATTRIBUTE + ".input"
+            ],
+        )
+        self.assertEqual(
+            record_root_span_id,
+            last_event_record_attributes[
+                SpanAttributes.EVAL_ROOT.ARGS_SPAN_ID + ".output"
+            ],
+        )
+        self.assertEqual(
+            SpanAttributes.RECORD_ROOT.OUTPUT,
+            last_event_record_attributes[
+                SpanAttributes.EVAL_ROOT.ARGS_SPAN_ATTRIBUTE + ".output"
+            ],
         )

--- a/tests/unit/test_otel_selector.py
+++ b/tests/unit/test_otel_selector.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from trulens.core.feedback.feedback_function_input import FeedbackFunctionInput
 from trulens.core.feedback.selector import Selector
 from trulens.otel.semconv.trace import SpanAttributes
 
@@ -100,40 +101,58 @@ class TestOtelSelector(OtelTestCase):
             Selector(
                 span_attributes_processor=lambda attributes: "z",
                 function_name="X",
-            ).process_span({}),
-            "z",
+            ).process_span("1", {}),
+            FeedbackFunctionInput(value="z", span_id="1"),
         )
         self.assertEqual(
-            Selector(span_attribute="Z", function_name="X").process_span({}),
-            None,
+            Selector(span_attribute="Z", function_name="X").process_span(
+                "2", {}
+            ),
+            FeedbackFunctionInput(value=None, span_id="2", span_attribute="Z"),
         )
         self.assertEqual(
-            Selector(span_attribute="Z", function_name="X").process_span({
-                "Z": "z"
-            }),
-            "z",
-        )
-        self.assertEqual(
-            Selector(
-                function_attribute="return", function_name="X"
-            ).process_span({}),
-            None,
+            Selector(span_attribute="Z", function_name="X").process_span(
+                "3", {"Z": "z"}
+            ),
+            FeedbackFunctionInput(value="z", span_id="3", span_attribute="Z"),
         )
         self.assertEqual(
             Selector(
                 function_attribute="return", function_name="X"
-            ).process_span({SpanAttributes.CALL.RETURN: "z"}),
-            "z",
+            ).process_span("4", {}),
+            FeedbackFunctionInput(
+                value=None,
+                span_id="4",
+                span_attribute=SpanAttributes.CALL.RETURN,
+            ),
         )
         self.assertEqual(
             Selector(
-                function_attribute="arg1", function_name="X"
-            ).process_span({}),
-            None,
+                function_attribute="return", function_name="X"
+            ).process_span("5", {SpanAttributes.CALL.RETURN: "z"}),
+            FeedbackFunctionInput(
+                value="z",
+                span_id="5",
+                span_attribute=SpanAttributes.CALL.RETURN,
+            ),
         )
         self.assertEqual(
-            Selector(
-                function_attribute="arg1", function_name="X"
-            ).process_span({f"{SpanAttributes.CALL.KWARGS}.arg1": "z"}),
-            "z",
+            Selector(function_attribute="arg1", function_name="X").process_span(
+                "6", {}
+            ),
+            FeedbackFunctionInput(
+                value=None,
+                span_id="6",
+                span_attribute=f"{SpanAttributes.CALL.KWARGS}.arg1",
+            ),
+        )
+        self.assertEqual(
+            Selector(function_attribute="arg1", function_name="X").process_span(
+                "7", {f"{SpanAttributes.CALL.KWARGS}.arg1": "z"}
+            ),
+            FeedbackFunctionInput(
+                value="z",
+                span_id="7",
+                span_attribute=f"{SpanAttributes.CALL.KWARGS}.arg1",
+            ),
         )

--- a/tests/util/df_comparison.py
+++ b/tests/util/df_comparison.py
@@ -171,7 +171,6 @@ def _compare_entity(
                     regex_replacements=regex_replacements,
                 )
                 return
-            # TODO(this_pr): do we still need this?
             for regex, replacement in regex_replacements:
                 expected = re.sub(regex, replacement, expected)
                 actual = re.sub(regex, replacement, actual)


### PR DESCRIPTION
# Description
Allow for feedbacks in OTEL and kick them off via a new `TruApp::compute_feedback` function.

This basically allows something like this now (see the test for this in action):
```python
# Create feedback function.
def custom(a: str, b: str) -> float:
    return 0.0

f_custom = Feedback(custom, name="custom").on({
    "a": Selector(
        span_type=SpanAttributes.SpanType.RECORD_ROOT,
        span_attribute=SpanAttributes.RECORD_ROOT.INPUT,
    ),
    "b": Selector(
        span_type=SpanAttributes.SpanType.RECORD_ROOT,
        span_attribute=SpanAttributes.RECORD_ROOT.OUTPUT,
    ),
})

# Create app.
app = ...
tru_recorder = TruChain(
    app,
    app_name="App",
    app_version="v1",
    main_method=rag_chain.invoke,
    feedbacks=[f_custom],
)
# Record and invoke.
tru_recorder.instrumented_invoke_main_method(
    run_name="test run",
    input_id="42",
    main_method_args=("What is multi-headed attention?",),
)
TruSession().force_flush()
# Compute feedback on record we just ingested.
tru_recorder.compute_feedbacks()
```

## Other details good to know for developers
Future work:
1. Don't let OTEL use any of the other `on` methods like `on_input` or `on_output` or if we use them, can't use `on` by itself with it.
2. Find a way to make the simple cases easy. Maybe like `Selector.RECORD_ROOT_INPUT` or something.
3. Have the compute_feedbacks done automatically if desired (i.e. "live evals").
4. If we've already computed an eval, don't recompute it.
5. Also allow an overall `compute_metrics` function on a run? Don't have runs right now though.
6. Allow us to do this to the Snowflake event table.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds OTEL-based feedback computation to `TruApp` with new `compute_feedbacks` method and supporting database and feedback updates.
> 
>   - **Behavior**:
>     - Introduces `compute_feedbacks` method in `TruApp` to compute feedbacks using OTEL tracing.
>     - Handles feedback computation by fetching events associated with the app and applying feedback functions.
>     - Raises error if OTEL tracing is not enabled.
>   - **Database**:
>     - Adds `get_events` method in `database/base.py` and `database/sqlalchemy.py` to fetch events by `app_id`.
>   - **Feedback**:
>     - Updates `Feedback` class to support OTEL mode with dictionary selectors.
>     - Introduces `FeedbackFunctionInput` dataclass to encapsulate feedback function inputs.
>   - **Tests**:
>     - Adds tests in `test_otel_feedback_computation.py` and `test_otel_selector.py` to verify feedback computation and selector functionality.
>   - **Misc**:
>     - Minor updates to `README.md` and `constants.py` for new functionality.
>     - Fixes typo in `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 0e00d33214c904af27c263bfdadfb1742c5eec6e. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->