### PR TITLE
[Fix] Update groundedness measure return to 0.0 instead of NaN when no non-trivial statements are found.

### DIFF
--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -1798,6 +1798,8 @@ class LLMProvider(core_provider.Provider):
 
         Abstentions will be considered as grounded.
 
+        If all statements are filtered out as trivial, returns 0.0 with a reason indicating no non-trivial statements were found.
+
         Example:
             ```python
             from trulens.core import Feedback
@@ -1883,6 +1885,9 @@ class LLMProvider(core_provider.Provider):
 
         if filter_trivial_statements:
             hypotheses = self._remove_trivial_statements(hypotheses)
+
+            if not hypotheses:
+                return 0.0, {"reason": "No non-trivial statements to evaluate"}
 
         output_space = self._determine_output_space(
             min_score_val, max_score_val
@@ -2000,6 +2005,8 @@ class LLMProvider(core_provider.Provider):
 
         If the question is considered answerable, abstentions will be considered as not grounded and punished with low scores. Otherwise, unanswerable abstentions will be considered grounded.
 
+        If all statements are filtered out as trivial, returns 0.0 with a reason indicating no non-trivial statements were found.
+
         Example:
             ```python
             from trulens.core import Feedback
@@ -2095,6 +2102,9 @@ class LLMProvider(core_provider.Provider):
 
         if filter_trivial_statements:
             hypotheses = self._remove_trivial_statements(hypotheses)
+
+            if not hypotheses:
+                return 0.0, {"reason": "No non-trivial statements to evaluate"}
 
         output_space = self._determine_output_space(
             min_score_val, max_score_val

--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -1792,13 +1792,11 @@ class LLMProvider(core_provider.Provider):
 
         The statement will first be split by a tokenizer into its component sentences.
 
-        Then, trivial statements are eliminated so as to not dilute the evaluation.
+        Then, trivial statements are eliminated so as to not dilute the evaluation. Note that if all statements are filtered out as trivial, returns 0.0 with a reason indicating no non-trivial statements were found.
 
         The LLM will process each statement, using chain of thought methodology to emit the reasons.
 
         Abstentions will be considered as grounded.
-
-        If all statements are filtered out as trivial, returns 0.0 with a reason indicating no non-trivial statements were found.
 
         Example:
             ```python
@@ -1997,15 +1995,13 @@ class LLMProvider(core_provider.Provider):
 
         The statement will first be split by a tokenizer into its component sentences.
 
-        Then, trivial statements are eliminated so as to not delete the evaluation.
+        Then, trivial statements are eliminated so as to not dilute the evaluation. Note that if all statements are filtered out as trivial, returns 0.0 with a reason indicating no non-trivial statements were found.
 
         The LLM will process each statement, using chain of thought methodology to emit the reasons.
 
         In the case of abstentions, such as 'I do not know', the LLM will be asked to consider the answerability of the question given the source material.
 
         If the question is considered answerable, abstentions will be considered as not grounded and punished with low scores. Otherwise, unanswerable abstentions will be considered grounded.
-
-        If all statements are filtered out as trivial, returns 0.0 with a reason indicating no non-trivial statements were found.
 
         Example:
             ```python


### PR DESCRIPTION
# Description

- Addresses #1641 

## Other details good to know for developers

- N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `groundedness_measure_with_cot_reasons` and `groundedness_measure_with_cot_reasons_consider_answerability` to return 0.0 instead of NaN when no non-trivial statements are found.
> 
>   - **Behavior**:
>     - `groundedness_measure_with_cot_reasons` and `groundedness_measure_with_cot_reasons_consider_answerability` in `llm_provider.py` now return 0.0 with a reason if all statements are trivial.
>   - **Documentation**:
>     - Updated docstrings in `groundedness_measure_with_cot_reasons` and `groundedness_measure_with_cot_reasons_consider_answerability` to reflect the new behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 396d5d287d58f2b70b391b26718a99e927268f03. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->