### PR TITLE
Create automatic job to compute feedbacks.

### DIFF
--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -55,6 +55,7 @@ from trulens.core.utils import asynchro as asynchro_utils
 from trulens.core.utils import constants as constant_utils
 from trulens.core.utils import containers as container_utils
 from trulens.core.utils import deprecation as deprecation_utils
+from trulens.core.utils import evaluator as evaluator_utils
 from trulens.core.utils import imports as import_utils
 from trulens.core.utils import json as json_utils
 from trulens.core.utils import pyschema as pyschema_utils
@@ -526,6 +527,8 @@ class App(
         self._current_context_manager_lock = threading.Lock()
         self._current_context_manager = None
 
+        self._evaluator = evaluator_utils.Evaluator(self)
+
         if connector and _can_import("trulens.connectors.snowflake"):
             from trulens.connectors.snowflake import SnowflakeConnector
             from trulens.connectors.snowflake.dao.enums import ObjectType
@@ -565,6 +568,7 @@ class App(
 
     def __del__(self):
         """Shut down anything associated with this app that might persist otherwise."""
+        self.stop_evaluator()
         try:
             # Use object.__getattribute__ to avoid triggering __getattr__
             m_thread = object.__getattribute__(
@@ -1893,22 +1897,31 @@ you use the `%s` wrapper to make sure `%s` does get instrumented. `%s` method
             "This feature is not yet implemented for non-OTEL TruLens!"
         )
 
+    # TODO(next_pr): Allow for single process/thread mode where we can assume the exporter sees all spans.
+    # TODO(next_pr): Probably should allow for specific record it to be computed again.
+    # TODO(next_pr): Probably should allow for all records to be computed again.
     def compute_feedbacks(
-        self, raise_error_on_no_feedbacks_computed: bool = True
+        self,
+        raise_error_on_no_feedbacks_computed: bool = True,
+        events: Optional[pd.DataFrame] = None,
     ) -> None:
         """Compute feedbacks for the app.
 
         Args:
             raise_error_on_no_feedbacks_computed:
                 Raise an error if no feedbacks were computed. Default is True.
+            events:
+                The events to compute feedbacks from. If None, uses all
+                events from the app.
         """
         if not is_otel_tracing_enabled():
             raise ValueError(
                 "This method is only supported for OTEL Tracing. Please enable OTEL tracing in the environment!"
             )
-        # Get all events associated with this app name and version.
-        # TODO(otel): Should probably handle the case where there are a lot of events with pagination.
-        events = self.connector.get_events(app_id=self.app_id)
+        if events is None:
+            # Get all events associated with this app name and version.
+            # TODO(otel): Should probably handle the case where there are a lot of events with pagination.
+            events = self.connector.get_events(app_id=self.app_id)
         for feedback in self.feedbacks:
             compute_feedback_by_span_group(
                 events,
@@ -1917,6 +1930,14 @@ you use the `%s` wrapper to make sure `%s` does get instrumented. `%s` method
                 feedback.selectors,
                 raise_error_on_no_feedbacks_computed,
             )
+
+    def start_evaluator(self) -> None:
+        """Start the evaluator for the app."""
+        self._evaluator.start_evaluator()
+
+    def stop_evaluator(self) -> None:
+        """Stop the evaluator for the app."""
+        self._evaluator.stop_evaluator()
 
 
 # NOTE: Cannot App.model_rebuild here due to circular imports involving mod_session.TruSession

--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -1897,9 +1897,6 @@ you use the `%s` wrapper to make sure `%s` does get instrumented. `%s` method
             "This feature is not yet implemented for non-OTEL TruLens!"
         )
 
-    # TODO(next_pr): Allow for single process/thread mode where we can assume the exporter sees all spans.
-    # TODO(next_pr): Probably should allow for specific record it to be computed again.
-    # TODO(next_pr): Probably should allow for all records to be computed again.
     def compute_feedbacks(
         self,
         raise_error_on_no_feedbacks_computed: bool = True,

--- a/src/core/trulens/core/database/base.py
+++ b/src/core/trulens/core/database/base.py
@@ -463,14 +463,17 @@ class DB(serial_utils.SerialModel, abc.ABC, text_utils.WithIdentString):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def get_events(self, app_id: str) -> List[event_schema.Event]:
+    def get_events(
+        self, app_id: str, start_time: Optional[datetime] = None
+    ) -> pd.DataFrame:
         """
-        Get all events from the database.
+        Get events from the database.
 
         Args:
             app_id: The app id to filter events by.
+            start_time: The minimum time to consider events from.
 
         Returns:
-            A list of events associated with the provided app id.
+            A pandas DataFrame of events associated with the provided app id.
         """
         raise NotImplementedError()

--- a/src/core/trulens/core/database/connector/base.py
+++ b/src/core/trulens/core/database/connector/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC
 from abc import abstractmethod
 from concurrent import futures
+import datetime
 import logging
 import queue
 from threading import Thread
@@ -16,7 +17,7 @@ from typing import (
     Union,
 )
 
-import pandas
+import pandas as pd
 from trulens.core._utils.pycompat import Future  # code style exception
 from trulens.core.database import base as core_db
 from trulens.core.schema import app as app_schema
@@ -324,7 +325,7 @@ class DBConnector(ABC, text_utils.WithIdentString):
         app_name: Optional[types_schema.AppName] = None,
         offset: Optional[int] = None,
         limit: Optional[int] = None,
-    ) -> Tuple[pandas.DataFrame, List[str]]:
+    ) -> Tuple[pd.DataFrame, List[str]]:
         """Get records, their feedback results, and feedback names.
 
         Args:
@@ -359,7 +360,7 @@ class DBConnector(ABC, text_utils.WithIdentString):
         group_by_metadata_key: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-    ) -> pandas.DataFrame:
+    ) -> pd.DataFrame:
         """Get a leaderboard for the given apps.
 
         Args:
@@ -435,14 +436,17 @@ class DBConnector(ABC, text_utils.WithIdentString):
         """
         return [self.add_event(event=event) for event in events]
 
-    def get_events(self, app_id: str) -> List[event_schema.Event]:
+    def get_events(
+        self, app_id: str, start_time: Optional[datetime.datetime] = None
+    ) -> pd.DataFrame:
         """
-        Get all events from the database relating to an app.
+        Get events from the database.
 
         Args:
             app_id: The app id to filter events by.
+            start_time: The minimum time to consider events from.
 
         Returns:
-            A list of events associated with the provided app id.
+            A pandas DataFrame of events associated with the provided app id.
         """
         return self.db.get_events(app_id)

--- a/src/core/trulens/core/utils/evaluator.py
+++ b/src/core/trulens/core/utils/evaluator.py
@@ -76,7 +76,6 @@ class Evaluator:
             A dict from record id to a pandas DataFrame of all events from that
             record. Only records that aren't fully processed will be included.
         """
-        # TODO(otel): This is a rather slow approach!
         events = self._app_ref().connector.get_events(
             app_id=self._app_ref().app_id, start_time=self._start_time
         )

--- a/src/core/trulens/core/utils/evaluator.py
+++ b/src/core/trulens/core/utils/evaluator.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import datetime
+import logging
+import threading
+import time
+from typing import TYPE_CHECKING, Dict
+import weakref
+
+import pandas as pd
+from trulens.core.otel.utils import is_otel_tracing_enabled
+from trulens.core.session import TruSession
+from trulens.otel.semconv.trace import SpanAttributes
+
+if TYPE_CHECKING:
+    from trulens.core.app import App
+
+logger = logging.getLogger(__name__)
+
+
+class Evaluator:
+    def __init__(self, app: App):
+        self._app_ref = weakref.ref(app)
+        self._app_name = app.app_name
+        self._app_version = app.app_version
+        self._thread = None
+        self._stop_event = threading.Event()
+        self._record_id_to_event_count = pd.Series([])
+        self._start_time = datetime.datetime.now()
+
+    def _events_under_record_root(self, events: pd.DataFrame) -> pd.DataFrame:
+        """
+        Get events that are under the record root.
+
+        Args:
+            events: A pandas DataFrame of events.
+
+        Returns:
+            The events that are under the record root.
+        """
+        # Construct a tree of events.
+        record_roots = []
+        span_id_to_children = {
+            event["trace"]["span_id"]: [] for _, event in events.iterrows()
+        }
+        for i, event in events.iterrows():
+            parent_id = event["trace"]["parent_id"]
+            if parent_id and parent_id in span_id_to_children:
+                span_id_to_children[parent_id].append(event)
+            if (
+                event["record_attributes"].get(SpanAttributes.SPAN_TYPE)
+                == SpanAttributes.SpanType.RECORD_ROOT
+            ):
+                record_roots.append(event)
+        # Count events under the record root.
+        if len(record_roots) != 1:
+            return []
+        ret = []
+        q = [record_roots[0]]
+        while q:
+            curr_event = q.pop(0)
+            ret.append(curr_event)
+            q.extend([
+                child_event
+                for child_event in span_id_to_children[
+                    curr_event["trace"]["span_id"]
+                ]
+            ])
+        return pd.DataFrame(ret)
+
+    def _get_record_id_to_unprocessed_events(self) -> Dict[str, pd.DataFrame]:
+        """
+        Get events for the app that weren't yet used for feedback computation.
+
+        Returns:
+            A dict from record id to a pandas DataFrame of all events from that
+            record. Only records that aren't fully processed will be included.
+        """
+        # TODO(otel): This is a rather slow approach!
+        events = self._app_ref().connector.get_events(
+            app_id=self._app_ref().app_id, start_time=self._start_time
+        )
+        record_ids = events["record_attributes"].apply(
+            lambda curr: curr.get(SpanAttributes.RECORD_ID)
+        )
+        record_id_to_events = events.groupby(record_ids)
+        record_id_to_events_under_record_root = {
+            k: self._events_under_record_root(events.loc[v])
+            for k, v in record_id_to_events.groups.items()
+        }
+        ret = {}
+        for (
+            record_id,
+            events_under_record_root,
+        ) in record_id_to_events_under_record_root.items():
+            count = len(events_under_record_root)
+            if (
+                record_id not in self._record_id_to_event_count
+                or count > self._record_id_to_event_count[record_id]
+            ):
+                ret[record_id] = events_under_record_root
+        return ret
+
+    def _run_evaluator(self) -> None:
+        """Background thread that periodically computes feedback for events."""
+        try:
+            while not self._stop_event.is_set():
+                record_id_to_events = (
+                    self._get_record_id_to_unprocessed_events()
+                )
+                for record_id, events in record_id_to_events.items():
+                    try:
+                        self._app_ref().compute_feedbacks(
+                            raise_error_on_no_feedbacks_computed=False,
+                            events=events,
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"Error computing feedbacks in evaluator thread (record_id={record_id}): {e}"
+                        )
+                    finally:
+                        self._record_id_to_event_count[record_id] = len(events)
+                    TruSession().force_flush()
+                    if self._stop_event.is_set():
+                        break
+                for _ in range(60):
+                    if self._stop_event.is_set():
+                        break
+                    time.sleep(1)
+        except Exception as e:
+            logger.error(f"Evaluator thread encountered an error: {e}")
+
+    def start_evaluator(self) -> None:
+        """Start the evaluator for the app."""
+        # Validate.
+        if not is_otel_tracing_enabled():
+            raise ValueError(
+                "This method is only supported for OTEL Tracing. Please enable OTEL tracing in the environment!"
+            )
+        if self._thread is not None:
+            raise RuntimeError(
+                "Evaluator thread already started. Please stop it before starting a new one."
+            )
+        # Create and start the evaluator thread.
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run_evaluator,
+            daemon=True,
+            name=f"evaluator_thread(app_name={self._app_name}, app_version={self._app_version})",
+        )
+        self._thread.start()
+
+    def stop_evaluator(self) -> None:
+        """Stop the evaluator for the app.
+
+        This is only supported for OTEL Tracing.
+        """
+        if self._thread is None:
+            logger.warning("No evaluator thread is running.")
+            return
+        # Signal the thread to stop.
+        self._stop_event.set()
+        # Give the thread a reasonable time to exit gracefully.
+        self._thread.join(timeout=300)
+        # If thread is still alive after timeout, log a warning.
+        if self._thread.is_alive():
+            logger.warning(
+                f"Evaluator thread (app_name={self._app_name}, app_version={self._app_version}) did not terminate gracefully within timeout."
+            )
+        else:
+            logger.info(
+                f"Stopped evaluator thread (app_name={self._app_name}, app_version={self._app_version})."
+            )
+        # Reset for potential future restart.
+        self._thread = None
+        self._stop_event.clear()
+
+    def __del__(self):
+        try:
+            if self._thread is not None:
+                logger.info(
+                    f"Stopping evaluator thread during garbage collection (app_name={self._app_name}, app_version={self._app_version})."
+                )
+                self.stop_evaluator()
+        except Exception:
+            # During interpreter shutdown, some modules might be already
+            # unloaded so we can't rely on the logger or other modules being
+            # available
+            pass

--- a/src/core/trulens/core/utils/evaluator.py
+++ b/src/core/trulens/core/utils/evaluator.py
@@ -25,7 +25,7 @@ class Evaluator:
         self._app_version = app.app_version
         self._thread = None
         self._stop_event = threading.Event()
-        self._record_id_to_event_count = pd.Series([])
+        self._record_id_to_event_count = pd.Series(dtype=int)
         self._start_time = datetime.datetime.now()
 
     def _events_under_record_root(self, events: pd.DataFrame) -> pd.DataFrame:
@@ -54,7 +54,7 @@ class Evaluator:
                 record_roots.append(event)
         # Count events under the record root.
         if len(record_roots) != 1:
-            return []
+            return pd.DataFrame()
         ret = []
         q = [record_roots[0]]
         while q:

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -157,6 +157,8 @@ trulens.core.app.App:
     snowflake_object_type: typing.Optional[builtins.str, builtins.NoneType]
     snowflake_object_version: typing.Optional[builtins.str, builtins.NoneType]
     snowflake_run_dao: typing.Optional[typing.Any, builtins.NoneType]
+    start_evaluator: builtins.function
+    stop_evaluator: builtins.function
     tags: builtins.str
     tru: builtins.property
     tru_class_info: trulens.core.utils.pyschema.Class
@@ -1354,6 +1356,18 @@ trulens.core.utils.deprecation:
     moved: builtins.function
     packages_dep_warn: builtins.function
     staticmethod_renamed: builtins.function
+trulens.core.utils.evaluator:
+  __class__: builtins.module
+  highs: {}
+  lows:
+    Evaluator: builtins.type
+trulens.core.utils.evaluator.Evaluator:
+  __bases__:
+  - builtins.object
+  __class__: builtins.type
+  attributes:
+    start_evaluator: builtins.function
+    stop_evaluator: builtins.function
 trulens.core.utils.imports:
   __class__: builtins.module
   highs: {}

--- a/tests/unit/test_otel_evaluator.py
+++ b/tests/unit/test_otel_evaluator.py
@@ -1,0 +1,124 @@
+"""
+Tests for OTEL Evaluator.
+"""
+
+import time
+from unittest.mock import MagicMock
+from unittest.mock import patch
+import weakref
+
+import pandas as pd
+import pytest
+from trulens.core.utils.evaluator import Evaluator
+from trulens.otel.semconv.trace import SpanAttributes
+
+from tests.util.otel_test_case import OtelTestCase
+
+
+@pytest.mark.optional
+class TestOtelEvaluator(OtelTestCase):
+    def test_evaluator_lifecycle(self):
+        # Create a mock app.
+        mock_app = MagicMock()
+        mock_app.app_name = "Test App"
+        mock_app.app_version = "v1"
+        mock_app.app_id = "test_app_id"
+        # Create evaluator.
+        evaluator = Evaluator(mock_app)
+        # Start evaluator.
+        evaluator.start_evaluator()
+        self.assertIsNotNone(evaluator._thread)
+        self.assertTrue(evaluator._thread.is_alive())
+        # Stop evaluator.
+        evaluator_ref = weakref.ref(evaluator)
+        thread_ref = weakref.ref(evaluator._thread)
+        evaluator.stop_evaluator()
+        time.sleep(2)
+        self.assertIsNone(evaluator._thread)
+        # Ensure everything is garbage collected.
+        del evaluator
+        self.assertCollected(evaluator_ref)
+        self.assertCollected(thread_ref)
+
+    def test_evaluator_processes_events(self):
+        # Create a mock app.
+        mock_app = MagicMock()
+        mock_app.app_name = "App"
+        mock_app.app_version = "v1"
+        mock_app.app_id = "app_id"
+        # Mock the get_events method to return test data.
+        test_events = pd.DataFrame([
+            {
+                "trace": {"span_id": "span1", "parent_id": None},
+                "record_attributes": {
+                    SpanAttributes.SPAN_TYPE: SpanAttributes.SpanType.RECORD_ROOT,
+                    SpanAttributes.RECORD_ID: "test_record_id",
+                },
+            },
+            {
+                "trace": {"span_id": "span2", "parent_id": "span1"},
+                "record_attributes": {
+                    SpanAttributes.RECORD_ID: "test_record_id"
+                },
+            },
+        ])
+        # Mock the connector to return test events.
+        mock_app.connector.get_events.return_value = test_events
+        evaluator = Evaluator(mock_app)
+        # Start evaluator.
+        evaluator.start_evaluator()
+        time.sleep(1)
+        # Verify compute_feedbacks was called correctly.
+        mock_app.compute_feedbacks.assert_called_once()
+        pd.testing.assert_frame_equal(
+            test_events,
+            mock_app.compute_feedbacks.call_args_list[0].kwargs["events"],
+        )
+        # Stop evaluator
+        evaluator.stop_evaluator()
+
+    def test_evaluator_error_handling(self):
+        """Test that evaluator handles errors gracefully."""
+        # Create a mock app that raises an error when compute_feedbacks is
+        # called.
+        mock_app = MagicMock()
+        mock_app.app_name = "Error App"
+        mock_app.app_version = "v1"
+        mock_app.app_id = "error_app_id"
+        mock_app.compute_feedbacks.side_effect = Exception("Test error")
+        # Create test data
+        test_events = pd.DataFrame([
+            {
+                "trace": {"span_id": "span1", "parent_id": None},
+                "record_attributes": {
+                    SpanAttributes.SPAN_TYPE: SpanAttributes.SpanType.RECORD_ROOT,
+                    SpanAttributes.RECORD_ID: "test_record_id",
+                },
+            }
+        ])
+        # Mock the connector to return test events.
+        mock_app.connector.get_events.return_value = test_events
+        # Start evaluator.
+        evaluator = Evaluator(mock_app)
+        evaluator.start_evaluator()
+        time.sleep(1)
+        # Verify compute_feedbacks was called even though it raised an error.
+        mock_app.compute_feedbacks.assert_called()
+
+    def test_evaluator_invalid_start(self):
+        mock_app = MagicMock()
+        mock_app.app_name = "Test App"
+        mock_app.app_version = "v1"
+        evaluator = Evaluator(mock_app)
+        # Try starting evaluator twice.
+        evaluator.start_evaluator()
+        with self.assertRaises(RuntimeError):
+            evaluator.start_evaluator()
+        evaluator.stop_evaluator()
+        # Try starting evaluator without OTEL tracing.
+        with patch(
+            "trulens.core.utils.evaluator.is_otel_tracing_enabled",
+            return_value=False,
+        ):
+            with self.assertRaises(ValueError):
+                evaluator.start_evaluator()

--- a/tests/unit/test_otel_feedback_computation.py
+++ b/tests/unit/test_otel_feedback_computation.py
@@ -510,7 +510,6 @@ class TestOtelFeedbackComputation(OtelTestCase):
         tru_recorder_ref = weakref.ref(tru_recorder)
         evaluator_ref = weakref.ref(tru_recorder._evaluator)
         thread_ref = weakref.ref(tru_recorder._evaluator._thread)
-        # thread = tru_recorder._evaluator._thread
         del tru_recorder
         gc.collect()
         self.assertCollected(tru_recorder_ref)

--- a/tests/unit/test_otel_feedback_computation.py
+++ b/tests/unit/test_otel_feedback_computation.py
@@ -4,7 +4,7 @@ Tests for OTEL Feedback Computation.
 
 import gc
 import time
-from typing import Callable, List
+from typing import TYPE_CHECKING, Callable, List
 import weakref
 
 import pandas as pd
@@ -30,6 +30,9 @@ from tests.util.mock_otel_feedback_computation import (
 )
 from tests.util.mock_otel_feedback_computation import feedback_function
 from tests.util.otel_test_case import OtelTestCase
+
+if TYPE_CHECKING:
+    from trulens.apps.langchain import TruChain
 
 try:
     # These imports require optional dependencies to be installed.

--- a/tests/unit/test_otel_feedback_computation.py
+++ b/tests/unit/test_otel_feedback_computation.py
@@ -4,7 +4,7 @@ Tests for OTEL Feedback Computation.
 
 import gc
 import time
-from typing import TYPE_CHECKING, Callable, List
+from typing import Callable, List
 import weakref
 
 import pandas as pd
@@ -30,9 +30,6 @@ from tests.util.mock_otel_feedback_computation import (
 )
 from tests.util.mock_otel_feedback_computation import feedback_function
 from tests.util.otel_test_case import OtelTestCase
-
-if TYPE_CHECKING:
-    from trulens.apps.langchain import TruChain
 
 try:
     # These imports require optional dependencies to be installed.
@@ -396,7 +393,7 @@ class TestOtelFeedbackComputation(OtelTestCase):
         )
         self.assertEqual([flattened_inputs[1]], res)
 
-    def _create_invoked_app_with_custom_feedback(self) -> TruChain:
+    def _create_invoked_app_with_custom_feedback(self) -> TruApp:
         # Create feedback function.
         def custom(input: str, output: str) -> float:
             if (


### PR DESCRIPTION
# Description
Create automatic job to compute feedbacks.

## Other details good to know for developers
Future work for this is to have this automatically turned on in OTel mode.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces an automatic feedback computation feature using an evaluator thread, with lifecycle management in the `App` class and event filtering in database methods.
> 
>   - **Behavior**:
>     - Adds `Evaluator` class in `evaluator.py` to compute feedbacks automatically in a background thread.
>     - Updates `App` class in `app.py` to manage evaluator lifecycle with `start_evaluator()` and `stop_evaluator()` methods.
>     - Modifies `compute_feedbacks()` in `app.py` to accept `events` parameter for selective feedback computation.
>   - **Database**:
>     - Updates `get_events()` in `base.py`, `connector/base.py`, and `sqlalchemy.py` to accept `start_time` for event filtering.
>   - **Tests**:
>     - Adds `test_otel_evaluator.py` to test evaluator lifecycle, event processing, and error handling.
>     - Updates `test_otel_feedback_computation.py` to test feedback computation with evaluator.
>   - **Misc**:
>     - Imports `evaluator` in `app.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 60c520e18475079f45734cafbc808b4714fb57d6. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->