### PR TITLE
Check that wrapped apps are garbage collected correctly.

### DIFF
--- a/tests/unit/test_otel_apps_table.py
+++ b/tests/unit/test_otel_apps_table.py
@@ -17,7 +17,7 @@ class TestOtelAppsTable(OtelTestCase):
             q = sa.select(db.orm.AppDefinition)
             return pd.read_sql(q, db_session.bind)
 
-    def test_smoke(self):
+    def test_smoke(self) -> None:
         app = tests.unit.test_otel_tru_custom.TestApp()
         TruApp(
             app,

--- a/tests/unit/test_otel_tru_basic.py
+++ b/tests/unit/test_otel_tru_basic.py
@@ -2,6 +2,9 @@
 Tests for OTEL TruBasic app.
 """
 
+import gc
+import weakref
+
 from trulens.apps.basic import TruBasicApp
 from trulens.core.session import TruSession
 from trulens.otel.semconv.trace import SpanAttributes
@@ -34,6 +37,11 @@ class TestOtelTruBasic(tests.util.otel_tru_app_test_case.OtelTruAppTestCase):
         self._compare_events_to_golden_dataframe(
             "tests/unit/static/golden/test_otel_tru_basic__test_smoke.csv"
         )
+        # Check garbage collection.
+        basic_app_ref = weakref.ref(basic_app)
+        del basic_app
+        gc.collect()
+        self.assertCollected(basic_app_ref)
 
     def test_japanese(self) -> None:
         # Create and run app.

--- a/tests/unit/test_otel_tru_chain.py
+++ b/tests/unit/test_otel_tru_chain.py
@@ -2,6 +2,9 @@
 Tests for OTEL TruChain app.
 """
 
+import gc
+import weakref
+
 import pytest
 from trulens.core.otel.instrument import instrument
 from trulens.otel.semconv.trace import SpanAttributes
@@ -98,3 +101,8 @@ class TestOtelTruChain(tests.util.otel_tru_app_test_case.OtelTruAppTestCase):
         self._compare_events_to_golden_dataframe(
             "tests/unit/static/golden/test_otel_tru_chain__test_smoke.csv"
         )
+        # Check garbage collection.
+        tru_recorder_ref = weakref.ref(tru_recorder)
+        del tru_recorder
+        gc.collect()
+        self.assertCollected(tru_recorder_ref)

--- a/tests/unit/test_otel_tru_chain.py
+++ b/tests/unit/test_otel_tru_chain.py
@@ -102,7 +102,12 @@ class TestOtelTruChain(tests.util.otel_tru_app_test_case.OtelTruAppTestCase):
             "tests/unit/static/golden/test_otel_tru_chain__test_smoke.csv"
         )
         # Check garbage collection.
+        # Note that we need to delete `rag_chain` too since `rag_chain` has
+        # instrument decorators that have closures of the `tru_recorder` object.
+        # Specifically the record root has this at the very least as it calls
+        # `TruChain::main_input` for instance.
         tru_recorder_ref = weakref.ref(tru_recorder)
         del tru_recorder
+        del rag_chain
         gc.collect()
         self.assertCollected(tru_recorder_ref)

--- a/tests/unit/test_otel_tru_custom.py
+++ b/tests/unit/test_otel_tru_custom.py
@@ -2,6 +2,9 @@
 Tests for OTEL instrument decorator and custom app.
 """
 
+import gc
+import weakref
+
 from trulens.apps.app import TruApp
 from trulens.core.otel.instrument import instrument
 from trulens.otel.semconv.trace import SpanAttributes
@@ -80,6 +83,11 @@ class TestOtelTruCustom(tests.util.otel_tru_app_test_case.OtelTruAppTestCase):
         self._compare_events_to_golden_dataframe(
             "tests/unit/static/golden/test_otel_tru_custom__test_smoke.csv"
         )
+        # Check garbage collection.
+        custom_app_ref = weakref.ref(custom_app)
+        del custom_app
+        gc.collect()
+        self.assertCollected(custom_app_ref)
 
     def test_incorrect_span_attributes(self) -> None:
         class MyProblematicApp:

--- a/tests/unit/test_otel_tru_llama.py
+++ b/tests/unit/test_otel_tru_llama.py
@@ -2,6 +2,9 @@
 Tests for OTEL TruLlama app.
 """
 
+import gc
+import weakref
+
 import pytest
 from trulens.otel.semconv.constants import (
     TRULENS_RECORD_ROOT_INSTRUMENT_WRAPPER_FLAG,
@@ -93,6 +96,11 @@ class TestOtelTruLlama(tests.util.otel_tru_app_test_case.OtelTruAppTestCase):
                 (_CONTEXT_RETRIEVAL_REGEX, _CONTEXT_RETRIEVAL_REPLACEMENT)
             ],
         )
+        # Check garbage collection.
+        tru_recorder_ref = weakref.ref(tru_recorder)
+        del tru_recorder
+        gc.collect()
+        self.assertCollected(tru_recorder_ref)
 
     def test_app_specific_record_root(self) -> None:
         rag1 = self._create_simple_rag()

--- a/tests/unit/test_otel_tru_llama.py
+++ b/tests/unit/test_otel_tru_llama.py
@@ -97,8 +97,13 @@ class TestOtelTruLlama(tests.util.otel_tru_app_test_case.OtelTruAppTestCase):
             ],
         )
         # Check garbage collection.
+        # Note that we need to delete `rag` too since `rag` has instrument
+        # decorators that have closures of the `tru_recorder` object.
+        # Specifically the record root has this at the very least as it calls
+        # `TruLlama::main_input`.
         tru_recorder_ref = weakref.ref(tru_recorder)
         del tru_recorder
+        del rag
         gc.collect()
         self.assertCollected(tru_recorder_ref)
 


### PR DESCRIPTION
# Description
Check that wrapped apps are garbage collected correctly.

## Other details good to know for developers
This caused a problem in https://github.com/truera/trulens/pull/1982 in a confusing way so I want to make sure we test this.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add garbage collection checks in test files to ensure wrapped apps are collected correctly.
> 
>   - **Tests**:
>     - Add garbage collection checks using `weakref` and `gc` in `test_otel_tru_basic.py`, `test_otel_tru_chain.py`, `test_otel_tru_custom.py`, and `test_otel_tru_llama.py`.
>     - Ensure wrapped apps are garbage collected correctly by deleting app instances and invoking `gc.collect()`.
>     - Use `assertCollected` to verify that the apps are collected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for e6f37edc28965abe85b2764aaefc7417bc6829f3. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->