### PR TITLE
Start evaluator immediately and also require that `FeedbackMode` must be `WITH_APP_THREAD` (the default).

### DIFF
--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -521,6 +521,15 @@ class App(
 
         super().__init__(**kwargs)
 
+        if (
+            is_otel_tracing_enabled()
+            and self.feedback_mode
+            != feedback_schema.FeedbackMode.WITH_APP_THREAD
+        ):
+            raise ValueError(
+                "Cannot use `feedback_mode` other than `WITH_APP_THREAD` with OTel tracing!"
+            )
+
         if main_method:
             self.main_method_name = main_method.__name__  # for serialization
 
@@ -562,7 +571,10 @@ class App(
             pass
 
         if self.feedback_mode == feedback_schema.FeedbackMode.WITH_APP_THREAD:
-            self._start_manage_pending_feedback_results()
+            if is_otel_tracing_enabled():
+                self.start_evaluator()
+            else:
+                self._start_manage_pending_feedback_results()
 
         self._tru_post_init()
 

--- a/src/core/trulens/core/session.py
+++ b/src/core/trulens/core/session.py
@@ -30,6 +30,7 @@ from trulens.core._utils import optional as optional_utils
 from trulens.core._utils.pycompat import Future  # code style exception
 from trulens.core.database import connector as core_connector
 from trulens.core.feedback import feedback as core_feedback
+from trulens.core.otel.utils import is_otel_tracing_enabled
 from trulens.core.schema import app as app_schema
 from trulens.core.schema import dataset as dataset_schema
 from trulens.core.schema import feedback as feedback_schema
@@ -38,7 +39,6 @@ from trulens.core.schema import record as record_schema
 from trulens.core.schema import types as types_schema
 from trulens.core.utils import deprecation as deprecation_utils
 from trulens.core.utils import imports as import_utils
-from trulens.core.utils import otel as otel_utils
 from trulens.core.utils import python as python_utils
 from trulens.core.utils import serial as serial_utils
 from trulens.core.utils import text as text_utils
@@ -930,7 +930,7 @@ class TruSession(
 
             [MAX_THREADS][trulens.core.utils.threading.TP.MAX_THREADS]
         """
-        if otel_utils.is_otel_tracing_enabled():
+        if is_otel_tracing_enabled():
             raise ValueError(
                 "Deferred evaluator not supported with OTEL tracing!"
             )

--- a/src/core/trulens/core/session.py
+++ b/src/core/trulens/core/session.py
@@ -38,6 +38,7 @@ from trulens.core.schema import record as record_schema
 from trulens.core.schema import types as types_schema
 from trulens.core.utils import deprecation as deprecation_utils
 from trulens.core.utils import imports as import_utils
+from trulens.core.utils import otel as otel_utils
 from trulens.core.utils import python as python_utils
 from trulens.core.utils import serial as serial_utils
 from trulens.core.utils import text as text_utils
@@ -929,6 +930,10 @@ class TruSession(
 
             [MAX_THREADS][trulens.core.utils.threading.TP.MAX_THREADS]
         """
+        if otel_utils.is_otel_tracing_enabled():
+            raise ValueError(
+                "Deferred evaluator not supported with OTEL tracing!"
+            )
 
         assert not fork, "Fork mode not yet implemented."
         assert (

--- a/src/core/trulens/core/utils/evaluator.py
+++ b/src/core/trulens/core/utils/evaluator.py
@@ -122,7 +122,7 @@ class Evaluator:
                     TruSession().force_flush()
                     if self._stop_event.is_set():
                         break
-                for _ in range(60):
+                for _ in range(10):
                     if self._stop_event.is_set():
                         break
                     time.sleep(1)

--- a/tests/unit/test_otel_feedback_computation.py
+++ b/tests/unit/test_otel_feedback_computation.py
@@ -497,7 +497,6 @@ class TestOtelFeedbackComputation(OtelTestCase):
     def test_evaluator(self) -> None:
         tru_recorder = self._create_invoked_app_with_custom_feedback()
         num_events = len(self._get_events())
-        tru_recorder.start_evaluator()
         # Wait for there to be a feedback computed.
         self._wait(lambda: len(self._get_events()) > num_events)
         events = self._get_events()


### PR DESCRIPTION
# Description
Start evaluator immediately and also require that `FeedbackMode` must be `WITH_APP_THREAD` (the default).

## Other details good to know for developers

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Start evaluator immediately with `WITH_APP_THREAD` mode and enforce this mode when OTEL tracing is enabled.
> 
>   - **Behavior**:
>     - In `app.py`, start evaluator immediately if `FeedbackMode` is `WITH_APP_THREAD` and OTEL tracing is enabled.
>     - Raise `ValueError` in `app.py` if `FeedbackMode` is not `WITH_APP_THREAD` when OTEL tracing is enabled.
>     - In `session.py`, raise `ValueError` in `start_evaluator` if OTEL tracing is enabled.
>   - **Evaluator**:
>     - In `evaluator.py`, reduce sleep loop from 60 to 10 seconds in `_run_evaluator()`.
>   - **Tests**:
>     - In `test_otel_feedback_computation.py`, remove `start_evaluator()` call in `test_evaluator()` as evaluator starts automatically.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 8abdcca08577f20717c7302e491290ab5b63fdaf. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->