### PR TITLE
Allow use of `Feedback`'s `on_input`, `on_output`, `on_input_output`, `on_default` methods.

### DIFF
--- a/src/core/trulens/core/feedback/feedback.py
+++ b/src/core/trulens/core/feedback/feedback.py
@@ -316,10 +316,17 @@ class Feedback(feedback_schema.FeedbackDefinition):
         num_remaining_parameters = len(
             list(k for k in sig.parameters.keys() if k not in self.selectors)
         )
+        if num_remaining_parameters == 0:
+            return self
         if num_remaining_parameters == 1:
-            return self.on_response()
+            # If there is only one parameter left, we assume it is the output.
+            return self.on_output()
         if num_remaining_parameters == 2:
+            # If there are two parameters left, we assume they are the input
+            # and output.
             return self.on_input_output()
+        # If there are more than two parameters left, we cannot guess what to
+        # do.
         raise RuntimeError(
             f"Cannot determine default paths for feedback function arguments. "
             f"The feedback function has signature {sig}."

--- a/src/core/trulens/core/feedback/feedback.py
+++ b/src/core/trulens/core/feedback/feedback.py
@@ -33,6 +33,8 @@ from rich.markdown import Markdown
 from rich.pretty import pretty_repr
 from trulens.core._utils import pycompat as pycompat_utils
 from trulens.core.feedback import endpoint as core_endpoint
+from trulens.core.feedback.selector import RECORD_ROOT_INPUT
+from trulens.core.feedback.selector import RECORD_ROOT_OUTPUT
 from trulens.core.feedback.selector import Selector
 from trulens.core.otel.utils import is_otel_tracing_enabled
 from trulens.core.schema import app as app_schema
@@ -306,13 +308,27 @@ class Feedback(feedback_schema.FeedbackDefinition):
         Returns a new Feedback object with this specification.
         """
 
-        ret = Feedback.model_copy(self)
-
-        ret._default_selectors()
-
-        return ret
+        if self.imp is None:
+            raise ValueError(
+                "Feedback function implementation is required to determine default argument names."
+            )
+        sig: Signature = signature(self.imp)
+        num_remaining_parameters = len(
+            list(k for k in sig.parameters.keys() if k not in self.selectors)
+        )
+        if num_remaining_parameters == 1:
+            return self.on_response()
+        if num_remaining_parameters == 2:
+            return self.on_input_output()
+        raise RuntimeError(
+            f"Cannot determine default paths for feedback function arguments. "
+            f"The feedback function has signature {sig}."
+        )
 
     def _print_guessed_selector(self, par_name, par_path):
+        if is_otel_tracing_enabled():
+            return
+
         if par_path == select_schema.Select.RecordCalls:
             alias_info = " or `Select.RecordCalls`"
         elif par_path == select_schema.Select.RecordInput:
@@ -326,54 +342,6 @@ class Feedback(feedback_schema.FeedbackDefinition):
             f"{text_utils.UNICODE_CHECK} In {self.supplied_name if self.supplied_name is not None else self.name}, "
             f"input {par_name} will be set to {par_path}{alias_info} ."
         )
-
-    def _default_selectors(self):
-        """
-        Fill in default selectors for any remaining feedback function arguments.
-        """
-
-        assert (
-            self.imp is not None
-        ), "Feedback function implementation is required to determine default argument names."
-
-        sig: Signature = signature(self.imp)
-        par_names = list(
-            k for k in sig.parameters.keys() if k not in self.selectors
-        )
-
-        if len(par_names) == 1:
-            # A single argument remaining. Assume it is record output.
-            selectors = {par_names[0]: select_schema.Select.RecordOutput}
-            self._print_guessed_selector(
-                par_names[0], select_schema.Select.RecordOutput
-            )
-
-            # TODO: replace with on_output ?
-
-        elif len(par_names) == 2:
-            # Two arguments remaining. Assume they are record input and output
-            # respectively.
-            selectors = {
-                par_names[0]: select_schema.Select.RecordInput,
-                par_names[1]: select_schema.Select.RecordOutput,
-            }
-            self._print_guessed_selector(
-                par_names[0], select_schema.Select.RecordInput
-            )
-            self._print_guessed_selector(
-                par_names[1], select_schema.Select.RecordOutput
-            )
-
-            # TODO: replace on_input_output ?
-        else:
-            # Otherwise give up.
-
-            raise RuntimeError(
-                f"Cannot determine default paths for feedback function arguments. "
-                f"The feedback function has signature {sig}."
-            )
-
-        self.selectors = selectors
 
     @staticmethod
     def evaluate_deferred(
@@ -585,7 +553,10 @@ class Feedback(feedback_schema.FeedbackDefinition):
             arg = self._next_unselected_arg_name()
             self._print_guessed_selector(arg, select_schema.Select.RecordInput)
 
-        new_selectors[arg] = select_schema.Select.RecordInput
+        if is_otel_tracing_enabled():
+            new_selectors[arg] = RECORD_ROOT_INPUT
+        else:
+            new_selectors[arg] = select_schema.Select.RecordInput
 
         ret = self.model_copy()
 
@@ -608,7 +579,10 @@ class Feedback(feedback_schema.FeedbackDefinition):
             arg = self._next_unselected_arg_name()
             self._print_guessed_selector(arg, select_schema.Select.RecordOutput)
 
-        new_selectors[arg] = select_schema.Select.RecordOutput
+        if is_otel_tracing_enabled():
+            new_selectors[arg] = RECORD_ROOT_OUTPUT
+        else:
+            new_selectors[arg] = select_schema.Select.RecordOutput
 
         ret = self.model_copy()
 
@@ -638,6 +612,7 @@ class Feedback(feedback_schema.FeedbackDefinition):
                 )
             sig = signature(self.imp)
             feedback_function_parameters = set(sig.parameters.keys())
+            new_selectors = self.selectors.copy()
             for k, v in selectors.items():
                 if not isinstance(k, str):
                     raise ValueError(
@@ -651,8 +626,9 @@ class Feedback(feedback_schema.FeedbackDefinition):
                     raise ValueError(
                         f"OTEL mode only supports Selector values, not {type(v)}!"
                     )
+                new_selectors[k] = v
             ret = self.model_copy()
-            ret.selectors = selectors
+            ret.selectors = new_selectors
             return ret
 
         new_selectors = self.selectors.copy()

--- a/src/core/trulens/core/feedback/selector.py
+++ b/src/core/trulens/core/feedback/selector.py
@@ -111,3 +111,14 @@ class Selector:
                 )
             ret.value = attributes.get(ret.span_attribute, None)
         return ret
+
+
+# Common Selectors.
+RECORD_ROOT_INPUT = Selector(
+    span_type=SpanAttributes.SpanType.RECORD_ROOT,
+    span_attribute=SpanAttributes.RECORD_ROOT.INPUT,
+)
+RECORD_ROOT_OUTPUT = Selector(
+    span_type=SpanAttributes.SpanType.RECORD_ROOT,
+    span_attribute=SpanAttributes.RECORD_ROOT.OUTPUT,
+)

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -671,6 +671,8 @@ trulens.core.feedback.selector:
   __class__: builtins.module
   highs: {}
   lows:
+    RECORD_ROOT_INPUT: trulens.core.feedback.selector.Selector
+    RECORD_ROOT_OUTPUT: trulens.core.feedback.selector.Selector
     Selector: builtins.type
 trulens.core.feedback.selector.Selector:
   __bases__:

--- a/tests/unit/test_otel_feedback.py
+++ b/tests/unit/test_otel_feedback.py
@@ -1,0 +1,61 @@
+from trulens.core.feedback import Feedback
+from trulens.core.feedback.selector import RECORD_ROOT_INPUT
+from trulens.core.feedback.selector import RECORD_ROOT_OUTPUT
+
+from tests.util.otel_test_case import OtelTestCase
+
+"""
+Tests for OTEL Feedback methods.
+"""
+
+
+class TestOtelFeedback(OtelTestCase):
+    def _mock_feedback_function_1(self, x: str) -> float:
+        return 0.1
+
+    def _mock_feedback_function_2(self, x: str, y: str) -> float:
+        return 0.2
+
+    def _mock_feedback_function_3(self, x: str, y: str, z: str) -> float:
+        return 0.3
+
+    def test_on_input(self) -> None:
+        feedback = Feedback(self._mock_feedback_function_1).on_input()
+        self.assertEqual(feedback.selectors, {"x": RECORD_ROOT_INPUT})
+        feedback = Feedback(self._mock_feedback_function_2).on_input()
+        self.assertEqual(feedback.selectors, {"x": RECORD_ROOT_INPUT})
+        feedback = Feedback(self._mock_feedback_function_3).on_input()
+        self.assertEqual(feedback.selectors, {"x": RECORD_ROOT_INPUT})
+
+    def test_on_output(self) -> None:
+        feedback = Feedback(self._mock_feedback_function_1).on_output()
+        self.assertEqual(feedback.selectors, {"x": RECORD_ROOT_OUTPUT})
+        feedback = Feedback(self._mock_feedback_function_2).on_output()
+        self.assertEqual(feedback.selectors, {"x": RECORD_ROOT_OUTPUT})
+        feedback = Feedback(self._mock_feedback_function_3).on_output()
+        self.assertEqual(feedback.selectors, {"x": RECORD_ROOT_OUTPUT})
+
+    def test_on_input_output(self) -> None:
+        with self.assertRaises(TypeError):
+            Feedback(self._mock_feedback_function_1).on_input_output()
+        feedback = Feedback(self._mock_feedback_function_2).on_input_output()
+        self.assertEqual(
+            feedback.selectors,
+            {"x": RECORD_ROOT_INPUT, "y": RECORD_ROOT_OUTPUT},
+        )
+        feedback = Feedback(self._mock_feedback_function_3).on_input_output()
+        self.assertEqual(
+            feedback.selectors,
+            {"x": RECORD_ROOT_INPUT, "y": RECORD_ROOT_OUTPUT},
+        )
+
+    def test_on_default(self) -> None:
+        feedback = Feedback(self._mock_feedback_function_1).on_default()
+        self.assertEqual(feedback.selectors, {"x": RECORD_ROOT_OUTPUT})
+        feedback = Feedback(self._mock_feedback_function_2).on_default()
+        self.assertEqual(
+            feedback.selectors,
+            {"x": RECORD_ROOT_INPUT, "y": RECORD_ROOT_OUTPUT},
+        )
+        with self.assertRaises(RuntimeError):
+            Feedback(self._mock_feedback_function_3).on_default()

--- a/tests/unit/test_otel_feedback.py
+++ b/tests/unit/test_otel_feedback.py
@@ -1,12 +1,12 @@
+"""
+Tests for OTEL Feedback methods.
+"""
+
 from trulens.core.feedback import Feedback
 from trulens.core.feedback.selector import RECORD_ROOT_INPUT
 from trulens.core.feedback.selector import RECORD_ROOT_OUTPUT
 
 from tests.util.otel_test_case import OtelTestCase
-
-"""
-Tests for OTEL Feedback methods.
-"""
 
 
 class TestOtelFeedback(OtelTestCase):


### PR DESCRIPTION
# Description
Allow use of `Feedback`'s `on_input`, `on_output`, `on_input_output`, `on_default` methods.

Also, introduce default `Selector`'s for record root input and output.

## Other details good to know for developers

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add new `Feedback` methods for input/output handling and default selectors, with corresponding tests.
> 
>   - **Behavior**:
>     - Enable `Feedback` methods `on_input`, `on_output`, `on_input_output`, `on_default` in `feedback.py`.
>     - Introduce default `Selector` for root input and output in `selector.py`.
>   - **Tests**:
>     - Add `TestOtelFeedback` in `test_otel_feedback.py` to test new `Feedback` methods.
>   - **Misc**:
>     - Remove `_default_selectors` method from `feedback.py`.
>     - Update `api.trulens.3.11.yaml` to include new selectors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for cbda47bc9ca44c96d82bc1a1ad04e175bc218603. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->