### PR TITLE
[SNOW-2111562] Render feedback visualizations for OTEL records

### DIFF
--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -1115,7 +1115,7 @@ class SQLAlchemyDB(core_db.DB):
                                     SpanAttributes.EVAL_ROOT.SCORE, 0.0
                                 )
                             )
-                            # NOTE: HIGHER_IS_BETTER has not been populated in the OTEL spans yet
+                            # TODO(SNOW-2112879): HIGHER_IS_BETTER has not been populated in the OTEL spans yet
                             feedback_result["direction"] = (
                                 record_attributes.get(
                                     SpanAttributes.EVAL_ROOT.HIGHER_IS_BETTER,
@@ -1125,7 +1125,7 @@ class SQLAlchemyDB(core_db.DB):
 
                         # Add call data
                         call_data = {
-                            # NOTE: Call data may not be populated in the OTEL spans yet
+                            # TODO(SNOW-2112879): Call data may not be populated in the OTEL spans yet
                             "args": record_attributes.get(
                                 SpanAttributes.CALL.KWARGS, {}
                             ),

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -1125,6 +1125,7 @@ class SQLAlchemyDB(core_db.DB):
 
                         # Add call data
                         call_data = {
+                            # NOTE: Call data may not be populated in the OTEL spans yet
                             "kwargs": record_attributes.get(
                                 SpanAttributes.CALL.KWARGS, {}
                             ),

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -1126,7 +1126,7 @@ class SQLAlchemyDB(core_db.DB):
                         # Add call data
                         call_data = {
                             # NOTE: Call data may not be populated in the OTEL spans yet
-                            "kwargs": record_attributes.get(
+                            "args": record_attributes.get(
                                 SpanAttributes.CALL.KWARGS, {}
                             ),
                             "ret": record_attributes.get(

--- a/src/dashboard/trulens/dashboard/utils/records_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/records_utils.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Optional, Sequence
 import pandas as pd
 import streamlit as st
 from trulens.core.database.base import MULTI_CALL_NAME_DELIMITER
-from trulens.core.otel.utils import is_otel_tracing_enabled
 from trulens.dashboard.display import expand_groundedness_df
 from trulens.dashboard.display import highlight
 from trulens.dashboard.ux.styles import CATEGORY
@@ -64,16 +63,13 @@ def display_feedback_call(
         # second or other column is a list, it will not do
         # this.
 
-        # NOTE: see https://github.com/truera/trulens/pull/1939#discussion_r2061174909
-        args_col_name = "kwargs" if is_otel_tracing_enabled() else "args"
-
         for c in call:
-            args: Dict = c[args_col_name]
+            args: Dict = c["args"]
             for k, v in args.items():
                 if not isinstance(v, str):
                     args[k] = pp.pformat(v)
 
-        df = pd.DataFrame.from_records(c[args_col_name] for c in call)
+        df = pd.DataFrame.from_records(c["args"] for c in call)
 
         df["score"] = pd.DataFrame([
             float(call[i]["ret"]) if call[i]["ret"] is not None else -1

--- a/src/dashboard/trulens/dashboard/utils/records_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/records_utils.py
@@ -62,7 +62,6 @@ def display_feedback_call(
         # multiple rows, one for each element, but if the
         # second or other column is a list, it will not do
         # this.
-
         for c in call:
             args: Dict = c["args"]
             for k, v in args.items():


### PR DESCRIPTION
# Description

[SNOW-2111562](https://snowflakecomputing.atlassian.net/browse/SNOW-2111562):
- Enable OTEL records and feedback to properly visualize on the Streamlit UI (`Compare` and `Records` pages).
- Note: this relies on OTEL feedback calls to be appropriately populated -- there are some follow-up tasks on the backend (e.g. populating higher_is_better, individual eval scores, metas, etc.) -- tracked here: [SNOW-2112879](https://snowflakecomputing.atlassian.net/browse/SNOW-2112879).
- Tested using `test_otel_quickstart.ipynb`.

## Other details good to know for developers

![Screenshot 2025-05-19 at 4 36 47 PM](https://github.com/user-attachments/assets/cadff03e-818d-4feb-9eef-8d1be3b21c8c)
![Screenshot 2025-05-19 at 3 43 54 PM](https://github.com/user-attachments/assets/118b667b-efe6-46f4-9634-143e51a25905)
![Screenshot 2025-05-19 at 3 43 24 PM](https://github.com/user-attachments/assets/692d122a-f7b7-4691-afd8-44c90d7d4554)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances `_get_records_and_feedback_otel` in `sqlalchemy.py` to support feedback visualization for OTEL records, including call data extraction and feedback result handling.
> 
>   - **Behavior**:
>     - Enhances `_get_records_and_feedback_otel` in `sqlalchemy.py` to support feedback visualization for OTEL records.
>     - Extracts call data and handles feedback results, including mean score and cost information.
>   - **Misc**:
>     - Renames `kwargs` to `args` in call data dictionary in `_get_records_and_feedback_otel`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 644814d23be5098cba5b7523ee1051dc32ce75c9. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->