### PR TITLE
Make old `@instrument` decorator work in OTel world.

### DIFF
--- a/tests/e2e/test_snowflake_event_table_exporter.py
+++ b/tests/e2e/test_snowflake_event_table_exporter.py
@@ -146,7 +146,7 @@ class TestSnowflakeEventTableExporter(SnowflakeTestCase):
             TruApp,
             {"input": "custom_input"},
             pd.DataFrame({"custom_input": ["Kojikun", "Nolan"]}),
-            10,
+            8,
         )
 
     def test_tru_llama(self):

--- a/tests/unit/test_otel_legacy_compatibility.py
+++ b/tests/unit/test_otel_legacy_compatibility.py
@@ -2,11 +2,20 @@ import importlib
 import os
 
 import trulens.apps.app
+from trulens.apps.app import TruApp
 from trulens.apps.app import instrument as legacy_instrument
 from trulens.core.otel.instrument import instrument as otel_instrument
 from trulens.core.otel.utils import is_otel_tracing_enabled
+from trulens.core.session import TruSession
+from trulens.otel.semconv.trace import SpanAttributes
 
 from tests.util.otel_test_case import OtelTestCase
+
+
+class _LegacyTestApp:
+    @legacy_instrument
+    def respond_to_query(self, query: str) -> str:
+        return f"response to {query}"
 
 
 class TestOtelLegacyCompatibility(OtelTestCase):
@@ -19,7 +28,7 @@ class TestOtelLegacyCompatibility(OtelTestCase):
         os.environ["TRULENS_OTEL_TRACING"] = "1"
         super().setUpClass()
 
-    def test_legacy_instrument(self) -> None:
+    def test_import(self) -> None:
         from trulens.apps.app import instrument
 
         self.assertIs(instrument, legacy_instrument)
@@ -27,3 +36,32 @@ class TestOtelLegacyCompatibility(OtelTestCase):
         from trulens.apps.app import instrument
 
         self.assertIsInstance(instrument, otel_instrument)
+
+    def test_legacy_app(self) -> None:
+        app = _LegacyTestApp()
+        tru_app = TruApp(
+            app,
+            main_method=app.respond_to_query,  # TODO(otel): This is not backwards compatible!
+            app_name="MyCustomApp",
+            app_version="v1",
+        )
+        with tru_app as recording:
+            app.respond_to_query("test")
+        TruSession().force_flush()
+        events = self._get_events()
+        self.assertEqual(1, len(events))
+        record_attributes = events["record_attributes"].iloc[0]
+        self.assertEqual(
+            SpanAttributes.SpanType.RECORD_ROOT,
+            record_attributes[SpanAttributes.SPAN_TYPE],
+        )
+        self.assertEqual(
+            "test", record_attributes[SpanAttributes.RECORD_ROOT.INPUT]
+        )
+        self.assertEqual(
+            "response to test",
+            record_attributes[SpanAttributes.RECORD_ROOT.OUTPUT],
+        )
+        self.assertIsNone(
+            recording
+        )  # TODO(otel): This is not backwards compatible!

--- a/tests/unit/test_otel_tru_custom.py
+++ b/tests/unit/test_otel_tru_custom.py
@@ -57,11 +57,7 @@ class TestApp:
     def nested3(self, query: str) -> str:
         if query == "throw":
             raise ValueError("nested3 exception")
-        return self.nested4(query)
-
-    @instrument
-    def nested4(self, query: str) -> str:
-        return "nested4"
+        return "nested3"
 
 
 class TestOtelTruCustom(tests.util.otel_tru_app_test_case.OtelTruAppTestCase):


### PR DESCRIPTION
# Description
Make old `@instrument` decorator work in OTel world.

I had a previous PR to do something similar to this in https://github.com/truera/trulens/pull/1765, but that allows even the new OTel `@instrument` decorator to work without parentheses --- which I'm not sure we want to allow yet.

## Other details good to know for developers

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces `legacy_instrument` for legacy `@instrument` compatibility with OTel, with conditional assignment and new tests.
> 
>   - **Behavior**:
>     - Introduces `legacy_instrument` class in `app.py` to support legacy `@instrument` decorator.
>     - Conditionally assigns `instrument` to `otel_instrument` or `legacy_instrument` based on `is_otel_tracing_enabled()`.
>   - **Testing**:
>     - Adds `test_otel_legacy_compatibility.py` to verify legacy `@instrument` compatibility with OTel.
>     - Tests ensure `instrument` is correctly assigned and legacy apps function with OTel tracing enabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 79a585a280fc6719b843f9ef02e1a0a47b1c7b79. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->