### PR TITLE
Make sure to clean up context manager after using it once.

### DIFF
--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -1104,6 +1104,7 @@ class App(
                 if self._current_context_manager is None:
                     raise RuntimeError("Unknown recording context manager!")
                 context_manager = self._current_context_manager
+                self._current_context_manager = None
             return context_manager.__exit__(exc_type, exc_value, exc_tb)
 
         self._prevent_invalid_otel_syntax()

--- a/src/trulens_eval/trulens_eval/tru_custom_app.py
+++ b/src/trulens_eval/trulens_eval/tru_custom_app.py
@@ -9,6 +9,6 @@ from trulens.core.utils import deprecation as deprecation_utils
 
 deprecation_utils.packages_dep_warn()
 
-from trulens.apps.custom import instrument
 from trulens.apps.custom import PLACEHOLDER
 from trulens.apps.custom import TruCustomApp
+from trulens.apps.custom import instrument

--- a/tests/unit/test_otel_tru_custom.py
+++ b/tests/unit/test_otel_tru_custom.py
@@ -83,6 +83,9 @@ class TestOtelTruCustom(tests.util.otel_tru_app_test_case.OtelTruAppTestCase):
         self._compare_events_to_golden_dataframe(
             "tests/unit/static/golden/test_otel_tru_custom__test_smoke.csv"
         )
+        # Check we can still call the app after recording once.
+        with custom_app:
+            test_app.respond_to_query("throw")
         # Check garbage collection.
         custom_app_ref = weakref.ref(custom_app)
         del custom_app


### PR DESCRIPTION
# Description
Make sure to clean up context manager after using it once.

## Other details good to know for developers

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix context manager cleanup in `app.py` and add test for reuse in `test_otel_tru_custom.py`.
> 
>   - **Bug Fix**:
>     - In `app.py`, reset `_current_context_manager` to `None` after use in `__exit__()` to ensure proper cleanup.
>   - **Imports**:
>     - Reorder imports in `tru_custom_app.py` for consistency.
>   - **Tests**:
>     - Add test in `test_otel_tru_custom.py` to verify app can be called after recording once.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for c85667429e3e3424bd8d9668fb44df7948891417. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->