### PR TITLE
[Minor] Allow trulens_trace to handle both record (pre-otel) and record id string (otel)

### DIFF
--- a/src/dashboard/trulens/dashboard/streamlit.py
+++ b/src/dashboard/trulens/dashboard/streamlit.py
@@ -3,14 +3,13 @@ import asyncio
 import json
 import math
 import sys
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from pydantic import BaseModel
 import streamlit as st
 from trulens.core import session as core_session
 from trulens.core.database import base as core_db
 from trulens.core.database.legacy import migration as legacy_migration
-from trulens.core.otel.utils import is_otel_tracing_enabled
 from trulens.core.schema import feedback as feedback_schema
 from trulens.core.schema import record as record_schema
 from trulens.core.utils import json as json_utils
@@ -310,23 +309,24 @@ def trulens_feedback(record: record_schema.Record):
         st.dataframe(styled_df, hide_index=True)
 
 
-def trulens_trace(record: record_schema.Record):
+def trulens_trace(record: Union[record_schema.Record, str]):
     """Display the trace view for a record.
 
     Args:
-
-        record: A trulens record.
+        record: Either a trulens record (non-OTel) or a record_id string (OTel).
 
     Example:
         ```python
         from trulens.core import streamlit as trulens_st
 
+        # Using with Record object
         with tru_llm as recording:
             response = llm.invoke(input_text)
-
         record, response = recording.get()
-
         trulens_st.trulens_trace(record=record)
+
+        # Using with record_id string
+        trulens_st.trulens_trace(record="record_123")
         ```
     """
 
@@ -336,17 +336,14 @@ def trulens_trace(record: record_schema.Record):
         st.warning(
             "TruLens trace view is not enabled when SiS compatibility is enabled."
         )
-    elif is_otel_tracing_enabled():
-        # NOTE: Given that this method relies on the Record table, I'm unsure if this block will ever
-        # get called because OTEL spans use the Event table instead of the Record table.
-        # TODO: Consider writing a separate method for OTEL.
-        event_spans = _get_event_otel_spans(record.record_id)
+    elif isinstance(record, str):
+        event_spans = _get_event_otel_spans(record)
         if event_spans:
             dashboard_record_viewer_otel.record_viewer_otel(
                 spans=event_spans, key=None
             )
         else:
-            st.warning("No trace data available for this record.")
+            st.warning("No OTel trace data available for this record.")
     else:
         dashboard_record_viewer.record_viewer(
             record_json=json.loads(json_utils.json_str_of_obj(record)),


### PR DESCRIPTION
# Description

`trulens_trace()` can now handle both pre-otel and otel records

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `trulens_trace` in `streamlit.py` to handle both pre-otel `Record` objects and otel `record_id` strings.
> 
>   - **Functionality**:
>     - `trulens_trace` in `streamlit.py` now accepts `Union[record_schema.Record, str]` for `record` parameter.
>     - Handles both pre-otel `Record` objects and otel `record_id` strings.
>     - Uses `_get_event_otel_spans` for otel records and displays with `record_viewer_otel`.
>   - **Behavior**:
>     - If `record` is a string, fetches otel spans and displays them.
>     - If no otel spans are found, shows a warning "No OTel trace data available for this record."
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 710d4b35addd8d16e5e00e62e757ad94313c3f2a. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->