### PR TITLE
Create `Recording` when using a `App` as a context manager.

### DIFF
--- a/src/core/trulens/core/otel/function_call_context_manager.py
+++ b/src/core/trulens/core/otel/function_call_context_manager.py
@@ -36,6 +36,9 @@ class CreateSpanFunctionCallContextManager:
                 self.token = context_api.attach(
                     set_baggage(SpanAttributes.RECORD_ID, record_id)
                 )
+                recording = get_baggage("__trulens_recording__")
+                if recording is not None:
+                    recording.add_record_id(record_id)
         # Create span.
         self.span_context_manager = (
             trace.get_tracer_provider()

--- a/tests/unit/test_otel_legacy_compatibility.py
+++ b/tests/unit/test_otel_legacy_compatibility.py
@@ -62,6 +62,7 @@ class TestOtelLegacyCompatibility(OtelTestCase):
             "response to test",
             record_attributes[SpanAttributes.RECORD_ROOT.OUTPUT],
         )
-        self.assertIsNone(
-            recording
-        )  # TODO(otel): This is not backwards compatible!
+        self.assertEqual(1, len(recording))
+        self.assertEqual(
+            record_attributes[SpanAttributes.RECORD_ID], recording.get()
+        )

--- a/tests/unit/test_otel_recording_contexts.py
+++ b/tests/unit/test_otel_recording_contexts.py
@@ -51,9 +51,19 @@ class TestOtelRecordingContexts(OtelTestCase):
                 self.assertEqual(value, event["record_attributes"][attribute])
 
     def test_legacy(self):
-        with self._tru_recorder:
+        with self._tru_recorder as recording:
             self._app.greet(name="Kojikun")
         self._validate()
+        events = self._get_events()
+        self.assertEqual(len(recording), 1)
+        self.assertEqual(
+            events.iloc[0]["record_attributes"][SpanAttributes.RECORD_ID],
+            recording.get(),
+        )
+        self.assertEqual(
+            events.iloc[0]["record_attributes"][SpanAttributes.RECORD_ID],
+            recording[0],
+        )
 
     def test_new(self):
         with self._tru_recorder.run("test_run"):


### PR DESCRIPTION
# Description
Create `Recording` when using a `App` as a context manager.

This is more backwards compatible than before since @joshreini1 said he uses this functionality. @nikhil-vytla is also adding being able to use this for `trulens_feedback` and `trulens_trace`.

## Other details good to know for developers

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Create `Recording` when using `App` as a context manager to manage record IDs, with tests updated to validate this behavior.
> 
>   - **Behavior**:
>     - `Recording` object created when using `App` as a context manager in `OtelRecordingContext.__enter__()`.
>     - `Recording` stores record IDs and provides methods to access them.
>   - **Classes**:
>     - New `Recording` class with methods `add_record_id`, `get`, `__getitem__`, and `__len__`.
>   - **Tests**:
>     - Updated `test_otel_legacy_compatibility.py` and `test_otel_recording_contexts.py` to validate `Recording` creation and record ID management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 1a412eb329d00127020d77b62dc7ff7ecf68d2e6. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->