### PR TITLE
Have `recording.get` wait for record to show up in event table before giving to user.

### DIFF
--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -404,12 +404,12 @@ class Recording:
     def add_record_id(self, record_id: str) -> None:
         self.record_ids.append(record_id)
 
-    def get(self, wait_till_in_database: bool = True) -> str:
+    def get(self, wait_for_record: bool = True) -> str:
         """
         Assumes there is exactly one record ID in the recording and returns it.
 
         Args:
-            wait_till_in_database:
+            wait_for_record:
                 Whether to wait until the record is in the database.
 
         Returns:
@@ -419,21 +419,13 @@ class Recording:
             raise RuntimeError("No record IDs found!")
         if len(self.record_ids) != 1:
             raise RuntimeError("There are multiple records!")
-        if wait_till_in_database:
-            self._wait_for_record(self.record_ids[0])
+        if wait_for_record:
+            TruSession().wait_for_record(self.record_ids[0], timeout=180)
         return self.record_ids[0]
 
     def __getitem__(self, index: int) -> str:
-        self._wait_for_record(self.record_ids[index])
+        TruSession().wait_for_record(self.record_ids[index], timeout=180)
         return self.record_ids[index]
-
-    @staticmethod
-    def _wait_for_record(record_id: str) -> None:
-        res = TruSession().wait_for_record(record_id, timeout=180)
-        if res is None:
-            raise RuntimeError(
-                f"Record with ID {record_id} not found in database!"
-            )
 
     def __len__(self) -> int:
         return len(self.record_ids)

--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -405,6 +405,16 @@ class Recording:
         self.record_ids.append(record_id)
 
     def get(self, wait_till_in_database: bool = True) -> str:
+        """
+        Assumes there is exactly one record ID in the recording and returns it.
+
+        Args:
+            wait_till_in_database:
+                Whether to wait until the record is in the database.
+
+        Returns:
+            The single record ID of the recording.
+        """
         if len(self.record_ids) == 0:
             raise RuntimeError("No record IDs found!")
         if len(self.record_ids) != 1:

--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -16,6 +16,7 @@ from trulens.core.otel.function_call_context_manager import (
     create_function_call_context_manager,
 )
 from trulens.core.schema.app import AppDefinition
+from trulens.core.session import TruSession
 from trulens.experimental.otel_tracing.core.session import TRULENS_SERVICE_NAME
 from trulens.experimental.otel_tracing.core.span import Attributes
 from trulens.experimental.otel_tracing.core.span import (
@@ -403,15 +404,26 @@ class Recording:
     def add_record_id(self, record_id: str) -> None:
         self.record_ids.append(record_id)
 
-    def get(self) -> str:
+    def get(self, wait_till_in_database: bool = True) -> str:
         if len(self.record_ids) == 0:
             raise RuntimeError("No record IDs found!")
         if len(self.record_ids) != 1:
             raise RuntimeError("There are multiple records!")
+        if wait_till_in_database:
+            self._wait_for_record(self.record_ids[0])
         return self.record_ids[0]
 
     def __getitem__(self, index: int) -> str:
+        self._wait_for_record(self.record_ids[index])
         return self.record_ids[index]
+
+    @staticmethod
+    def _wait_for_record(record_id: str) -> None:
+        res = TruSession().wait_for_record(record_id, timeout=180)
+        if res is None:
+            raise RuntimeError(
+                f"Record with ID {record_id} not found in database!"
+            )
 
     def __len__(self) -> int:
         return len(self.record_ids)

--- a/src/core/trulens/core/session.py
+++ b/src/core/trulens/core/session.py
@@ -1189,6 +1189,8 @@ class TruSession(
         Returns:
             The record_id if found, else None.
         """
+        if is_otel_tracing_enabled():
+            self.force_flush()
         start_time = time()
         while time() - start_time < timeout:
             records_df, _ = self.get_records_and_feedback()

--- a/src/core/trulens/core/session.py
+++ b/src/core/trulens/core/session.py
@@ -1177,7 +1177,7 @@ class TruSession(
         record_id: str,
         timeout: float = 10,
         poll_interval: float = 0.5,
-    ):
+    ) -> None:
         """
         Wait for a specific record_id to appear in the TruLens session.
 
@@ -1185,9 +1185,6 @@ class TruSession(
             record_id: The record_id to wait for.
             timeout: Maximum time to wait in seconds.
             poll_interval: How often to poll in seconds.
-
-        Returns:
-            The record_id if found, else None.
         """
         if is_otel_tracing_enabled():
             self.force_flush()
@@ -1197,9 +1194,9 @@ class TruSession(
             if not records_df.empty and record_id in set(
                 records_df["record_id"]
             ):
-                return record_id
+                return
             sleep(poll_interval)
-        return None
+        raise RuntimeError(f"Record with ID {record_id} not found in database!")
 
 
 def Tru(*args, **kwargs) -> TruSession:


### PR DESCRIPTION
# Description
Have `recording.get` wait for record to show up in event table before giving to user.

## Other details good to know for developers

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> `Recording.get` now waits for a record to appear in the database using `TruSession.wait_for_record`, which raises an error if the record is not found within the timeout.
> 
>   - **Behavior**:
>     - `Recording.get` method now optionally waits for a record to appear in the database before returning it, using `TruSession.wait_for_record`.
>     - `TruSession.wait_for_record` now raises `RuntimeError` if the record is not found within the timeout.
>   - **Functions**:
>     - Updated `get` in `Recording` class to include `wait_for_record` parameter.
>     - Modified `wait_for_record` in `TruSession` to raise an error if the record is not found.
>   - **Misc**:
>     - Added import for `TruSession` in `instrument.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 4c090d98d3aefac2fc187cc496780162310475a7. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->