### PR TITLE
Fix TruLens nits

### DIFF
--- a/src/dashboard/trulens/dashboard/Leaderboard.py
+++ b/src/dashboard/trulens/dashboard/Leaderboard.py
@@ -722,9 +722,6 @@ def _render_list_tab(
                 ] = [app_id]
                 st.switch_page("pages/Records.py")
 
-        # with st.expander("Model metadata"):
-        #    st.markdown(draw_metadata(metadata))
-
         st.markdown("""---""")
 
 

--- a/src/dashboard/trulens/dashboard/Leaderboard.py
+++ b/src/dashboard/trulens/dashboard/Leaderboard.py
@@ -551,21 +551,16 @@ def _render_grid_tab(
         st.switch_page("pages/Records.py")
     # Compare App Versions
     if len(selected_app_ids) < Compare_page.MIN_COMPARATORS:
-        _compare_button_label = (
-            f"Min {Compare_page.MIN_COMPARATORS} App Versions"
-        )
         _compare_button_disabled = True
         help_msg = f"Select at least {Compare_page.MIN_COMPARATORS} app versions to compare."
     elif len(selected_app_ids) > Compare_page.MAX_COMPARATORS:
-        _compare_button_label = (
-            f"Max {Compare_page.MAX_COMPARATORS} App Versions"
-        )
         _compare_button_disabled = True
         help_msg = f"Deselect to at most {Compare_page.MAX_COMPARATORS} app versions to compare."
     else:
-        _compare_button_label = "Compare"
         _compare_button_disabled = False
         help_msg = None
+
+    _compare_button_label = "Compare"
 
     if c4.button(
         _compare_button_label,

--- a/src/dashboard/trulens/dashboard/Leaderboard.py
+++ b/src/dashboard/trulens/dashboard/Leaderboard.py
@@ -7,6 +7,7 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 import streamlit as st
 from trulens.apps import virtual as virtual_app
+from trulens.core.otel.utils import is_otel_tracing_enabled
 from trulens.core.schema import feedback as feedback_schema
 from trulens.core.utils import text as text_utils
 from trulens.dashboard import constants as dashboard_constants
@@ -583,18 +584,20 @@ def _render_grid_tab(
     ):
         handle_add_metadata(selected_rows, version_metadata_col_names)
 
-    # Add Virtual App
-    if c6.button(
-        "Add Virtual App",
-        use_container_width=True,
-        key=f"{dashboard_constants.LEADERBOARD_PAGE_NAME}.add_virtual_app_button",
-    ):
-        handle_add_virtual_app(
-            app_name,
-            feedback_col_names,
-            feedback_defs,
-            version_metadata_col_names,
-        )
+    # Virtual apps do not work in OTEL world.
+    if not is_otel_tracing_enabled():
+        # Add Virtual App
+        if c6.button(
+            "Add Virtual App",
+            use_container_width=True,
+            key=f"{dashboard_constants.LEADERBOARD_PAGE_NAME}.add_virtual_app_button",
+        ):
+            handle_add_virtual_app(
+                app_name,
+                feedback_col_names,
+                feedback_defs,
+                version_metadata_col_names,
+            )
 
 
 @streamlit_compat.st_fragment
@@ -711,8 +714,8 @@ def _render_list_tab(
 
         with select_app_col:
             if st.button(
-                "Select App",
-                key=f"select_app_{app_id}",
+                "Select App Version",
+                key=f"select_app_version_{app_id}",
             ):
                 st.session_state[
                     f"{dashboard_constants.RECORDS_PAGE_NAME}.app_ids"

--- a/src/dashboard/trulens/dashboard/pages/Records.py
+++ b/src/dashboard/trulens/dashboard/pages/Records.py
@@ -121,10 +121,10 @@ def _render_trace(
 
     input_col, output_col = st_columns(2)
     with input_col.expander("Record Input"):
-        st_code(selected_row["input"], wrap_lines=True, language="plaintext")
+        st_code(selected_row["input"], wrap_lines=True)
 
     with output_col.expander("Record Output"):
-        st_code(selected_row["output"], wrap_lines=True, language="plaintext")
+        st_code(selected_row["output"], wrap_lines=True)
 
     _render_record_metrics(records_df, selected_row)
 

--- a/src/dashboard/trulens/dashboard/pages/Records.py
+++ b/src/dashboard/trulens/dashboard/pages/Records.py
@@ -121,10 +121,10 @@ def _render_trace(
 
     input_col, output_col = st_columns(2)
     with input_col.expander("Record Input"):
-        st_code(selected_row["input"], wrap_lines=True)
+        st_code(selected_row["input"], wrap_lines=True, language="plaintext")
 
     with output_col.expander("Record Output"):
-        st_code(selected_row["output"], wrap_lines=True)
+        st_code(selected_row["output"], wrap_lines=True, language="plaintext")
 
     _render_record_metrics(records_df, selected_row)
 

--- a/src/dashboard/trulens/dashboard/run.py
+++ b/src/dashboard/trulens/dashboard/run.py
@@ -107,7 +107,7 @@ def run_dashboard(
         "--server.headless=True",
         "--theme.base=dark",
         "--theme.primaryColor=#E0735C",
-        "--theme.font=sans serif",
+        '--theme.font="sans-serif"',
     ]
     if _watch_changes:
         args.extend([

--- a/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
@@ -287,15 +287,7 @@ def render_sidebar():
         st.text(f"{mod_core.__package__} {mod_core.__version__}")
         st.text(f"{mod_dashboard.__package__} {mod_dashboard.__version__}")
 
-        FEEDBACK_FORM_URL = "https://forms.gle/HAc4HBk5nZRpgw7C6"
         BUG_REPORT_URL = "https://github.com/truera/trulens/issues/new?template=bug-report.md"
-
-        st.link_button(
-            "Share Feedback",
-            FEEDBACK_FORM_URL,
-            help="Help us improve TruLens!",
-            use_container_width=True,
-        )
 
         st.link_button(
             "Report a Bug 🐞",

--- a/src/dashboard/trulens/dashboard/utils/records_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/records_utils.py
@@ -75,7 +75,11 @@ def display_feedback_call(
             for i in range(len(call))
         ])
         df["meta"] = pd.Series([call[i]["meta"] for i in range(len(call))])
-        df = df.join(df.meta.apply(lambda m: pd.Series(m))).drop(columns="meta")
+        df = (
+            df.join(df.meta.apply(lambda m: pd.Series(m)))
+            .drop(columns="meta")
+            .drop(columns="criteria")
+        )
 
         # note: improve conditional to not rely on the feedback name
         if "groundedness" in feedback_name.lower():

--- a/src/dashboard/trulens/dashboard/utils/streamlit_compat.py
+++ b/src/dashboard/trulens/dashboard/utils/streamlit_compat.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from packaging.version import Version
 import streamlit as st
 
@@ -23,7 +25,7 @@ def st_columns(
 
 def st_code(
     body,
-    language: str = "python",
+    language: Optional[str] = None,
     *,
     line_numbers: bool = False,
     wrap_lines: bool = False,


### PR DESCRIPTION
# Description

This PR enhances the TruLens dashboard with several UI improvements and compatibility updates:

1. Disabled the "Add Virtual App" button when OpenTelemetry tracing is enabled, as virtual apps are not compatible with OTEL
2. Improved button labeling by changing "Select App" to "Select App Version" for clarity
3. Fixed code display in Records page by specifying "plaintext" language for input and output code blocks
4. Removed the "Share Feedback" button from the sidebar
5. Simplified the Compare button logic by setting a consistent label
6. Fixed feedback call display by removing the "criteria" column from metadata

## Other details good to know for developers

- Added an import for `is_otel_tracing_enabled` to check OTEL compatibility
- The virtual app functionality is now conditionally rendered based on OTEL status
- Feedback display has been improved by cleaning up unnecessary columns

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance TruLens dashboard UI and compatibility by disabling incompatible features with OTEL, improving button labels, and cleaning up the interface.
> 
>   - **Behavior**:
>     - Disable "Add Virtual App" button in `Leaderboard.py` when OTEL tracing is enabled.
>     - Change "Select App" to "Select App Version" in `Leaderboard.py` and `streamlit_compat.py`.
>     - Remove "Share Feedback" button from sidebar in `dashboard_utils.py`.
>     - Set consistent label for Compare button in `Leaderboard.py`.
>     - Remove "criteria" column from feedback call display in `records_utils.py`.
>   - **Compatibility**:
>     - Add import for `is_otel_tracing_enabled` in `Leaderboard.py`.
>     - Conditionally render virtual app functionality based on OTEL status in `Leaderboard.py`.
>   - **Misc**:
>     - Fix theme font in `run.py` to "sans-serif".
>     - Specify "plaintext" language for code blocks in `streamlit_compat.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 725790771f1fa4f017350f47518ef60c0393da40. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->