### PR TITLE
Don't use session state api for metadata dropdown

### DIFF
--- a/src/dashboard/trulens/dashboard/Leaderboard.py
+++ b/src/dashboard/trulens/dashboard/Leaderboard.py
@@ -451,22 +451,22 @@ def _render_grid_tab(
     ]
 
     # Validate metadata_cols
-    if metadata_cols := st.session_state.get(
+    if metadata_col_values := st.session_state.get(
         f"{dashboard_constants.LEADERBOARD_PAGE_NAME}.metadata_cols", []
     ):
-        st.session_state[
-            f"{dashboard_constants.LEADERBOARD_PAGE_NAME}.metadata_cols"
-        ] = [
+        metadata_select_options = [
             col_name
-            for col_name in metadata_cols
+            for col_name in metadata_col_values
             if col_name in _metadata_options
         ]
+    else:
+        metadata_select_options = _metadata_options
 
     metadata_cols = st.multiselect(
         label="Display Metadata Columns",
         key=f"{dashboard_constants.LEADERBOARD_PAGE_NAME}.metadata_cols",
-        options=_metadata_options,
-        default=_metadata_options,
+        options=metadata_select_options,
+        default=metadata_select_options,
     )
     if len(metadata_cols) != len(_metadata_options):
         st.query_params["metadata_cols"] = ",".join(metadata_cols)


### PR DESCRIPTION
# Description

Removes session state update to metadata dropdown in leaderboard. This sometimes throw a streamlit error/warning.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove session state update for metadata dropdown in `Leaderboard.py` to prevent Streamlit errors.
> 
>   - **Behavior**:
>     - Remove session state update for metadata dropdown in `_render_grid_tab` in `Leaderboard.py`.
>     - Use local variable `metadata_select_options` to manage dropdown options.
>     - Ensure dropdown options are validated and displayed without errors.
>   - **Misc**:
>     - Rename `metadata_cols` to `metadata_col_values` for clarity in `_render_grid_tab`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for abd8a24692b4fb08712d90372f45b0187ee9128a. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->