### PR TITLE
fix app version search and advanced filters search

### DIFF
--- a/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
@@ -462,11 +462,13 @@ def render_app_version_filters(
                     metadata_selections[metadata_key]
                 )
             ]
-        filtered_app_versions = filtered_app_versions[
-            filtered_app_versions["tags"].apply(
-                lambda x: any(tag in x for tag in selected_tags)
-            )
-        ]
+
+        if len(selected_tags):
+            filtered_app_versions = filtered_app_versions.loc[
+                filtered_app_versions["tags"].apply(
+                    lambda x: any(tag in x for tag in selected_tags)
+                )
+            ]
 
     if len(active_adv_filters):
         col2.button(


### PR DESCRIPTION
# Description

Fixes missing app_ids keyerror in versions search and advanced filters.
Previously, filtering by tags on an empty df would create a 0x0 shape dataframe, which removes any column data. with .loc we index only on the rows and preserve the columns even if no rows exist. This avoids keyerrors down the road.

https://snowflakecomputing.atlassian.net/browse/SNOW-2126918
https://snowflakecomputing.atlassian.net/browse/SNOW-2126917

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes KeyError in `render_app_version_filters` by preserving DataFrame columns when filtering by tags on an empty DataFrame.
> 
>   - **Bug Fix**:
>     - Fixes KeyError in `render_app_version_filters` in `dashboard_utils.py` by using `.loc` to preserve columns when filtering by tags on an empty DataFrame.
>   - **Behavior**:
>     - Ensures `filtered_app_versions` retains column structure even if no rows match the filter criteria.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 2c03d050becaf1ed9d296b35445c407e8d027435. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->