### PR TITLE
Nit: Clean up and standardize otel tracing params

### DIFF
--- a/examples/experimental/test_otel_quickstart.ipynb
+++ b/examples/experimental/test_otel_quickstart.ipynb
@@ -354,7 +354,6 @@
    "source": [
     "from trulens.dashboard import run_dashboard\n",
     "\n",
-    "# NOTE: OTEL TRACING\n",
     "run_dashboard(session)"
    ]
   },
@@ -381,8 +380,7 @@
     "    )\n",
     "\n",
     "offset = None\n",
-    "limit = 1000\n",
-    "use_otel = True"
+    "limit = 1000"
    ]
   },
   {
@@ -410,7 +408,6 @@
     "    app_name=app_name,\n",
     "    offset=offset,\n",
     "    limit=limit,\n",
-    "    use_otel=use_otel,\n",
     ")\n",
     "\n",
     "# With app_ids\n",
@@ -419,7 +416,6 @@
     "    app_name=app_name,\n",
     "    offset=offset,\n",
     "    limit=limit,\n",
-    "    use_otel=use_otel,\n",
     ")\n",
     "\n",
     "# print(records_df_no_app_ids == records_df_with_app_ids, len(records_df_no_app_ids) == len(records_df_with_app_ids))"

--- a/src/dashboard/trulens/dashboard/run.py
+++ b/src/dashboard/trulens/dashboard/run.py
@@ -144,8 +144,6 @@ def run_dashboard(
     ]
     if sis_compatibility_mode:
         args += ["--sis-compatibility"]
-    # if is_otel_tracing_enabled():
-    #     args += ["--otel-tracing"]
 
     proc = subprocess.Popen(
         args,

--- a/src/dashboard/trulens/dashboard/run.py
+++ b/src/dashboard/trulens/dashboard/run.py
@@ -12,7 +12,6 @@ from typing import Optional
 
 from trulens.core import session as core_session
 from trulens.core.database.connector.base import DBConnector
-from trulens.core.otel.utils import is_otel_tracing_enabled
 from trulens.core.utils import imports as import_utils
 from trulens.dashboard.utils import notebook_utils
 from typing_extensions import Annotated
@@ -145,8 +144,8 @@ def run_dashboard(
     ]
     if sis_compatibility_mode:
         args += ["--sis-compatibility"]
-    if is_otel_tracing_enabled():
-        args += ["--otel-tracing"]
+    # if is_otel_tracing_enabled():
+    #     args += ["--otel-tracing"]
 
     proc = subprocess.Popen(
         args,


### PR DESCRIPTION
# Description

Clean up otel tracing params in quickstart and in Streamlit UI. Fix rendering of OTEL Streamlit UI. Follow-up of #2029.

Before (hanging, unresponsive):

<img width="1840" alt="Screenshot 2025-05-30 at 4 03 29 PM" src="https://github.com/user-attachments/assets/963d76e8-987e-4b8d-a324-4e474fcc0c6a" />



After (expected):

<img width="1840" alt="Screenshot 2025-05-30 at 4 03 31 PM" src="https://github.com/user-attachments/assets/22741416-47f1-4890-ba8d-21660d3a689a" />

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Removes OpenTelemetry tracing check and cleans up unused import in `run_dashboard` in `run.py`.
> 
>   - **Behavior**:
>     - Removes OpenTelemetry tracing check in `run_dashboard` in `run.py`, eliminating `--otel-tracing` argument.
>   - **Misc**:
>     - Cleans up unused import `is_otel_tracing_enabled` from `run.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 9894fd347d44b49df28cb03f1728507a3537022a. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->