### PR TITLE
Clean up `TruSession` before tests as previous tests can interfere with each other.

### DIFF
--- a/tests/e2e/test_snowflake_event_table_exporter.py
+++ b/tests/e2e/test_snowflake_event_table_exporter.py
@@ -45,7 +45,6 @@ class TestSnowflakeEventTableExporter(SnowflakeTestCase):
         super().tearDownClass()
 
     def setUp(self) -> None:
-        self.clear_TruSession_singleton()
         super().setUp()
         self.create_and_use_schema(
             "TestSnowflakeEventTableExporter", append_uuid=True

--- a/tests/e2e/test_snowflake_event_table_exporter.py
+++ b/tests/e2e/test_snowflake_event_table_exporter.py
@@ -45,6 +45,7 @@ class TestSnowflakeEventTableExporter(SnowflakeTestCase):
         super().tearDownClass()
 
     def setUp(self) -> None:
+        self.clear_TruSession_singleton()
         super().setUp()
         self.create_and_use_schema(
             "TestSnowflakeEventTableExporter", append_uuid=True

--- a/tests/test.py
+++ b/tests/test.py
@@ -583,6 +583,10 @@ class TruTestCase(WithJSONTestCase, TestCase):
                     print(f"Reference path from test frame to {ref}:")
                     test_utils.print_referent_lens(origin=alls, lens=path)
 
+    def setUp(self) -> None:
+        super().setUp()
+        self.clear_TruSession_singleton()
+
     def tearDown(self):
         """Check for running tasks and non-main threads after each test.
 
@@ -593,6 +597,7 @@ class TruTestCase(WithJSONTestCase, TestCase):
             AssertionError: If there are any non-main threads running and the
                 environment variable `TEST_THREADS_CLEANUP` is set.
         """
+        self.clear_TruSession_singleton()
 
         # GC here to make sure we don't have any references to tasks or threads
         # that are keeping them alive.

--- a/tests/test.py
+++ b/tests/test.py
@@ -30,6 +30,7 @@ import pandas as pd
 import pydantic
 from pydantic import BaseModel
 from trulens.core._utils.pycompat import ReferenceType
+from trulens.core.session import TruSession
 from trulens.core.utils import python as python_utils
 from trulens.core.utils import serial as serial_utils
 import yaml
@@ -667,3 +668,14 @@ class TruTestCase(WithJSONTestCase, TestCase):
             print("    " + str(thread))
 
         super().tearDownClass()
+
+    @classmethod
+    def clear_TruSession_singleton(cls) -> None:
+        # [HACK!] Clean up any instances of `TruSession` so tests don't
+        # interfere with each other.
+        for key in [
+            curr
+            for curr in TruSession._singleton_instances
+            if curr[0] == "trulens.core.session.TruSession"
+        ]:
+            del TruSession._singleton_instances[key]

--- a/tests/util/otel_test_case.py
+++ b/tests/util/otel_test_case.py
@@ -21,17 +21,6 @@ from tests.util.df_comparison import (
 
 class OtelTestCase(TruTestCase):
     @classmethod
-    def clear_TruSession_singleton(cls) -> None:
-        # [HACK!] Clean up any instances of `TruSession` so tests don't
-        # interfere with each other.
-        for key in [
-            curr
-            for curr in TruSession._singleton_instances
-            if curr[0] == "trulens.core.session.TruSession"
-        ]:
-            del TruSession._singleton_instances[key]
-
-    @classmethod
     def setUpClass(cls) -> None:
         os.environ["TRULENS_OTEL_TRACING"] = "1"
         instrument.enable_all_instrumentation()

--- a/tests/util/otel_test_case.py
+++ b/tests/util/otel_test_case.py
@@ -30,20 +30,17 @@ class OtelTestCase(TruTestCase):
     def tearDownClass(cls) -> None:
         instrument.disable_all_instrumentation()
         del os.environ["TRULENS_OTEL_TRACING"]
-        cls.clear_TruSession_singleton()
         return super().tearDownClass()
 
     def setUp(self) -> None:
-        self.clear_TruSession_singleton()
+        super().setUp()
         tru_session = TruSession()
         tru_session.reset_database()
-        return super().setUp()
 
     def tearDown(self) -> None:
         tru_session = TruSession()
         tru_session.force_flush()
         tru_session._experimental_otel_span_processor.shutdown()
-        self.clear_TruSession_singleton()
         return super().tearDown()
 
     @staticmethod

--- a/tests/util/snowflake_test_case.py
+++ b/tests/util/snowflake_test_case.py
@@ -18,6 +18,7 @@ from tests.test import TruTestCase
 
 class SnowflakeTestCase(TruTestCase):
     def setUp(self):
+        super().setUp()
         self._logger = logging.getLogger(__name__)
         self._database = os.environ["SNOWFLAKE_DATABASE"]
         self._snowflake_connection_parameters: Dict[str, str] = {

--- a/tests/util/snowflake_test_case.py
+++ b/tests/util/snowflake_test_case.py
@@ -5,7 +5,6 @@ Test class to use for Snowflake testing.
 import logging
 import os
 from typing import Any, Dict, List, Optional
-from unittest import TestCase
 import uuid
 
 from snowflake.snowpark import Session
@@ -14,8 +13,10 @@ from trulens.connectors import snowflake as snowflake_connector
 from trulens.core import session as core_session
 from trulens.providers.cortex.provider import Cortex
 
+from tests.test import TruTestCase
 
-class SnowflakeTestCase(TestCase):
+
+class SnowflakeTestCase(TruTestCase):
     def setUp(self):
         self._logger = logging.getLogger(__name__)
         self._database = os.environ["SNOWFLAKE_DATABASE"]


### PR DESCRIPTION
# Description
Clean up `TruSession` before tests as previous tests can interfere with each other.

We were running into a strange issue recently where this manifested when we ran these three tests in this order:
`tests/e2e/test_otel_costs.py::TestOtelCosts::test_tru_custom_app_openai`
`tests/e2e/test_otel_notebooks.py::TestOtelNotebooks::test_otel_exporter`
`tests/e2e/test_snowflake_event_table_exporter.py::TestSnowflakeEventTableExporter::test_feedback_computation`
due to this problem.

## Other details good to know for developers

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces `clear_TruSession_singleton()` in `TruTestCase` to prevent test interference by cleaning up `TruSession` instances before and after tests.
> 
>   - **Behavior**:
>     - Introduces `clear_TruSession_singleton()` in `TruTestCase` to clear `TruSession` instances before and after each test.
>     - Ensures tests do not interfere with each other by cleaning up `TruSession` instances.
>   - **Test Cases**:
>     - `OtelTestCase` and `SnowflakeTestCase` now inherit from `TruTestCase` and utilize the new cleanup method.
>     - Removes redundant `clear_TruSession_singleton()` from `OtelTestCase` and `SnowflakeTestCase`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 524ed668b3ee2d234a9fc69827c9b94409583f89. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->