### PR TITLE
Update tooltips for cost and latency based on delta value

### DIFF
--- a/src/dashboard/trulens/dashboard/pages/Records.py
+++ b/src/dashboard/trulens/dashboard/pages/Records.py
@@ -89,7 +89,9 @@ def _render_record_metrics(
             value=_format_cost(cost, cost_currency),
             delta=f"{delta_cost:3g}" if delta_cost != 0 else None,
             delta_color="inverse",
-            help=f"Cost of the app execution measured in {cost_currency}. Delta is relative to average cost for the app.",
+            help=f"Cost of the app execution measured in {cost_currency}. Delta is relative to average cost for the app."
+            if delta_cost != 0
+            else f"Cost of the app execution measured in {cost_currency}.",
         )
 
     latency = selected_row["latency"]
@@ -101,7 +103,9 @@ def _render_record_metrics(
             value=f"{selected_row['latency']}s",
             delta=f"{delta_latency:.3g}s" if delta_latency != 0 else None,
             delta_color="inverse",
-            help="Latency of the app execution. Delta is relative to average latency for the app.",
+            help="Latency of the app execution. Delta is relative to average latency for the app."
+            if delta_latency != 0
+            else "Latency of the app execution.",
         )
 
 


### PR DESCRIPTION
# Description

- Include/exclude mention of delta in the tooltip for cost and latency if delta exists.
- [SNOW-2126946](https://snowflakecomputing.atlassian.net/browse/SNOW-2126946)

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update tooltips in `Records.py` to conditionally include delta information for cost and latency metrics based on delta value presence.
> 
>   - **Behavior**:
>     - Update tooltips in `_render_record_metrics` in `Records.py` to conditionally include delta information for cost and latency metrics.
>     - Tooltips mention delta only if `delta_cost` or `delta_latency` is non-zero.
>   - **Misc**:
>     - No changes to logic or data processing, only tooltip text adjustments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 0a187c4ea53eaab3b90bcedd6567f5c07c1cba2c. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->