### PR TITLE
Safely drop columns as sometimes the "output" column isn't there.

### DIFF
--- a/src/dashboard/trulens/dashboard/utils/records_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/records_utils.py
@@ -76,7 +76,7 @@ def display_feedback_call(
         ])
         df["meta"] = pd.Series([call[i]["meta"] for i in range(len(call))])
         df = df.join(df.meta.apply(lambda m: pd.Series(m))).drop(
-            columns=["meta", "output", "metadata"]
+            columns=["meta", "output", "metadata"], errors="ignore"
         )
 
         # note: improve conditional to not rely on the feedback name


### PR DESCRIPTION
# Description
Safely drop columns as sometimes the "output" column isn't there.

## Other details good to know for developers

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes column drop error in `display_feedback_call` by ignoring missing columns in `records_utils.py`.
> 
>   - **Bug Fix**:
>     - In `display_feedback_call` function in `records_utils.py`, modified `drop` method to use `errors="ignore"` to safely drop columns even if they are missing, specifically addressing the absence of the "output" column.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 73c2adad2f7f8428d9313733021b151cc5c23ca9. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->