### PR TITLE
[Bugfix] Update groundedness parallelization to use TruLens custom ThreadPoolExecutor

### DIFF
--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -1,4 +1,3 @@
-from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import as_completed
 import logging
 import re
@@ -11,6 +10,7 @@ import numpy as np
 from trulens.core.feedback import feedback as core_feedback
 from trulens.core.feedback import provider as core_provider
 from trulens.core.utils import deprecation as deprecation_utils
+from trulens.core.utils.threading import ThreadPoolExecutor
 from trulens.feedback import generated as feedback_generated
 from trulens.feedback import prompts as feedback_prompts
 from trulens.feedback.v2 import feedback as feedback_v2


### PR DESCRIPTION
# Description

- Related issues: #1649, #1748, and possibly a part of #1773
- Related previous changes: #1180

## Other details good to know for developers

It seems that parallelized groundedness LLM calls have been broken/failing silently -- that is, the `evaluate_hypothesis` method has not been getting called. This PR updates `groundedness_measure_with_cot_reasons()` and `groundedness_measure_with_cot_reasons_consider_answerability()` to use TruLens' custom `ThreadPoolExecutor`, which extends `concurrent.futures.ThreadPoolExecutor` and should handle context propagation and stack tracking appropriately.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
