### PR TITLE
Add `on_trace` selector and show custom trajectory eval

### DIFF
--- a/examples/experimental/otel/langgraph_quickstart_otel.ipynb
+++ b/examples/experimental/otel/langgraph_quickstart_otel.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,7 +343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,14 +391,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "from typing import Dict, Tuple\n",
+    "\n",
     "import numpy as np\n",
     "from trulens.core import Feedback\n",
     "from trulens.providers.openai import OpenAI\n",
-    "from typing import Tuple, Dict\n",
     "\n",
     "provider = OpenAI(model_engine=\"gpt-4.1-mini\")\n",
     "\n",
@@ -425,27 +426,52 @@
     "    .on_input()\n",
     "    .on_context(collect_list=False)\n",
     "    .aggregate(np.mean)  # choose a different aggregation method if you wish\n",
-    ")\n",
-    "\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Add a custom evaluation to evaluate agent trajectory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from trulens.feedback import prompts\n",
+    "\n",
     "\n",
     "class CustomTrajEval(OpenAI):\n",
     "    def traj_execution_with_cot_reasons(self, trace) -> Tuple[float, Dict]:\n",
-    "        system_prompt = f\"\"\"\n",
+    "        system_prompt = \"\"\"\n",
     "        Use the following rubric to evaluate the execution trace of the system:\n",
     "        0: Agents made wrong or unnecessary calls. Critical steps were skipped or repeated without purpose. Generated outputs were off-topic, hallucinated, or contradictory. Confusion between agent roles. User goal was not meaningfully addressed.\n",
     "        1: Several unnecessary or misordered agent/tool use. Some factual errors or under-specified steps. Redundant or partially irrelevant tool calls. Weak or ambiguous agent outputs at one or more steps\n",
     "        2: Some minor inefficiencies or unclear transitions. Moments of stalled progress, but ultimately resolved. The agents mostly fulfilled their roles, and the conversation mostly fulfilled answering the query.\n",
     "        3: Agent handoffs were well-timed and logical. Tool calls were necessary, sufficient, and accurate. No redundancies, missteps, or dead ends. Progress toward the user query was smooth and continuous. No hallucination or incorrect outputs\n",
     "        \"\"\"\n",
-    "        user_prompt = f\"\"\" Please score the execution trace. Execution Trace (possible in json str format): {trace}. \\n\n",
+    "        user_prompt = f\"\"\" Please score the execution trace. Execution Trace: {trace}. \\n\n",
     "        {prompts.COT_REASONS_TEMPLATE}\n",
     "        \"\"\"\n",
-    "        return self.generate_score_and_reasons(system_prompt=system_prompt, user_prompt=user_prompt, min_score_val = 0, max_score_val = 3)\n",
-    "    \n",
+    "\n",
+    "        print(trace)\n",
+    "        return self.generate_score_and_reasons(\n",
+    "            system_prompt=system_prompt,\n",
+    "            user_prompt=user_prompt,\n",
+    "            min_score_val=0,\n",
+    "            max_score_val=3,\n",
+    "        )\n",
+    "\n",
+    "\n",
     "custom_provider = CustomTrajEval()\n",
     "\n",
-    "f_trajectory = Feedback(custom_provider.traj_execution_with_cot_reasons, name=\"Trajectory\").on_trace()"
+    "f_trajectory = Feedback(\n",
+    "    custom_provider.traj_execution_with_cot_reasons, name=\"Trajectory\"\n",
+    ").on_trace(collect_list=True)"
    ]
   },
   {
@@ -457,7 +483,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -467,7 +493,12 @@
     "    multi_agent_graph,\n",
     "    app_name=\"Multi-Agent Chart Generation\",\n",
     "    app_version=\"Base\",\n",
-    "    feedbacks=[f_answer_relevance, f_context_relevance, f_groundedness, f_trajectory],\n",
+    "    feedbacks=[\n",
+    "        f_answer_relevance,\n",
+    "        f_context_relevance,\n",
+    "        f_groundedness,\n",
+    "        f_trajectory,\n",
+    "    ],\n",
     ")"
    ]
   },
@@ -534,8 +565,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/experimental/otel/langgraph_quickstart_otel.ipynb
+++ b/examples/experimental/otel/langgraph_quickstart_otel.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,12 +120,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Define tracing helper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def append_to_execution_trace(state: dict, step: int, entry: dict) -> dict:\n",
+    "    trace = state.get(\"execution_trace\", {})\n",
+    "    if step not in trace:\n",
+    "        trace[step] = []\n",
+    "    trace[step].append(entry)\n",
+    "    return trace"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Define Nodes"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,13 +391,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
     "from trulens.core import Feedback\n",
     "from trulens.providers.openai import OpenAI\n",
+    "from typing import Tuple, Dict\n",
     "\n",
     "provider = OpenAI(model_engine=\"gpt-4.1-mini\")\n",
     "\n",
@@ -403,7 +425,27 @@
     "    .on_input()\n",
     "    .on_context(collect_list=False)\n",
     "    .aggregate(np.mean)  # choose a different aggregation method if you wish\n",
-    ")"
+    ")\n",
+    "\n",
+    "from trulens.feedback import prompts\n",
+    "\n",
+    "class CustomTrajEval(OpenAI):\n",
+    "    def traj_execution_with_cot_reasons(self, trace) -> Tuple[float, Dict]:\n",
+    "        system_prompt = f\"\"\"\n",
+    "        Use the following rubric to evaluate the execution trace of the system:\n",
+    "        0: Agents made wrong or unnecessary calls. Critical steps were skipped or repeated without purpose. Generated outputs were off-topic, hallucinated, or contradictory. Confusion between agent roles. User goal was not meaningfully addressed.\n",
+    "        1: Several unnecessary or misordered agent/tool use. Some factual errors or under-specified steps. Redundant or partially irrelevant tool calls. Weak or ambiguous agent outputs at one or more steps\n",
+    "        2: Some minor inefficiencies or unclear transitions. Moments of stalled progress, but ultimately resolved. The agents mostly fulfilled their roles, and the conversation mostly fulfilled answering the query.\n",
+    "        3: Agent handoffs were well-timed and logical. Tool calls were necessary, sufficient, and accurate. No redundancies, missteps, or dead ends. Progress toward the user query was smooth and continuous. No hallucination or incorrect outputs\n",
+    "        \"\"\"\n",
+    "        user_prompt = f\"\"\" Please score the execution trace. Execution Trace (possible in json str format): {trace}. \\n\n",
+    "        {prompts.COT_REASONS_TEMPLATE}\n",
+    "        \"\"\"\n",
+    "        return self.generate_score_and_reasons(system_prompt=system_prompt, user_prompt=user_prompt, min_score_val = 0, max_score_val = 3)\n",
+    "    \n",
+    "custom_provider = CustomTrajEval()\n",
+    "\n",
+    "f_trajectory = Feedback(custom_provider.traj_execution_with_cot_reasons, name=\"Trajectory\").on_trace()"
    ]
   },
   {
@@ -415,7 +457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -425,7 +467,7 @@
     "    multi_agent_graph,\n",
     "    app_name=\"Multi-Agent Chart Generation\",\n",
     "    app_version=\"Base\",\n",
-    "    feedbacks=[f_answer_relevance, f_context_relevance, f_groundedness],\n",
+    "    feedbacks=[f_answer_relevance, f_context_relevance, f_groundedness, f_trajectory],\n",
     ")"
    ]
   },
@@ -492,7 +534,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/experimental/otel/langgraph_quickstart_otel.ipynb
+++ b/examples/experimental/otel/langgraph_quickstart_otel.ipynb
@@ -120,27 +120,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Define tracing helper"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def append_to_execution_trace(state: dict, step: int, entry: dict) -> dict:\n",
-    "    trace = state.get(\"execution_trace\", {})\n",
-    "    if step not in trace:\n",
-    "        trace[step] = []\n",
-    "    trace[step].append(entry)\n",
-    "    return trace"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Define Nodes"
    ]
   },

--- a/src/core/trulens/core/feedback/feedback.py
+++ b/src/core/trulens/core/feedback/feedback.py
@@ -609,17 +609,21 @@ class Feedback(feedback_schema.FeedbackDefinition):
         ret = self.model_copy()
         ret.selectors = new_selectors
         return ret
-    
-    def on_trace(self, arg: Optional[str] = "trace"):
+
+    def on_trace(
+        self, arg: Optional[str] = "trace", *, collect_list: bool = True
+    ):
         """
         The selector will return a list of dicts as expected by select_trace.
         """
         from trulens.core.otel.utils import is_otel_tracing_enabled
+
         if not is_otel_tracing_enabled():
             raise RuntimeError("on_trace is only supported in OTel mode.")
         from trulens.core.feedback.selector import Selector
+
         new_selectors = self.selectors.copy()
-        new_selectors[arg] = Selector.select_trace()
+        new_selectors[arg] = Selector.select_trace(collect_list=collect_list)
         ret = self.model_copy()
         ret.selectors = new_selectors
         return ret
@@ -1352,6 +1356,7 @@ Feedback function signature:
                 app=app, record=record, source_data=source_data
             )
         )
+
 
 class SnowflakeFeedback(Feedback):
     """[DEPRECATED] Similar to the parent class Feedback except this ensures the feedback is run only on the Snowflake server.

--- a/src/core/trulens/core/feedback/feedback.py
+++ b/src/core/trulens/core/feedback/feedback.py
@@ -609,6 +609,20 @@ class Feedback(feedback_schema.FeedbackDefinition):
         ret = self.model_copy()
         ret.selectors = new_selectors
         return ret
+    
+    def on_trace(self, arg: Optional[str] = "trace"):
+        """
+        The selector will return a list of dicts as expected by select_trace.
+        """
+        from trulens.core.otel.utils import is_otel_tracing_enabled
+        if not is_otel_tracing_enabled():
+            raise RuntimeError("on_trace is only supported in OTel mode.")
+        from trulens.core.feedback.selector import Selector
+        new_selectors = self.selectors.copy()
+        new_selectors[arg] = Selector.select_trace()
+        ret = self.model_copy()
+        ret.selectors = new_selectors
+        return ret
 
     def on(self, *args, **kwargs) -> Feedback:
         """
@@ -1338,7 +1352,6 @@ Feedback function signature:
                 app=app, record=record, source_data=source_data
             )
         )
-
 
 class SnowflakeFeedback(Feedback):
     """[DEPRECATED] Similar to the parent class Feedback except this ensures the feedback is run only on the Snowflake server.

--- a/src/core/trulens/core/feedback/feedback.py
+++ b/src/core/trulens/core/feedback/feedback.py
@@ -620,8 +620,6 @@ class Feedback(feedback_schema.FeedbackDefinition):
 
         if not is_otel_tracing_enabled():
             raise RuntimeError("on_trace is only supported in OTel mode.")
-        from trulens.core.feedback.selector import Selector
-
         new_selectors = self.selectors.copy()
         new_selectors[arg] = Selector.select_trace(collect_list=collect_list)
         ret = self.model_copy()

--- a/src/core/trulens/core/feedback/selector.py
+++ b/src/core/trulens/core/feedback/selector.py
@@ -48,7 +48,9 @@ class Selector:
     ):
         # Only require at least one selector if not using a processor that handles all spans
         if (
-            function_name is None and span_name is None and span_type is None
+            function_name is None
+            and span_name is None
+            and span_type is None
             and span_attributes_processor is None
         ):
             raise ValueError(
@@ -215,29 +217,32 @@ class Selector:
         The system will collect these into a list (if collect_list=True), with each string describing a step: function name, input, and output.
         """
         from trulens.otel.semconv.trace import SpanAttributes
+
         def trace_processor(attrs: dict) -> str:
             if "record_attributes" in attrs:
                 attrs = attrs["record_attributes"]
             if not isinstance(attrs, dict):
-                return ""
+                pass
             span_type = attrs.get(SpanAttributes.SPAN_TYPE)
             if span_type in (
-                    SpanAttributes.SpanType.RECORD_ROOT,
-                    SpanAttributes.SpanType.EVAL,
-                    SpanAttributes.SpanType.EVAL_ROOT,
-                    "record_root",
-                    "eval",
-                    "eval_root"
+                SpanAttributes.SpanType.RECORD_ROOT,
+                SpanAttributes.SpanType.EVAL,
+                SpanAttributes.SpanType.EVAL_ROOT,
+                "record_root",
+                "eval",
+                "eval_root",
             ):
                 return ""
             # Extract function name, input, output if available
             name = attrs.get(SpanAttributes.CALL.FUNCTION, "<unknown>")
-            input_val = attrs.get(SpanAttributes.RECORD_ROOT.INPUT, attrs.get("input", "?"))
-            output_val = attrs.get(SpanAttributes.CALL.RETURN, attrs.get("output", "?"))
-            return f"{name}(input={input_val}, output={output_val})"
+            output_val = attrs.get(
+                SpanAttributes.CALL.RETURN, attrs.get("output", "?")
+            )
+            return f"{name}: {output_val}"
+
         return Selector(
             span_type=None,
             span_attributes_processor=trace_processor,
             collect_list=collect_list,
-            match_only_if_no_ancestor_matched=False
+            match_only_if_no_ancestor_matched=False,
         )

--- a/src/core/trulens/core/feedback/selector.py
+++ b/src/core/trulens/core/feedback/selector.py
@@ -219,10 +219,6 @@ class Selector:
         from trulens.otel.semconv.trace import SpanAttributes
 
         def trace_processor(attrs: dict) -> str:
-            if "record_attributes" in attrs:
-                attrs = attrs["record_attributes"]
-            if not isinstance(attrs, dict):
-                return ""
             span_type = attrs.get(SpanAttributes.SPAN_TYPE)
             if span_type in (
                 SpanAttributes.SpanType.RECORD_ROOT,
@@ -235,7 +231,7 @@ class Selector:
             output_val = attrs.get(
                 SpanAttributes.CALL.RETURN, attrs.get("output", "?")
             )
-            return f"{name}: {output_val}"
+            return f"TRACE STEP: {name} \n STEP OUTPUT: \n {output_val}"
 
         return Selector(
             span_type=None,

--- a/src/core/trulens/core/feedback/selector.py
+++ b/src/core/trulens/core/feedback/selector.py
@@ -228,9 +228,6 @@ class Selector:
                 SpanAttributes.SpanType.RECORD_ROOT,
                 SpanAttributes.SpanType.EVAL,
                 SpanAttributes.SpanType.EVAL_ROOT,
-                "record_root",
-                "eval",
-                "eval_root",
             ):
                 return ""
             # Extract function name, input, output if available

--- a/src/core/trulens/core/feedback/selector.py
+++ b/src/core/trulens/core/feedback/selector.py
@@ -222,7 +222,7 @@ class Selector:
             if "record_attributes" in attrs:
                 attrs = attrs["record_attributes"]
             if not isinstance(attrs, dict):
-                pass
+                return ""
             span_type = attrs.get(SpanAttributes.SPAN_TYPE)
             if span_type in (
                 SpanAttributes.SpanType.RECORD_ROOT,

--- a/src/feedback/trulens/feedback/computer.py
+++ b/src/feedback/trulens/feedback/computer.py
@@ -572,7 +572,7 @@ def _run_feedback_on_inputs(
                     span_group,
                 )
             return len(group_map)
-    # Default: call per input (old behavior)
+
     ret = 0
     for record_id, span_group, inputs in flattened_inputs:
         try:

--- a/src/feedback/trulens/feedback/computer.py
+++ b/src/feedback/trulens/feedback/computer.py
@@ -542,6 +542,38 @@ def _run_feedback_on_inputs(
     Returns:
         Number of feedbacks computed.
     """
+    # If there is only one kwarg and all inputs are for that kwarg, and collect_list is True,
+    # aggregate all values and call feedback function ONCE.
+    if flattened_inputs:
+        first_inputs = flattened_inputs[0][2]
+        if (
+            len(first_inputs) == 1
+            and hasattr(list(first_inputs.values())[0], "collect_list")
+            and list(first_inputs.values())[0].collect_list
+        ):
+            key = list(first_inputs.keys())[0]
+            all_values = [
+                inputs[key].value
+                for _, _, inputs in flattened_inputs
+                if key in inputs
+            ]
+            record_id, span_group, _ = flattened_inputs[0]
+            # Wrap in FeedbackFunctionInput as expected by _call_feedback_function
+            inputs = {
+                key: FeedbackFunctionInput(value=all_values, collect_list=True)
+            }
+            _call_feedback_function(
+                feedback_name,
+                feedback_function,
+                higher_is_better,
+                feedback_aggregator,
+                inputs,
+                record_id_to_record_root[record_id]["record_attributes"],
+                record_id_to_record_root[record_id]["resource_attributes"],
+                span_group,
+            )
+            return 1
+    # Default: call per input (old behavior)
     ret = 0
     for record_id, span_group, inputs in flattened_inputs:
         try:


### PR DESCRIPTION
# Description

Add `on_trace` selector and show use via custom trajectory eval

![Screenshot 2025-06-11 at 6 32 10 PM](https://github.com/user-attachments/assets/6f6ee518-2351-4e2a-8760-6ca20d082463)



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [x] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `on_trace` selector to `Feedback` for custom trajectory evaluation using trace-based selection.
> 
>   - **New Feature**:
>     - Add `on_trace` method to `Feedback` in `feedback.py` for trace-based selection.
>     - Add `select_trace` static method to `Selector` in `selector.py` to match all spans and return summaries.
>   - **Behavior**:
>     - `on_trace` raises `RuntimeError` if OTel tracing is not enabled.
>     - `select_trace` collects span summaries into a list if `collect_list=True`.
>   - **Feedback Computation**:
>     - Update `_run_feedback_on_inputs` in `computer.py` to handle grouped span inputs for feedback computation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for ec5829571e64f2f7daf7cb91cf447e971ef821c5. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->