### PR TITLE
[Bugfix] Update dedup logic for feedback calls to gracefully handle both OTel and non-OTel spans

### DIFF
--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -1183,11 +1183,6 @@ class SQLAlchemyDB(core_db.DB):
                                 SpanAttributes.EVAL_ROOT.ARGS_SPAN_ATTRIBUTE,
                             )
 
-                            # Extract namespaced attributes using the helper method
-                            kwargs = self._extract_namespaced_attributes(
-                                record_attributes, SpanAttributes.CALL.KWARGS
-                            )
-
                             call_data = {
                                 "span_type": record_attributes.get(
                                     SpanAttributes.SPAN_TYPE

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -1189,7 +1189,9 @@ class SQLAlchemyDB(core_db.DB):
                             )
 
                             call_data = {
-                                "args": kwargs,
+                                "span_type": record_attributes.get(
+                                    SpanAttributes.SPAN_TYPE
+                                ),
                                 "eval_root_id": record_attributes.get(
                                     SpanAttributes.EVAL.EVAL_ROOT_ID
                                 ),
@@ -1214,6 +1216,9 @@ class SQLAlchemyDB(core_db.DB):
                             )
 
                             call_data = {
+                                "span_type": record_attributes.get(
+                                    SpanAttributes.SPAN_TYPE
+                                ),
                                 "args": kwargs,
                                 "ret": record_attributes.get(
                                     SpanAttributes.EVAL.SCORE

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -1183,7 +1183,13 @@ class SQLAlchemyDB(core_db.DB):
                                 SpanAttributes.EVAL_ROOT.ARGS_SPAN_ATTRIBUTE,
                             )
 
+                            # Extract namespaced attributes using the helper method
+                            kwargs = self._extract_namespaced_attributes(
+                                record_attributes, SpanAttributes.CALL.KWARGS
+                            )
+
                             call_data = {
+                                "args": kwargs,
                                 "eval_root_id": record_attributes.get(
                                     SpanAttributes.EVAL.EVAL_ROOT_ID
                                 ),
@@ -1872,9 +1878,9 @@ class AppsExtractor:
                 with `apps`.
         """
 
-        assert (
-            apps is None or records is None
-        ), "`apps` and `records` are mutually exclusive"
+        assert apps is None or records is None, (
+            "`apps` and `records` are mutually exclusive"
+        )
 
         if apps is not None:
             df = pd.concat(self.extract_apps(apps))

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -1878,9 +1878,9 @@ class AppsExtractor:
                 with `apps`.
         """
 
-        assert apps is None or records is None, (
-            "`apps` and `records` are mutually exclusive"
-        )
+        assert (
+            apps is None or records is None
+        ), "`apps` and `records` are mutually exclusive"
 
         if apps is not None:
             df = pd.concat(self.extract_apps(apps))

--- a/src/dashboard/trulens/dashboard/utils/records_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/records_utils.py
@@ -1,6 +1,6 @@
 from functools import partial
 import pprint as pp
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import pandas as pd
 import streamlit as st
@@ -39,13 +39,111 @@ def df_cell_highlight(
     return [f"background-color: {cat.color}"] * n_cells
 
 
+def _identify_span_types(
+    call: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Identify and separate EVAL_ROOT and EVAL spans from the call list.
+
+    Args:
+        call: List of call dictionaries containing span information
+
+    Returns:
+        Tuple of (eval_root_calls, eval_calls) lists
+    """
+    eval_root_calls = []
+    eval_calls = []
+
+    for c in call:
+        # For OTel spans, use explicit span_type field
+        if c.get("span_type") == "EVAL_ROOT":
+            eval_root_calls.append(c)
+        elif c.get("span_type") == "EVAL":
+            eval_calls.append(c)
+        # For legacy spans (pre-OTel), all calls should contain the following fields: args, ret, and meta
+        elif "args" in c and "ret" in c and "meta" in c:
+            eval_calls.append(c)
+
+    return eval_root_calls, eval_calls
+
+
+def _filter_eval_calls_by_root(
+    eval_root_calls: List[Dict[str, Any]], eval_calls: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """Filter EVAL calls to only those belonging to the most recent EVAL_ROOT spans.
+
+    Args:
+        eval_root_calls: List of EVAL_ROOT span dictionaries
+        eval_calls: List of EVAL span dictionaries
+
+    Returns:
+        Filtered list of EVAL span dictionaries
+
+    Raises:
+        KeyError: If eval_root_id is missing from any EVAL_ROOT or EVAL call
+    """
+    if not eval_root_calls:
+        return eval_calls
+
+    eval_root_df = pd.DataFrame(eval_root_calls)
+    if "eval_root_id" not in eval_root_df.columns:
+        raise KeyError("eval_root_id column missing from EVAL_ROOT spans")
+
+    if eval_root_df.empty:
+        return eval_calls
+
+    eval_root_df = _filter_duplicate_span_calls(eval_root_df)
+    most_recent_eval_root_ids = set(eval_root_df["eval_root_id"].unique())
+
+    # Verify all eval_calls have eval_root_id
+    for c in eval_calls:
+        if "eval_root_id" not in c:
+            raise KeyError("eval_root_id missing from EVAL spans")
+
+    return [
+        c for c in eval_calls if c["eval_root_id"] in most_recent_eval_root_ids
+    ]
+
+
+def _process_eval_calls_for_display(
+    eval_calls: List[Dict[str, Any]],
+) -> pd.DataFrame:
+    """Process EVAL calls into a displayable DataFrame.
+
+    Args:
+        eval_calls: List of EVAL span dictionaries
+
+    Returns:
+        DataFrame ready for display
+    """
+    # Convert non-string args to formatted strings
+    for c in eval_calls:
+        args: Dict = c["args"]
+        for k, v in args.items():
+            if not isinstance(v, str):
+                args[k] = pp.pformat(v)
+
+    # Create DataFrame from processed calls
+    df = pd.DataFrame.from_records(c["args"] for c in eval_calls)
+    df["score"] = pd.DataFrame([
+        float(eval_calls[i]["ret"]) if eval_calls[i]["ret"] is not None else -1
+        for i in range(len(eval_calls))
+    ])
+    df["meta"] = pd.Series([
+        eval_calls[i]["meta"] for i in range(len(eval_calls))
+    ])
+
+    return df.join(df.meta.apply(lambda m: pd.Series(m))).drop(
+        columns=["meta", "output", "metadata"], errors="ignore"
+    )
+
+
 def display_feedback_call(
     record_id: str,
     call: List[Dict[str, Any]],
     feedback_name: str,
     feedback_directions: Dict[str, bool],
 ):
-    """Display the feedback call details in a DataFrame.
+    """Display feedback call details in a DataFrame. For OTel spans, this function filters and displays EVAL spans only, not EVAL_ROOT spans.
 
     Args:
         record_id (str): The record ID.
@@ -53,67 +151,54 @@ def display_feedback_call(
         feedback_name (str): The feedback name.
         feedback_directions (Dict[str, bool]): A dictionary mapping feedback names to their directions. True if higher is better, False otherwise.
     """
-    if call is not None and len(call) > 0:
-        # NOTE(piotrm for garett): converting feedback
-        # function inputs to strings here as other
-        # structures get rendered as [object Object] in the
-        # javascript downstream. If the first input/column
-        # is a list, the DataFrame.from_records does create
-        # multiple rows, one for each element, but if the
-        # second or other column is a list, it will not do
-        # this.
-        for c in call:
-            args: Dict = c["args"]
-            for k, v in args.items():
-                if not isinstance(v, str):
-                    args[k] = pp.pformat(v)
-
-        df = pd.DataFrame.from_records(c["args"] for c in call)
-
-        df["score"] = pd.DataFrame([
-            float(call[i]["ret"]) if call[i]["ret"] is not None else -1
-            for i in range(len(call))
-        ])
-        df["meta"] = pd.Series([call[i]["meta"] for i in range(len(call))])
-        df = df.join(df.meta.apply(lambda m: pd.Series(m))).drop(
-            columns=["meta", "output", "metadata"], errors="ignore"
-        )
-
-        # Filter to only show the latest results for calls with the same args_span_id and args_span_attribute
-        # NOTE: this is an optimization to not show duplicate calls in the UI (e.g. when a feedback function is recomputed on the same metric name and inputs)
-        df = _filter_duplicate_span_calls(df)
-
-        # note: improve conditional to not rely on the feedback name
-        if "groundedness" in feedback_name.lower():
-            try:
-                df = expand_groundedness_df(df)
-            except ValueError:
-                st.error(
-                    "Error expanding groundedness DataFrame. "
-                    "Please ensure the DataFrame is in the correct format."
-                )
-
-        if df.empty:
-            st.warning("No feedback details found.")
-        else:
-            style_highlight_fn = partial(
-                highlight,
-                selected_feedback=feedback_name,
-                feedback_directions=feedback_directions,
-                default_direction=default_direction,
-            )
-            styled_df = df.style.apply(
-                style_highlight_fn,
-                axis=1,
-            )
-
-            # Format only numeric columns
-            for col in df.select_dtypes(include=["number"]).columns:
-                styled_df = styled_df.format({col: "{:.2f}"})
-
-            st.dataframe(styled_df, hide_index=True)
-    else:
+    if not call:
         st.warning("No feedback details found.")
+        return
+
+    # First, identify and separate EVAL_ROOT and feedback calls (EVAL spans)
+    eval_root_calls, eval_calls = _identify_span_types(call)
+
+    # For OTel spans only: filter EVAL_ROOT spans to get most recent ones
+    eval_calls = _filter_eval_calls_by_root(eval_root_calls, eval_calls)
+
+    if not eval_calls:
+        st.warning("No feedback details found.")
+        return
+
+    # Process feedback calls (EVAL spans) for display
+    df = _process_eval_calls_for_display(eval_calls)
+
+    # Handle groundedness feedback specially
+    if "groundedness" in feedback_name.lower():
+        try:
+            df = expand_groundedness_df(df)
+        except ValueError:
+            st.error(
+                "Error expanding groundedness DataFrame. "
+                "Please ensure the DataFrame is in the correct format."
+            )
+
+    if df.empty:
+        st.warning("No feedback details found.")
+        return
+
+    # Style and display the DataFrame
+    style_highlight_fn = partial(
+        highlight,
+        selected_feedback=feedback_name,
+        feedback_directions=feedback_directions,
+        default_direction=default_direction,
+    )
+    styled_df = df.style.apply(
+        style_highlight_fn,
+        axis=1,
+    )
+
+    # Format only numeric columns
+    for col in df.select_dtypes(include=["number"]).columns:
+        styled_df = styled_df.format({col: "{:.2f}"})
+
+    st.dataframe(styled_df, hide_index=True)
 
 
 def _filter_duplicate_span_calls(df: pd.DataFrame) -> pd.DataFrame:
@@ -127,14 +212,27 @@ def _filter_duplicate_span_calls(df: pd.DataFrame) -> pd.DataFrame:
 
     Returns:
         DataFrame with duplicate span calls filtered to show only rows from the most recent eval_root_id
+
+    Raises:
+        KeyError: If required columns (eval_root_id, timestamp) are missing
+        ValueError: If timestamps are invalid (None or not parseable)
     """
     # Early exit if required columns are missing
-    if not {"eval_root_id", "timestamp"}.issubset(df.columns) or df.empty:
+    required_columns = {"eval_root_id", "timestamp"}
+    missing_columns = required_columns - set(df.columns)
+    if missing_columns:
+        raise KeyError(f"Required columns missing: {missing_columns}")
+
+    if df.empty:
         return df
+
+    # Verify timestamps are valid
+    if df["timestamp"].isna().any():
+        raise ValueError("Invalid timestamps: None values found")
 
     # If we have args_span_id and args_span_attribute columns, do sophisticated deduplication
     if {"args_span_id", "args_span_attribute"}.issubset(df.columns):
-        # Avoid full copy - create string columns directly without modifying original df
+        # Create string columns for grouping
         args_span_id_str = (
             df["args_span_id"]
             .astype(str)
@@ -151,42 +249,32 @@ def _filter_duplicate_span_calls(df: pd.DataFrame) -> pd.DataFrame:
             [args_span_id_str, args_span_attribute_str], dropna=False
         )
 
-        # Find the most recent eval_root_id for each group and collect indices
-        indices_to_keep = []
+        # Find the most recent eval_root_id for each group
+        most_recent_indices = []
         for _, group_df in grouped:
             if len(group_df) <= 1:
                 # Single eval_root_id - keep all rows
-                indices_to_keep.extend(group_df.index)
+                most_recent_indices.extend(group_df.index)
             else:
                 # Multiple eval_root_ids - keep only the most recent one
-                most_recent_eval_root_id = group_df.loc[
-                    group_df["timestamp"].idxmax(), "eval_root_id"
-                ]
-                recent_rows = group_df[
-                    group_df["eval_root_id"] == most_recent_eval_root_id
-                ]
-                indices_to_keep.extend(recent_rows.index)
+                most_recent_idx = group_df["timestamp"].idxmax()
+                most_recent_indices.append(most_recent_idx)
 
-        # Filter and clean up
-        if indices_to_keep:
-            filtered_df = df.loc[indices_to_keep]
-            return filtered_df.drop(
-                columns=[
-                    "eval_root_id",
-                    "args_span_id",
-                    "args_span_attribute",
-                ],
-                errors="ignore",
-            )
+        # Filter to keep only the most recent rows
+        filtered_df = df.loc[most_recent_indices].copy()
+
+        # Drop columns that were only needed for filtering, but keep eval_root_id
+        return filtered_df.drop(
+            columns=["args_span_id", "args_span_attribute", "timestamp"],
+            errors="ignore",
+        )
     else:
         # Simple case: just keep rows from the most recent eval_root_id
         most_recent_eval_root_id = df.loc[
             df["timestamp"].idxmax(), "eval_root_id"
         ]
         filtered_df = df[df["eval_root_id"] == most_recent_eval_root_id].copy()
-        return filtered_df.drop(columns=["eval_root_id"], errors="ignore")
-
-    return df
+        return filtered_df.drop(columns=["timestamp"], errors="ignore")
 
 
 def _render_feedback_pills(

--- a/src/dashboard/trulens/dashboard/utils/records_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/records_utils.py
@@ -269,12 +269,9 @@ def _filter_duplicate_span_calls(df: pd.DataFrame) -> pd.DataFrame:
             errors="ignore",
         )
     else:
-        # Simple case: just keep rows from the most recent eval_root_id
-        most_recent_eval_root_id = df.loc[
-            df["timestamp"].idxmax(), "eval_root_id"
-        ]
-        filtered_df = df[df["eval_root_id"] == most_recent_eval_root_id].copy()
-        return filtered_df.drop(columns=["timestamp"], errors="ignore")
+        # If we only have spans with no args_span_id or args_span_attribute,
+        # return all spans without filtering
+        return df.drop(columns=["timestamp"], errors="ignore")
 
 
 def _render_feedback_pills(

--- a/tests/unit/test_records_utils.py
+++ b/tests/unit/test_records_utils.py
@@ -1,248 +1,210 @@
-"""Test module for dashboard records_utils functions."""
-
 from datetime import datetime
-import unittest
 
 import pandas as pd
+import pytest
 from trulens.dashboard.utils.records_utils import _filter_duplicate_span_calls
+from trulens.dashboard.utils.records_utils import _filter_eval_calls_by_root
+from trulens.dashboard.utils.records_utils import _identify_span_types
+
+# Test data for OTel spans
+OTEL_EVAL_ROOT = {
+    "span_type": "EVAL_ROOT",
+    "eval_root_id": "root1",
+    "timestamp": datetime.now().isoformat(),
+    "args_span_id": "span1",
+    "args_span_attribute": "attr1",
+}
+
+OTEL_EVAL = {
+    "span_type": "EVAL",
+    "eval_root_id": "root1",
+    "timestamp": datetime.now().isoformat(),
+    "args": {"input": "test"},
+    "ret": 0.8,
+    "meta": {"feedback": "test"},
+}
+
+# Test data for legacy spans
+LEGACY_EVAL = {
+    "args": {"input": "test"},
+    "ret": 0.8,
+    "meta": {"feedback": "test"},
+}
 
 
-class TestFilterDuplicateSpanCalls(unittest.TestCase):
-    """Test cases for _filter_duplicate_span_calls function."""
+def test_identify_span_types_otel():
+    """Test identifying span types with OTel tracing enabled."""
+    calls = [OTEL_EVAL_ROOT, OTEL_EVAL]
+    eval_root_calls, eval_calls = _identify_span_types(calls)
 
-    def test_filter_duplicate_span_calls_keeps_most_recent_eval_root_id(self):
-        """Test that the function keeps only rows from the most recent eval_root_id when args_span_id and args_span_attribute are identical."""
-        # Create test data with duplicate args_span_id/args_span_attribute but different eval_root_ids
-        test_data = pd.DataFrame([
-            {
-                "eval_root_id": "eval_1",
-                "timestamp": datetime(2023, 1, 1, 10, 0, 0),
-                "args_span_id": {"span": "test_span_1"},
-                "args_span_attribute": {"attr": "test_attr_1"},
-                "score": 0.8,
-                "other_data": "row1_eval1",
-            },
-            {
-                "eval_root_id": "eval_2",
-                "timestamp": datetime(2023, 1, 1, 11, 0, 0),  # More recent
-                "args_span_id": {"span": "test_span_1"},
-                "args_span_attribute": {"attr": "test_attr_1"},
-                "score": 0.9,
-                "other_data": "row1_eval2",
-            },
-            {
-                "eval_root_id": "eval_2",
-                "timestamp": datetime(
-                    2023, 1, 1, 11, 5, 0
-                ),  # Another row from same eval_root_id
-                "args_span_id": {"span": "test_span_1"},
-                "args_span_attribute": {"attr": "test_attr_1"},
-                "score": 0.85,
-                "other_data": "row2_eval2",
-            },
-        ])
+    assert len(eval_root_calls) == 1
+    assert len(eval_calls) == 1
+    assert eval_root_calls[0]["span_type"] == "EVAL_ROOT"
+    assert eval_calls[0]["span_type"] == "EVAL"
 
-        result = _filter_duplicate_span_calls(test_data)
 
-        # Should keep both rows from eval_2 (the most recent eval_root_id)
-        self.assertEqual(len(result), 2)
-        self.assertIn("row1_eval2", result["other_data"].values)
-        self.assertIn("row2_eval2", result["other_data"].values)
-        # Metadata columns should be dropped
-        self.assertNotIn("eval_root_id", result.columns)
-        self.assertNotIn("args_span_id", result.columns)
-        self.assertNotIn("args_span_attribute", result.columns)
+def test_identify_span_types_legacy():
+    """Test identifying span types with legacy spans."""
+    calls = [LEGACY_EVAL]
+    eval_root_calls, eval_calls = _identify_span_types(calls)
 
-    def test_filter_duplicate_span_calls_keeps_unique_combinations(self):
-        """Test that rows with unique args_span_id/args_span_attribute combinations are kept regardless of eval_root_id."""
-        test_data = pd.DataFrame([
-            {
-                "eval_root_id": "eval_1",
-                "timestamp": datetime(2023, 1, 1, 10, 0, 0),
-                "args_span_id": {"span": "test_span_1"},
-                "args_span_attribute": {"attr": "test_attr_1"},
-                "score": 0.8,
-                "other_data": "unique_row_1",
-            },
-            {
-                "eval_root_id": "eval_1",
-                "timestamp": datetime(2023, 1, 1, 10, 0, 0),
-                "args_span_id": {"span": "test_span_2"},  # Different span_id
-                "args_span_attribute": {"attr": "test_attr_1"},
-                "score": 0.7,
-                "other_data": "unique_row_2",
-            },
-            {
-                "eval_root_id": "eval_2",
-                "timestamp": datetime(2023, 1, 1, 11, 0, 0),
-                "args_span_id": {"span": "test_span_1"},
-                "args_span_attribute": {
-                    "attr": "test_attr_2"
-                },  # Different attribute
-                "score": 0.9,
-                "other_data": "unique_row_3",
-            },
-        ])
+    assert len(eval_root_calls) == 0
+    assert len(eval_calls) == 1
+    assert "args" in eval_calls[0]
+    assert "ret" in eval_calls[0]
+    assert "meta" in eval_calls[0]
 
-        result = _filter_duplicate_span_calls(test_data)
 
-        # Should keep all rows since they all have unique combinations
-        self.assertEqual(len(result), 3)
-        expected_values = {"unique_row_1", "unique_row_2", "unique_row_3"}
-        self.assertEqual(set(result["other_data"].values), expected_values)
+def test_filter_eval_calls_by_root():
+    """Test filtering eval calls by root spans."""
+    eval_root_calls = [OTEL_EVAL_ROOT]
+    eval_calls = [OTEL_EVAL]
 
-    def test_filter_duplicate_span_calls_with_none_values(self):
-        """Test handling of None values in args_span_id and args_span_attribute."""
-        test_data = pd.DataFrame([
-            {
-                "eval_root_id": "eval_1",
-                "timestamp": datetime(2023, 1, 1, 10, 0, 0),
-                "args_span_id": None,
-                "args_span_attribute": None,
-                "score": 0.8,
-                "other_data": "none_row_1",
-            },
-            {
-                "eval_root_id": "eval_2",
-                "timestamp": datetime(2023, 1, 1, 11, 0, 0),  # More recent
-                "args_span_id": None,
-                "args_span_attribute": None,
-                "score": 0.9,
-                "other_data": "none_row_2",
-            },
-        ])
+    filtered_calls = _filter_eval_calls_by_root(eval_root_calls, eval_calls)
+    assert len(filtered_calls) == 1
+    assert filtered_calls[0]["eval_root_id"] == "root1"
 
-        result = _filter_duplicate_span_calls(test_data)
 
-        # Should keep only the row from the most recent eval_root_id
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result["other_data"].iloc[0], "none_row_2")
-        # Metadata columns should be dropped
-        self.assertNotIn("eval_root_id", result.columns)
+def test_filter_eval_calls_by_root_no_roots():
+    """Test filtering eval calls when no root spans exist."""
+    eval_root_calls = []
+    eval_calls = [OTEL_EVAL]
 
-    def test_filter_duplicate_span_calls_missing_columns(self):
-        """Test that function returns original DataFrame when required columns are missing."""
-        test_data = pd.DataFrame([
-            {
-                "eval_root_id": "eval_1",
-                "score": 0.8,
-                "other_data": "test_row",
-            }
-        ])
+    filtered_calls = _filter_eval_calls_by_root(eval_root_calls, eval_calls)
+    assert len(filtered_calls) == 1
+    assert filtered_calls == eval_calls
 
-        result = _filter_duplicate_span_calls(test_data)
 
-        # Should return original DataFrame unchanged
-        pd.testing.assert_frame_equal(result, test_data)
+def test_filter_duplicate_span_calls():
+    """Test filtering duplicate span calls."""
+    # Create test data with duplicates
+    data = {
+        "eval_root_id": ["root1", "root2", "root1"],
+        "timestamp": [
+            datetime.now().isoformat(),
+            datetime.now().isoformat(),
+            datetime.now().isoformat(),
+        ],
+        "args_span_id": ["span1", "span1", "span1"],
+        "args_span_attribute": ["attr1", "attr1", "attr1"],
+    }
+    df = pd.DataFrame(data)
 
-    def test_filter_duplicate_span_calls_empty_dataframe(self):
-        """Test that function handles empty DataFrame gracefully."""
-        test_data = pd.DataFrame()
+    filtered_df = _filter_duplicate_span_calls(df)
+    assert len(filtered_df) == 1
+    assert "eval_root_id" in filtered_df.columns
+    assert "args_span_id" not in filtered_df.columns
+    assert "args_span_attribute" not in filtered_df.columns
+    assert "timestamp" not in filtered_df.columns
 
-        result = _filter_duplicate_span_calls(test_data)
 
-        # Should return empty DataFrame
-        self.assertTrue(result.empty)
+def test_filter_duplicate_span_calls_missing_columns():
+    """Test filtering duplicate span calls with missing columns."""
+    # Create test data without required columns
+    data = {
+        "eval_root_id": ["root1", "root2"],
+        "other_column": ["value1", "value2"],
+    }
+    df = pd.DataFrame(data)
+    with pytest.raises(
+        KeyError, match="Required columns missing: {'timestamp'}"
+    ):
+        _filter_duplicate_span_calls(df)
 
-    def test_filter_duplicate_span_calls_complex_scenario(self):
-        """Test a complex scenario with multiple groups and eval_root_ids."""
-        test_data = pd.DataFrame([
-            # Group 1: span_1 + attr_1 (should keep eval_3 rows)
-            {
-                "eval_root_id": "eval_1",
-                "timestamp": datetime(2023, 1, 1, 10, 0, 0),
-                "args_span_id": {"span": "test_span_1"},
-                "args_span_attribute": {"attr": "test_attr_1"},
-                "score": 0.8,
-                "other_data": "group1_eval1",
-            },
-            {
-                "eval_root_id": "eval_3",
-                "timestamp": datetime(
-                    2023, 1, 1, 12, 0, 0
-                ),  # Most recent for group 1
-                "args_span_id": {"span": "test_span_1"},
-                "args_span_attribute": {"attr": "test_attr_1"},
-                "score": 0.95,
-                "other_data": "group1_eval3_row1",
-            },
-            {
-                "eval_root_id": "eval_3",
-                "timestamp": datetime(
-                    2023, 1, 1, 12, 5, 0
-                ),  # Another row from eval_3
-                "args_span_id": {"span": "test_span_1"},
-                "args_span_attribute": {"attr": "test_attr_1"},
-                "score": 0.92,
-                "other_data": "group1_eval3_row2",
-            },
-            # Group 2: span_2 + attr_2 (should keep eval_2 row)
-            {
-                "eval_root_id": "eval_1",
-                "timestamp": datetime(2023, 1, 1, 10, 30, 0),
-                "args_span_id": {"span": "test_span_2"},
-                "args_span_attribute": {"attr": "test_attr_2"},
-                "score": 0.7,
-                "other_data": "group2_eval1",
-            },
-            {
-                "eval_root_id": "eval_2",
-                "timestamp": datetime(
-                    2023, 1, 1, 11, 30, 0
-                ),  # Most recent for group 2
-                "args_span_id": {"span": "test_span_2"},
-                "args_span_attribute": {"attr": "test_attr_2"},
-                "score": 0.85,
-                "other_data": "group2_eval2",
-            },
-            # Group 3: span_3 + attr_3 (unique, should keep)
-            {
-                "eval_root_id": "eval_1",
-                "timestamp": datetime(2023, 1, 1, 10, 45, 0),
-                "args_span_id": {"span": "test_span_3"},
-                "args_span_attribute": {"attr": "test_attr_3"},
-                "score": 0.6,
-                "other_data": "group3_unique",
-            },
-        ])
 
-        result = _filter_duplicate_span_calls(test_data)
+def test_filter_duplicate_span_calls_empty():
+    """Test filtering duplicate span calls with empty DataFrame."""
+    df = pd.DataFrame()
+    with pytest.raises(
+        KeyError,
+        match="Required columns missing",
+    ):
+        _filter_duplicate_span_calls(df)
 
-        # Should keep 4 rows: 2 from group1_eval3, 1 from group2_eval2, 1 from group3
-        self.assertEqual(len(result), 4)
-        expected_values = {
-            "group1_eval3_row1",
-            "group1_eval3_row2",
-            "group2_eval2",
-            "group3_unique",
-        }
-        self.assertEqual(set(result["other_data"].values), expected_values)
 
-    def test_filter_duplicate_span_calls_with_string_values(self):
-        """Test function works with string values in args_span_id and args_span_attribute."""
-        test_data = pd.DataFrame([
-            {
-                "eval_root_id": "eval_1",
-                "timestamp": datetime(2023, 1, 1, 10, 0, 0),
-                "args_span_id": "string_span_1",
-                "args_span_attribute": "string_attr_1",
-                "score": 0.8,
-                "other_data": "string_row_1",
-            },
-            {
-                "eval_root_id": "eval_2",
-                "timestamp": datetime(2023, 1, 1, 11, 0, 0),  # More recent
-                "args_span_id": "string_span_1",
-                "args_span_attribute": "string_attr_1",
-                "score": 0.9,
-                "other_data": "string_row_2",
-            },
-        ])
+def test_identify_span_types_malformed():
+    """Test _identify_span_types with malformed input (missing fields)."""
+    malformed = {"span_type": "EVAL"}  # missing eval_root_id, args, ret, meta
+    eval_root_calls, eval_calls = _identify_span_types([malformed])
+    # Should not raise, but may not classify as valid eval
+    assert isinstance(eval_root_calls, list)
+    assert isinstance(eval_calls, list)
 
-        result = _filter_duplicate_span_calls(test_data)
 
-        # Should keep only the row from the most recent eval_root_id
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result["other_data"].iloc[0], "string_row_2")
-        # Metadata columns should be dropped
-        self.assertNotIn("eval_root_id", result.columns)
+def test_identify_span_types_multiple():
+    """Test _identify_span_types with multiple EVAL_ROOT and EVAL spans."""
+    calls = [
+        dict(OTEL_EVAL_ROOT),
+        dict(OTEL_EVAL_ROOT, eval_root_id="root2"),
+        dict(OTEL_EVAL),
+        dict(OTEL_EVAL, eval_root_id="root2"),
+    ]
+    eval_root_calls, eval_calls = _identify_span_types(calls)
+    assert len(eval_root_calls) == 2
+    assert len(eval_calls) == 2
+
+
+def test_filter_eval_calls_by_root_missing_eval_root_id():
+    """Test _filter_eval_calls_by_root with EVAL call missing eval_root_id."""
+    eval_root_calls = [dict(OTEL_EVAL_ROOT)]
+    eval_calls = [dict(OTEL_EVAL)]
+    del eval_calls[0]["eval_root_id"]
+    with pytest.raises(KeyError, match="eval_root_id"):
+        _filter_eval_calls_by_root(eval_root_calls, eval_calls)
+
+
+def test_filter_eval_calls_by_root_non_matching_eval_root_id():
+    """Test _filter_eval_calls_by_root with EVAL call referencing non-existent root."""
+    eval_root_calls = [dict(OTEL_EVAL_ROOT)]
+    eval_calls = [dict(OTEL_EVAL, eval_root_id="not_a_root")]  # not in roots
+    filtered = _filter_eval_calls_by_root(eval_root_calls, eval_calls)
+    assert filtered == []
+
+
+def test_filter_eval_calls_by_root_missing_eval_root_id_in_root():
+    """Test _filter_eval_calls_by_root with EVAL_ROOT missing eval_root_id."""
+    eval_root_calls = [dict(OTEL_EVAL_ROOT)]
+    del eval_root_calls[0]["eval_root_id"]
+    eval_calls = [dict(OTEL_EVAL)]
+    with pytest.raises(KeyError, match="eval_root_id"):
+        _filter_eval_calls_by_root(eval_root_calls, eval_calls)
+
+
+def test_filter_duplicate_span_calls_multiple_groups():
+    """Test _filter_duplicate_span_calls with multiple groups, each with duplicates."""
+    data = {
+        "eval_root_id": ["root1", "root2", "root3", "root4"],
+        "timestamp": [
+            datetime.now().isoformat(),
+            datetime.now().isoformat(),
+            datetime.now().isoformat(),
+            datetime.now().isoformat(),
+        ],
+        "args_span_id": ["span1", "span1", "span2", "span2"],
+        "args_span_attribute": ["attr1", "attr1", "attr2", "attr2"],
+    }
+    df = pd.DataFrame(data)
+    filtered_df = _filter_duplicate_span_calls(df)
+    # Should keep only the most recent for each group
+    assert len(filtered_df) == 2
+
+
+def test_filter_duplicate_span_calls_invalid_timestamps():
+    """Test _filter_duplicate_span_calls with invalid timestamps."""
+    data = {
+        "eval_root_id": ["root1", "root2"],
+        "timestamp": [None, None],
+        "args_span_id": ["span1", "span1"],
+        "args_span_attribute": ["attr1", "attr1"],
+    }
+    df = pd.DataFrame(data)
+    with pytest.raises(ValueError, match="timestamp"):
+        _filter_duplicate_span_calls(df)
+
+
+def test_filter_duplicate_span_calls_all_columns_missing():
+    """Test _filter_duplicate_span_calls with all required columns missing."""
+    data = {"foo": [1, 2], "bar": [3, 4]}
+    df = pd.DataFrame(data)
+    with pytest.raises(KeyError, match="eval_root_id"):
+        _filter_duplicate_span_calls(df)

--- a/tests/unit/test_records_utils.py
+++ b/tests/unit/test_records_utils.py
@@ -81,9 +81,9 @@ def test_filter_duplicate_span_calls():
     data = {
         "eval_root_id": ["root1", "root2", "root1"],
         "timestamp": [
-            datetime.now().isoformat(),
-            datetime.now().isoformat(),
-            datetime.now().isoformat(),
+            "2023-01-01T01:00:00",
+            "2023-02-01T02:00:00",
+            "2023-03-01T03:00:00",
         ],
         "args_span_id": ["span1", "span1", "span1"],
         "args_span_attribute": ["attr1", "attr1", "attr1"],


### PR DESCRIPTION
# Description

#2003 introduced logic for deduping calls that relied heavily on `EVAL_ROOT` spans. However, the underlying display code was brittle, and introducing a new span type into the feedback call table broke a number of different assumptions made by the legacy visualization code (e.g. assuming that `EVAL_ROOT` and `EVAL` spans have the same fields available to them, assuming that this same filter logic would work for non-OTel spans, etc.).

The old implementation also displayed the EVAL_ROOT span in the table, which is not ideal (the other columns are empty, so this looked odd...)

This PR:
- updates the filter/dedup logic to work with both OTel (dedup) and non-OTel spans (passed through as-is), 
- attempts to make the filtering logic more readable and easier to maintain, and
- fixes visualization issues for feedback calls across both OTel and non-OTel spans (see comments below).

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

Working:

![Screenshot 2025-06-17 at 3 24 48 PM](https://github.com/user-attachments/assets/b4424534-8590-4972-ad24-cd89d70fd30f)

![Screenshot 2025-06-17 at 3 36 27 PM](https://github.com/user-attachments/assets/afd41638-ce5e-4640-a3f0-f90a1fa39c6c)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes deduplication logic for feedback calls to support both OTel and non-OTel spans, improving filtering and visualization.
> 
>   - **Behavior**:
>     - Updates deduplication logic in `display_feedback_call` to handle both OTel and non-OTel spans.
>     - Filters EVAL spans, excluding EVAL_ROOT spans, for OTel spans.
>     - Improves readability and maintainability of filtering logic.
>   - **Functions**:
>     - Adds `_identify_span_types` to separate EVAL_ROOT and EVAL spans.
>     - Adds `_filter_eval_calls_by_root` to filter EVAL calls by recent EVAL_ROOT spans.
>     - Updates `_filter_duplicate_span_calls` to handle missing columns and invalid timestamps.
>   - **Tests**:
>     - Adds tests for `_identify_span_types`, `_filter_eval_calls_by_root`, and `_filter_duplicate_span_calls` in `test_records_utils.py`.
>     - Tests cover OTel and legacy spans, missing columns, and invalid timestamps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for c8da285521835ee4a0c0d2b782e1a1c057d6c768. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->