### PR TITLE
Add makefile recipe to install all subpackages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,13 @@ lock: $(POETRY_DIRS)
 		poetry lock -C $$dir; \
 	done
 
+# Lock the poetry dependencies for all the subprojects.
+pip-install: $(POETRY_DIRS)
+	for dir in $(POETRY_DIRS); do \
+		echo "Installing $$dir/pyproject.toml"; \
+		pip install $$dir; \
+	done
+
 # Test build of conda packages against the Snowflake channel
 # This does not publish packages, only builds them locally.
 conda-build: $(CONDA_BUILD_DIRS)

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ lock: $(POETRY_DIRS)
 		poetry lock -C $$dir; \
 	done
 
-# Lock the poetry dependencies for all the subprojects.
+# Install all the subprojects using pip.
 pip-install: $(POETRY_DIRS)
 	pip install $(POETRY_DIRS)
 

--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,7 @@ lock: $(POETRY_DIRS)
 
 # Lock the poetry dependencies for all the subprojects.
 pip-install: $(POETRY_DIRS)
-	for dir in $(POETRY_DIRS); do \
-		echo "Installing $$dir/pyproject.toml"; \
-		pip install $$dir; \
-	done
+	pip install $(POETRY_DIRS)
 
 # Test build of conda packages against the Snowflake channel
 # This does not publish packages, only builds them locally.


### PR DESCRIPTION
# Description

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `pip-install` target to Makefile for installing all subprojects using pip.
> 
>   - **Makefile**:
>     - Adds `pip-install` target to install all subprojects using pip.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 1c97edad5dafa705ac4570a5eb679d8fefcab8ee. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->