### PR TITLE
Use pydantic ConfigDict and inherit

### DIFF
--- a/src/apps/llamaindex/trulens/apps/llamaindex/tru_llama.py
+++ b/src/apps/llamaindex/trulens/apps/llamaindex/tru_llama.py
@@ -392,8 +392,6 @@ class TruLlama(core_app.App):
             and [AppDefinition][trulens.core.schema.app.AppDefinition].
     """
 
-    model_config: ClassVar[dict] = dict(arbitrary_types_allowed=True)
-
     app: Union[BaseQueryEngine, BaseChatEngine]
 
     # TODEP

--- a/src/apps/nemo/trulens/apps/nemo/tru_rails.py
+++ b/src/apps/nemo/trulens/apps/nemo/tru_rails.py
@@ -379,8 +379,6 @@ class TruRails(core_app.App):
         app: A _NeMo Guardrails_ application.
     """
 
-    model_config: ClassVar[dict] = {"arbitrary_types_allowed": True}
-
     app: LLMRails
 
     # TODEP

--- a/src/core/trulens/apps/app.py
+++ b/src/core/trulens/apps/app.py
@@ -196,7 +196,6 @@ import logging
 from pprint import PrettyPrinter
 from typing import Any, Callable, ClassVar, Optional, Set
 
-import pydantic
 from pydantic import Field
 from trulens.core import app as core_app
 from trulens.core import instruments as core_instruments
@@ -327,10 +326,6 @@ class TruApp(core_app.App):
         **kwargs: Additional arguments to pass to [App][trulens.core.app.App]
             and [AppDefinition][trulens.core.schema.app.AppDefinition]
     """
-
-    model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
-        arbitrary_types_allowed=True
-    )
 
     app: Any
 

--- a/src/core/trulens/apps/basic.py
+++ b/src/core/trulens/apps/basic.py
@@ -102,8 +102,6 @@ class TruBasicApp(core_app.App):
             and [AppDefinition][trulens.core.schema.app.AppDefinition]
     """
 
-    model_config: ClassVar[dict] = dict(arbitrary_types_allowed=True)
-
     app: TruWrapperApp
     """The app to be instrumented."""
 

--- a/src/core/trulens/core/feedback/endpoint.py
+++ b/src/core/trulens/core/feedback/endpoint.py
@@ -69,6 +69,10 @@ class EndpointCallback(serial_utils.SerialModel):
     like token usage.
     """
 
+    model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
+        arbitrary_types_allowed=True
+    )
+
     endpoint: Endpoint = Field(exclude=True)
     """The endpoint owning this callback."""
 

--- a/src/core/trulens/core/feedback/provider.py
+++ b/src/core/trulens/core/feedback/provider.py
@@ -1,6 +1,7 @@
 import logging
 from typing import ClassVar, Optional
 
+from pydantic import ConfigDict
 from trulens.core.feedback import endpoint as core_endpoint
 from trulens.core.utils import pyschema as pyschema_utils
 from trulens.core.utils import serial as serial_utils
@@ -57,7 +58,9 @@ class Provider(pyschema_utils.WithClassInfo, serial_utils.SerialModel):
         ```
     """
 
-    model_config: ClassVar[dict] = dict(arbitrary_types_allowed=True)
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        arbitrary_types_allowed=True
+    )
 
     endpoint: Optional[core_endpoint.Endpoint] = None
     """Endpoint supporting this provider.

--- a/src/core/trulens/core/schema/feedback.py
+++ b/src/core/trulens/core/schema/feedback.py
@@ -323,7 +323,9 @@ class FeedbackDefinition(
     [Feedback][trulens.core.Feedback] class.
     """
 
-    model_config: ClassVar[dict] = dict(arbitrary_types_allowed=True)
+    model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
+        arbitrary_types_allowed=True
+    )
 
     implementation: Optional[
         Union[pyschema_utils.Function, pyschema_utils.Method]

--- a/src/core/trulens/core/schema/record.py
+++ b/src/core/trulens/core/schema/record.py
@@ -118,10 +118,9 @@ class Record(serial_utils.SerialModel, Hashable):
 
         return ret
 
-    model_config: ClassVar[dict] = {
-        # for `Future[FeedbackResult]`
-        "arbitrary_types_allowed": True
-    }
+    model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
+        arbitrary_types_allowed=True
+    )
 
     record_id: types_schema.RecordID
     """Unique identifier for this record."""

--- a/src/core/trulens/core/utils/pace.py
+++ b/src/core/trulens/core/utils/pace.py
@@ -8,6 +8,7 @@ import time
 from typing import ClassVar, Deque, Optional
 
 from pydantic import BaseModel
+from pydantic import ConfigDict
 from pydantic import Field
 from pydantic import PrivateAttr
 
@@ -68,7 +69,9 @@ class Pace(BaseModel):
     _alock: asyncio.Lock = PrivateAttr(default_factory=asyncio.Lock)
     """Asyncio Lock to ensure amark method details run only one at a time."""
 
-    model_config: ClassVar[dict] = dict(arbitrary_types_allowed=True)
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        arbitrary_types_allowed=True
+    )
 
     _warned: bool = False
     """Whether the long delay warning has already been issued.

--- a/src/feedback/trulens/feedback/groundtruth.py
+++ b/src/feedback/trulens/feedback/groundtruth.py
@@ -61,7 +61,9 @@ class GroundTruthAgreement(
 
     ground_truth_imp: Optional[Callable] = pydantic.Field(None, exclude=True)
 
-    model_config: ClassVar[dict] = dict(arbitrary_types_allowed=True)
+    model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
+        arbitrary_types_allowed=True
+    )
 
     def __init__(
         self,
@@ -744,7 +746,7 @@ class GroundTruthAgreement(
 class GroundTruthAggregator(
     pyschema_utils.WithClassInfo, serial_utils.SerialModel
 ):
-    model_config: ClassVar[dict] = dict(
+    model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
         arbitrary_types_allowed=True, extra="allow"
     )
     """Aggregate benchmarking metrics for ground-truth-based evaluation on feedback functions."""

--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -8,6 +8,7 @@ import nltk
 from nltk.tokenize import sent_tokenize
 import numpy as np
 from pydantic import BaseModel
+from pydantic import ConfigDict
 from trulens.core.feedback import feedback as core_feedback
 from trulens.core.feedback import provider as core_provider
 from trulens.core.utils import deprecation as deprecation_utils
@@ -43,7 +44,7 @@ class LLMProvider(core_provider.Provider):
     # warnings if we try to override some internal pydantic name.
     model_engine: str
 
-    model_config: ClassVar[dict] = dict(protected_namespaces=())
+    model_config: ClassVar[ConfigDict] = ConfigDict(protected_namespaces=())
 
     def __init__(self, *args, **kwargs):
         # TODO: why was self_kwargs required here independently of kwargs?

--- a/src/feedback/trulens/feedback/v2/provider/base.py
+++ b/src/feedback/trulens/feedback/v2/provider/base.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 from typing import ClassVar, Iterable, Optional
 
+import pydantic
 from trulens.core.feedback import endpoint as core_endpoint
 from trulens.core.utils import pyschema as pyschema_utils
 from trulens.core.utils import serial as serial_utils
@@ -16,7 +17,9 @@ from trulens.feedback.v2.feedback import WithPrompt
 
 
 class Provider(pyschema_utils.WithClassInfo, serial_utils.SerialModel):
-    model_config: ClassVar[dict] = dict(arbitrary_types_allowed=True)
+    model_config: ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
+        arbitrary_types_allowed=True
+    )
 
     endpoint: Optional[core_endpoint.Endpoint]
 

--- a/src/providers/bedrock/trulens/providers/bedrock/endpoint.py
+++ b/src/providers/bedrock/trulens/providers/bedrock/endpoint.py
@@ -1,7 +1,7 @@
 import inspect
 import logging
 import pprint
-from typing import Any, Callable, ClassVar, Iterable, Optional
+from typing import Any, Callable, Iterable, Optional
 
 import boto3
 from botocore.client import ClientCreator
@@ -15,8 +15,6 @@ pp = pprint.PrettyPrinter()
 
 
 class BedrockCallback(core_endpoint.EndpointCallback):
-    model_config: ClassVar[dict] = dict(arbitrary_types_allowed=True)
-
     def handle_generation_chunk(self, response: Any) -> None:
         super().handle_generation_chunk(response)
 

--- a/src/providers/cortex/trulens/providers/cortex/endpoint.py
+++ b/src/providers/cortex/trulens/providers/cortex/endpoint.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 import pprint
-from typing import Any, Callable, ClassVar, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from snowflake.cortex._sse_client import Event
 from snowflake.cortex._sse_client import SSEClient
@@ -50,7 +50,6 @@ class CortexCostComputer:
 
 
 class CortexCallback(core_endpoint.EndpointCallback):
-    model_config: ClassVar[dict] = dict(arbitrary_types_allowed=True)
     _model_costs: Optional[dict] = None
     # TODO (Daniel): cost tracking for Cortex finetuned models is not yet implemented.
 

--- a/src/providers/langchain/trulens/providers/langchain/endpoint.py
+++ b/src/providers/langchain/trulens/providers/langchain/endpoint.py
@@ -1,6 +1,6 @@
 import inspect
 import logging
-from typing import Any, Callable, ClassVar, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.language_models.llms import BaseLLM
@@ -10,8 +10,6 @@ logger = logging.getLogger(__name__)
 
 
 class LangchainCallback(core_endpoint.EndpointCallback):
-    model_config: ClassVar[dict] = dict(arbitrary_types_allowed=True)
-
     def handle_classification(self, response: Dict) -> None:
         super().handle_classification(response)
 

--- a/src/providers/litellm/trulens/providers/litellm/endpoint.py
+++ b/src/providers/litellm/trulens/providers/litellm/endpoint.py
@@ -1,7 +1,7 @@
 import inspect
 import logging
 import pprint
-from typing import Any, Callable, ClassVar, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 import pydantic
 from trulens.core.feedback import endpoint as core_endpoint
@@ -32,8 +32,6 @@ class LiteLLMCostComputer:
 
 
 class LiteLLMCallback(core_endpoint.EndpointCallback):
-    model_config: ClassVar[dict] = dict(arbitrary_types_allowed=True)
-
     def handle_classification(self, response: pydantic.BaseModel) -> None:
         super().handle_classification(response)
 

--- a/src/providers/openai/trulens/providers/openai/endpoint.py
+++ b/src/providers/openai/trulens/providers/openai/endpoint.py
@@ -133,8 +133,6 @@ class OpenAIClient(serial_utils.SerialModel):
     """Parameters of the OpenAI client that will not be serialized because they
     contain secrets."""
 
-    model_config: ClassVar[dict] = dict(arbitrary_types_allowed=True)
-
     client: Union[openai.OpenAI, openai.AzureOpenAI] = pydantic.Field(
         exclude=True
     )
@@ -226,8 +224,6 @@ class OpenAIClient(serial_utils.SerialModel):
 
 
 class OpenAICallback(core_endpoint.EndpointCallback):
-    model_config: ClassVar[dict] = dict(arbitrary_types_allowed=True)
-
     langchain_handler: OpenAICallbackHandler = pydantic.Field(
         default_factory=OpenAICallbackHandler, exclude=True
     )


### PR DESCRIPTION
# Description

The option to configure pydantic models with dictionaries is being deprecated. This should also remove some of the deprecation warnings we're seeing.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
