### PR TITLE
set alembic path_separator

### DIFF
--- a/src/core/trulens/core/database/migrations/alembic.ini
+++ b/src/core/trulens/core/database/migrations/alembic.ini
@@ -51,6 +51,7 @@ prepend_sys_path = .
 # version_path_separator = space
 version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
 
+path_separator = os # overrides version_path_separator
 # the output encoding used when revision files
 # are written from script.py.mako
 # output_encoding = utf-8


### PR DESCRIPTION
# Description

Removes an alembic warning that this field is not set.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
