### PR TITLE
[Major version change] Enable OTEL by default

### DIFF
--- a/docs/blog/posts/trulens_otel.md
+++ b/docs/blog/posts/trulens_otel.md
@@ -166,10 +166,11 @@ Today, we are launching a pre-release of TruLens on Otel. Below is a minimal wal
 pip install trulens-core==1.5.0
 ```
 
-2. **Enable OpenTelemetry**:
+2. **OpenTelemetry is enabled by default**:
 
 ```python
-os.environ["TRULENS_OTEL_TRACING"] = "1"
+# OpenTelemetry is now enabled by default
+# To disable it, set: os.environ["TRULENS_OTEL_TRACING"] = "0"
 ```
 
 3. **Instrument Methods**:

--- a/docs/component_guides/instrumentation/index.md
+++ b/docs/component_guides/instrumentation/index.md
@@ -4,7 +4,7 @@ TruLens is a framework designed to help you instrument and evaluate LLM applicat
 
 !!! note
 
-    To turn on OpenTelemetry tracing, set the environment variable `TRULENS_OTEL_TRACING` to "1".
+    OpenTelemetry tracing is enabled by default. To disable it, set the environment variable `TRULENS_OTEL_TRACING` to "0" or "false".
 
 This instrumentation capability allows you to track the entire execution flow of your app, including inputs, outputs, internal operations, and performance metrics.
 

--- a/src/core/trulens/core/otel/utils.py
+++ b/src/core/trulens/core/otel/utils.py
@@ -1,13 +1,27 @@
 import os
 
 
-def _is_env_var_set(var_name: str) -> bool:
-    return os.getenv(var_name, "").lower() in ["1", "true"]
+def _is_env_var_disabled(var_name: str) -> bool:
+    """Check if an environment variable is explicitly set to disable a feature.
+
+    Returns True if the environment variable is explicitly set to "0" or "false"
+    (case-insensitive), indicating the feature should be disabled.
+    Returns False otherwise (feature enabled by default).
+    """
+    return os.getenv(var_name, "").lower() in ["0", "false"]
 
 
 def is_otel_tracing_enabled() -> bool:
-    return _is_env_var_set("TRULENS_OTEL_TRACING")
+    """Check if OpenTelemetry tracing is enabled.
+
+    Returns True by default unless TRULENS_OTEL_TRACING is explicitly set to "0" or "false".
+    """
+    return not _is_env_var_disabled("TRULENS_OTEL_TRACING")
 
 
 def is_otel_backwards_compatibility_enabled() -> bool:
-    return _is_env_var_set("TRULENS_OTEL_BACKWARDS_COMPATIBILITY")
+    """Check if OpenTelemetry backwards compatibility is enabled.
+
+    Returns True by default unless TRULENS_OTEL_BACKWARDS_COMPATIBILITY is explicitly set to "0" or "false".
+    """
+    return not _is_env_var_disabled("TRULENS_OTEL_BACKWARDS_COMPATIBILITY")

--- a/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
@@ -705,14 +705,14 @@ def _show_no_records_error(
         st.error(
             f"No records found for app `{app_name}` in OTEL mode. "
             f"However, {non_otel_count} records exist in non-OTEL format. "
-            f"Restart without `TRULENS_OTEL_TRACING` to access them.",
+            f"Set `TRULENS_OTEL_TRACING=0` to disable OTEL mode and access them.",
             icon="🔄",
         )
     elif not is_otel_mode and non_otel_count == 0 and otel_count > 0:
         st.error(
             f"No records found for app `{app_name}` in non-OTEL mode. "
             f"However, {otel_count} records exist in OTEL format. "
-            f"Set `TRULENS_OTEL_TRACING=1` to access them.",
+            f"Remove `TRULENS_OTEL_TRACING=0` to enable OTEL mode and access them.",
             icon="🔄",
         )
     else:


### PR DESCRIPTION
# Description

This should go into trulens release 2.0.0.


We'll first only release `trulens-core` package to coordinate with the LLM GA GS release. 

And the rest of the packages, esp `trulens-dashboard` where some remaining work is needed to make record viewer work w/ OTE,  will be upgraded to 2.0.0 alongside the announcement from OSS. 

cc @sfc-gh-jreini  

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
