### PR TITLE
TruLens 2.0.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -10670,7 +10670,7 @@ reference = "pypi-public"
 
 [[package]]
 name = "trulens-apps-langchain"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10682,7 +10682,7 @@ develop = true
 langchain = ">=0.2.10"
 langchain-core = ">=0.2.0"
 pydantic = "^2.4.2"
-trulens-core = "^1.0.0"
+trulens-core = "^2.0.0"
 
 [package.source]
 type = "directory"
@@ -10690,7 +10690,7 @@ url = "src/apps/langchain"
 
 [[package]]
 name = "trulens-apps-llamaindex"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10705,8 +10705,8 @@ tiktoken = [
     {version = ">=0.3.3", markers = "python_version < \"3.13\""},
     {version = ">=0.8.0", markers = "python_version >= \"3.13\""},
 ]
-trulens-apps-langchain = "^1.0.0"
-trulens-core = "^1.0.0"
+trulens-apps-langchain = "^2.0.0"
+trulens-core = "^2.0.0"
 
 [package.source]
 type = "directory"
@@ -10714,7 +10714,7 @@ url = "src/apps/llamaindex"
 
 [[package]]
 name = "trulens-apps-nemo"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9,<3.13"
@@ -10730,8 +10730,8 @@ onnxruntime = [
     {version = ">=1.14.0", markers = "python_version >= \"3.10\""},
 ]
 pydantic = "^2.4.2"
-trulens-apps-langchain = "^1.0.0"
-trulens-core = "^1.0.0"
+trulens-apps-langchain = "^2.0.0"
+trulens-core = "^2.0.0"
 
 [package.source]
 type = "directory"
@@ -10739,7 +10739,7 @@ url = "src/apps/nemo"
 
 [[package]]
 name = "trulens-benchmark"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10749,7 +10749,7 @@ develop = true
 
 [package.dependencies]
 poetry = "<2.0.0"
-trulens-core = "^1.0.0"
+trulens-core = "^2.0.0"
 
 [package.source]
 type = "directory"
@@ -10757,7 +10757,7 @@ url = "src/benchmark"
 
 [[package]]
 name = "trulens-connectors-snowflake"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9,<3.13"
@@ -10769,7 +10769,7 @@ develop = true
 [package.dependencies]
 snowflake-snowpark-python = "^1.18"
 snowflake-sqlalchemy = "^1.6"
-trulens-core = "^1.0.0"
+trulens-core = "^2.0.0"
 
 [package.source]
 type = "directory"
@@ -10777,7 +10777,7 @@ url = "src/connectors/snowflake"
 
 [[package]]
 name = "trulens-core"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10803,7 +10803,7 @@ python-dotenv = ">=0.21,<2.0"
 requests = "^2.31"
 rich = "^13.6.0"
 sqlalchemy = "^2.0"
-trulens-otel-semconv = "^1.4.9"
+trulens-otel-semconv = "^2.0.0"
 typing_extensions = "^4.9"
 wrapt = ">=1.17.0"
 
@@ -10813,7 +10813,7 @@ url = "src/core"
 
 [[package]]
 name = "trulens-dashboard"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9,!=3.9.7"
@@ -10832,7 +10832,7 @@ rich = "^13.6"
 streamlit = "^1.35"
 streamlit-aggrid = {version = "^1.0.5", optional = true}
 traitlets = "^5.0.5"
-trulens-core = "^1.0.0"
+trulens-core = "^2.0.0"
 
 [package.extras]
 full = ["streamlit-aggrid (>=1.0.5,<2.0.0)"]
@@ -10843,7 +10843,7 @@ url = "src/dashboard"
 
 [[package]]
 name = "trulens-eval"
-version = "1.5.2"
+version = "2.0.0"
 description = "Backwards-compatibility package for API of trulens_eval<1.0.0 using API of trulens-*>=1.0.0."
 optional = false
 python-versions = "^3.9,!=3.9.7"
@@ -10852,9 +10852,9 @@ files = []
 develop = true
 
 [package.dependencies]
-trulens-core = "^1.0.0"
-trulens-dashboard = "^1.0.0"
-trulens-feedback = "^1.0.0"
+trulens-core = "^2.0.0"
+trulens-dashboard = "^2.0.0"
+trulens-feedback = "^2.0.0"
 
 [package.source]
 type = "directory"
@@ -10862,7 +10862,7 @@ url = "src/trulens_eval"
 
 [[package]]
 name = "trulens-feedback"
-version = "1.5.2"
+version = "2.0.0"
 description = "A TruLens extension package implementing feedback functions for LLM App evaluation."
 optional = false
 python-versions = "^3.9"
@@ -10877,7 +10877,7 @@ pydantic = "^2.4.2"
 requests = "^2.31"
 scikit-learn = "^1.3.0"
 scipy = "^1.11.1"
-trulens-core = "^1.0.0"
+trulens-core = "^2.0.0"
 
 [package.source]
 type = "directory"
@@ -10885,7 +10885,7 @@ url = "src/feedback"
 
 [[package]]
 name = "trulens-hotspots"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library and command-line tool to list features lowering your evaluation score."
 optional = false
 python-versions = "^3.9"
@@ -10897,7 +10897,7 @@ develop = true
 pandas = ">=1.0.0"
 regex = ">2021.8.28"
 scipy = "^1.11.1"
-trulens-core = "^1.0.0"
+trulens-core = "^2.0.0"
 
 [package.source]
 type = "directory"
@@ -10905,7 +10905,7 @@ url = "src/hotspots"
 
 [[package]]
 name = "trulens-otel-semconv"
-version = "1.5.2"
+version = "2.0.0"
 description = "Semantic conventions for spans produced by TruLens."
 optional = false
 python-versions = "^3.9"
@@ -10923,7 +10923,7 @@ url = "src/otel/semconv"
 
 [[package]]
 name = "trulens-providers-bedrock"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10934,8 +10934,8 @@ develop = true
 [package.dependencies]
 boto3 = "^1.33"
 botocore = "^1.33"
-trulens-core = "^1.0.0"
-trulens-feedback = "^1.0.0"
+trulens-core = "^2.0.0"
+trulens-feedback = "^2.0.0"
 
 [package.source]
 type = "directory"
@@ -10943,7 +10943,7 @@ url = "src/providers/bedrock"
 
 [[package]]
 name = "trulens-providers-cortex"
-version = "1.5.2"
+version = "2.0.0"
 description = "A TruLens extension package adding Snowflake Cortex support for LLM App evaluation."
 optional = false
 python-versions = "^3.9,<3.13"
@@ -10957,8 +10957,8 @@ packaging = ">=23.0"
 snowflake-connector-python = "^3.11"
 snowflake-ml-python = "^1.7.2"
 snowflake-snowpark-python = "^1.18.0"
-trulens-core = "^1.0.0"
-trulens-feedback = "^1.0.0"
+trulens-core = "^2.0.0"
+trulens-feedback = "^2.0.0"
 
 [package.source]
 type = "directory"
@@ -10966,7 +10966,7 @@ url = "src/providers/cortex"
 
 [[package]]
 name = "trulens-providers-huggingface"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10980,8 +10980,8 @@ numpy = ">=1.23.0"
 requests = "^2.31"
 torch = "^2.1.2"
 transformers = "^4.38.1"
-trulens-core = "^1.0.0"
-trulens-feedback = "^1.0.0"
+trulens-core = "^2.0.0"
+trulens-feedback = "^2.0.0"
 
 [package.source]
 type = "directory"
@@ -10989,7 +10989,7 @@ url = "src/providers/huggingface"
 
 [[package]]
 name = "trulens-providers-langchain"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10999,8 +10999,8 @@ develop = true
 
 [package.dependencies]
 langchain-core = ">=0.2.0"
-trulens-core = "^1.0.0"
-trulens-feedback = "^1.0.0"
+trulens-core = "^2.0.0"
+trulens-feedback = "^2.0.0"
 
 [package.source]
 type = "directory"
@@ -11008,7 +11008,7 @@ url = "src/providers/langchain"
 
 [[package]]
 name = "trulens-providers-litellm"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -11018,8 +11018,8 @@ develop = true
 
 [package.dependencies]
 litellm = "^1.25"
-trulens-core = "^1.0.0"
-trulens-feedback = "^1.0.0"
+trulens-core = "^2.0.0"
+trulens-feedback = "^2.0.0"
 
 [package.source]
 type = "directory"
@@ -11027,7 +11027,7 @@ url = "src/providers/litellm"
 
 [[package]]
 name = "trulens-providers-openai"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -11038,8 +11038,8 @@ develop = true
 [package.dependencies]
 langchain-community = ">=0.0.20"
 openai = ">=1.52.1"
-trulens-core = "^1.0.0"
-trulens-feedback = "^1.0.0"
+trulens-core = "^2.0.0"
+trulens-feedback = "^2.0.0"
 
 [package.source]
 type = "directory"
@@ -12032,4 +12032,4 @@ reference = "pypi-public"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9,!=3.9.7"
-content-hash = "b0c51804c2a065491a87bc3866eac42ca52862c1fb79bf5519db10b2331469e7"
+content-hash = "c3b40e79783029d9f779281dff31c4ff1381e35e7eaa74e830f7eeddab777f8f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,14 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9,!=3.9.7"
-trulens-core = { version = "^1.0.0" }
-trulens-feedback = { version = "^1.0.0" }
-trulens-dashboard = { version = "^1.0.0", extras = [
+trulens-core = { version = "^2.0.0" }
+trulens-feedback = { version = "^2.0.0" }
+trulens-dashboard = { version = "^2.0.0", extras = [
   "full",
 ] }
-trulens-otel-semconv = { version = "^1.0.0" }
+trulens-otel-semconv = { version = "^2.0.0" }
 # Remove after deprecation period:
-trulens_eval = { version = "^1.0.0" }
+trulens_eval = { version = "^2.0.0" }
 
 [tool.poetry.group.benchmark.dependencies]
 trulens-benchmark = { path = "src/benchmark", develop = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens"
-version = "2.0.0"
+version = "2.0.1"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/langchain/meta.yaml
+++ b/src/apps/langchain/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-apps-langchain" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "1.5.2" %}
+{% set version = "2.0.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/apps/langchain/meta.yaml
+++ b/src/apps/langchain/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-core >=1.0.0,<3.0.0
+    - trulens-core >=2.0.0,<3.0.0
     - langchain >=0.2.10
     - langchain-core >=0.2.0
     - pydantic >=2.4.2

--- a/src/apps/langchain/meta.yaml
+++ b/src/apps/langchain/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-apps-langchain" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.0.0" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}

--- a/src/apps/langchain/meta.yaml
+++ b/src/apps/langchain/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-core >=1.0.0,<2.0.0
+    - trulens-core >=1.0.0,<3.0.0
     - langchain >=0.2.10
     - langchain-core >=0.2.0
     - pydantic >=2.4.2

--- a/src/apps/langchain/meta.yaml
+++ b/src/apps/langchain/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-apps-langchain" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.0.1" %}
+{% set version = "1.5.2" %}
 
 package:
   name: {{ name|lower }}
@@ -25,7 +25,7 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-core >=2.0.0,<3.0.0
+    - trulens-core >=1.0.0,<2.0.0
     - langchain >=0.2.10
     - langchain-core >=0.2.0
     - pydantic >=2.4.2

--- a/src/apps/langchain/meta.yaml
+++ b/src/apps/langchain/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-core >=1.0.0,<2.0.0
+    - trulens-core >=2.0.0,<3.0.0
     - langchain >=0.2.10
     - langchain-core >=0.2.0
     - pydantic >=2.4.2

--- a/src/apps/langchain/pyproject.toml
+++ b/src/apps/langchain/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-trulens-core = { version = "^1.0.0" }
+trulens-core = { version = "^2.0.0" }
 langchain = ">=0.2.10"
 langchain-core = ">=0.2.0"
 pydantic = "^2.4.2"

--- a/src/apps/langchain/pyproject.toml
+++ b/src/apps/langchain/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-langchain"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/langchain/pyproject.toml
+++ b/src/apps/langchain/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-langchain"
-version = "2.0.0"
+version = "2.0.1"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/llamaindex/pyproject.toml
+++ b/src/apps/llamaindex/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-llamaindex"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/llamaindex/pyproject.toml
+++ b/src/apps/llamaindex/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-llamaindex"
-version = "2.0.0"
+version = "2.0.1"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/llamaindex/pyproject.toml
+++ b/src/apps/llamaindex/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-trulens-core = { version = "^1.0.0" }
-trulens-apps-langchain = { version = "^1.0.0" }
+trulens-core = { version = "^2.0.0" }
+trulens-apps-langchain = { version = "^2.0.0" }
 pydantic = "^2.4.2"
 llama-index = ">=0.11"
 tiktoken = [

--- a/src/apps/nemo/pyproject.toml
+++ b/src/apps/nemo/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-nemo"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/nemo/pyproject.toml
+++ b/src/apps/nemo/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9,<3.13"
-trulens-core = { version = "^1.0.0" }
-trulens-apps-langchain = { version = "^1.0.0" }
+trulens-core = { version = "^2.0.0" }
+trulens-apps-langchain = { version = "^2.0.0" }
 pydantic = "^2.4.2"
 nemoguardrails = ">=0.9"
 onnxruntime = [

--- a/src/apps/nemo/pyproject.toml
+++ b/src/apps/nemo/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-nemo"
-version = "2.0.0"
+version = "2.0.1"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/benchmark/pyproject.toml
+++ b/src/benchmark/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.9"
 poetry = "<2.0.0"
-trulens-core = { version = "^1.0.0" }
+trulens-core = { version = "^2.0.0" }
 
 [tool.poetry.group.dev.dependencies]
 trulens-core = { path = "../core", develop = true }

--- a/src/benchmark/pyproject.toml
+++ b/src/benchmark/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-benchmark"
-version = "2.0.0"
+version = "2.0.1"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/benchmark/pyproject.toml
+++ b/src/benchmark/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-benchmark"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/connectors/snowflake/meta.yaml
+++ b/src/connectors/snowflake/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-connectors-snowflake" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "1.5.2" %}
+{% set version = "2.0.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/connectors/snowflake/meta.yaml
+++ b/src/connectors/snowflake/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-connectors-snowflake" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.0.0" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}

--- a/src/connectors/snowflake/meta.yaml
+++ b/src/connectors/snowflake/meta.yaml
@@ -28,6 +28,7 @@ requirements:
   run:
     - python >=3.9,<3.13
     - trulens-core >=2.0.0,<3.0.0
+    - trulens-otel-semconv >=2.0.0,<3.0.0
     - snowflake-snowpark-python >=1.18.0,<2.0.0
     - snowflake-sqlalchemy >=1.6.0,<2.0.0
 

--- a/src/connectors/snowflake/meta.yaml
+++ b/src/connectors/snowflake/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-core >=1.0.0,<2.0.0
+    - trulens-core >=2.0.0,<3.0.0
     - snowflake-snowpark-python >=1.18.0,<2.0.0
     - snowflake-sqlalchemy >=1.6.0,<2.0.0
 

--- a/src/connectors/snowflake/meta.yaml
+++ b/src/connectors/snowflake/meta.yaml
@@ -12,7 +12,7 @@ source:
   {% else %}
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-connectors-snowflake/#files
-  sha256: 9db4f6ec0491eb864101387e731ced402a001bde8d8db4f4dd722821d5b4d74a
+  sha256: 3cafb8dc233703d916b2cfdcf6190dc9e4ec6a2f5d2ab773bde999f7f1bf95b7
   {% endif %}
 
 build:

--- a/src/connectors/snowflake/pyproject.toml
+++ b/src/connectors/snowflake/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-connectors-snowflake"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/connectors/snowflake/pyproject.toml
+++ b/src/connectors/snowflake/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9,<3.13"
-trulens-core = { version = "^1.0.0" }
+trulens-core = { version = "^2.0.0" }
 snowflake-snowpark-python = { version = "^1.18" }
 snowflake-sqlalchemy = { version = "^1.6" }
 

--- a/src/connectors/snowflake/pyproject.toml
+++ b/src/connectors/snowflake/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-connectors-snowflake"
-version = "2.0.0"
+version = "2.0.1"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-core" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "1.5.2" %}
+{% set version = "2.0.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -12,7 +12,7 @@ source:
   {% else %}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-core/#files
-  sha256: 296d023f2da9ccc7dade01ea7a2ddc3677c9cdfcced7ae97540ad4a02ee1c3ac
+  sha256: 193f7781fe3dbe0721a1aba7e03edd78cb2ed90a062f85acb9319c6a8cbb9604
   {% endif %}
 
 build:

--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-core" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.0.0" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}

--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -12,7 +12,7 @@ source:
   {% else %}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-core/#files
-  sha256: 2b1877a41d6c29894963431ffa3a44226c08bf830f44ea8ca96321011c7f2c48
+  sha256: 296d023f2da9ccc7dade01ea7a2ddc3677c9cdfcced7ae97540ad4a02ee1c3ac
   {% endif %}
 
 build:

--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-otel-semconv >=1.4.7,<2.0.0
+    - trulens-otel-semconv >=1.4.7,<3.0.0
     - opentelemetry-api >=1.23.0
     - opentelemetry-sdk >=1.23.0
     - opentelemetry-proto >=1.23.0

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-core"
-version = "2.0.0"
+version = "2.0.1"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-core"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-trulens-otel-semconv = { version = "^1.4.9" }
+trulens-otel-semconv = { version = "^2.0.0" }
 opentelemetry-api = ">=1.23.0"
 opentelemetry-sdk = ">=1.23.0"
 opentelemetry-proto = ">=1.23.0"

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-dashboard" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "1.5.2" %}
+{% set version = "2.0.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -7,13 +7,13 @@ package:
   version: {{ version }}
 
 source:
-  # {% if environ.get('CONDA_SOURCE_USE_PATH') == '1' %}
+  {% if environ.get('CONDA_SOURCE_USE_PATH') == '1' %}
   path: ./
-  # {% else %}
-  # url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  # # Get SHA256 from https://pypi.org/project/trulens-dashboard/#files
-  # sha256: c29e536ae6a26808fb3d902237f21240abc16371f95b6612d95fa12ca5e2930a
-  # {% endif %}
+  {% else %}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  # Get SHA256 from https://pypi.org/project/trulens-dashboard/#files
+  sha256: c29e536ae6a26808fb3d902237f21240abc16371f95b6612d95fa12ca5e2930a
+  {% endif %}
 
 build:
   noarch: python
@@ -27,7 +27,7 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-core >=1.0.0,<3.0.0
+    - trulens-core >=2.0.0,<3.0.0
     - ipywidgets >=7.1.2
     - jupyter >=1.0.0,<2.0.0
     - pandas >=1.0.0

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-core >=1.0.0,<2.0.0
+    - trulens-core >=2.0.0,<3.0.0
     - ipywidgets >=7.1.2
     - jupyter >=1.0.0,<2.0.0
     - pandas >=1.0.0

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-core >=1.0.0,<2.0.0
+    - trulens-core >=1.0.0,<3.0.0
     - ipywidgets >=7.1.2
     - jupyter >=1.0.0,<2.0.0
     - pandas >=1.0.0

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-dashboard" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.0.0" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -1,19 +1,19 @@
 {% set name = "trulens-dashboard" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "1.5.2" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  {% if environ.get('CONDA_SOURCE_USE_PATH') == '1' %}
+  # {% if environ.get('CONDA_SOURCE_USE_PATH') == '1' %}
   path: ./
-  {% else %}
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  # Get SHA256 from https://pypi.org/project/trulens-dashboard/#files
-  sha256: c29e536ae6a26808fb3d902237f21240abc16371f95b6612d95fa12ca5e2930a
-  {% endif %}
+  # {% else %}
+  # url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  # # Get SHA256 from https://pypi.org/project/trulens-dashboard/#files
+  # sha256: c29e536ae6a26808fb3d902237f21240abc16371f95b6612d95fa12ca5e2930a
+  # {% endif %}
 
 build:
   noarch: python

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-dashboard" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.0.1" %}
+{% set version = "1.5.2" %}
 
 package:
   name: {{ name|lower }}
@@ -27,7 +27,7 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-core >=2.0.0,<3.0.0
+    - trulens-core >=1.0.0,<2.0.0
     - ipywidgets >=7.1.2
     - jupyter >=1.0.0,<2.0.0
     - pandas >=1.0.0

--- a/src/dashboard/pyproject.toml
+++ b/src/dashboard/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9,!=3.9.7"
-trulens-core = { version = "^1.0.0" }
+trulens-core = { version = "^2.0.0" }
 ipywidgets = ">=7.1.2"
 jupyter = "^1"
 pandas = ">=1.0.0"

--- a/src/dashboard/pyproject.toml
+++ b/src/dashboard/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-dashboard"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/dashboard/pyproject.toml
+++ b/src/dashboard/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-dashboard"
-version = "2.0.0"
+version = "2.0.1"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/feedback/meta.yaml
+++ b/src/feedback/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-core >=1.0.0,<2.0.0
+    - trulens-core >=2.0.0,<3.0.0
     - nltk >=3.9.1,<4.0.0
     - pydantic >=2.4.2,<3.0.0
     - numpy >=1.23.0

--- a/src/feedback/meta.yaml
+++ b/src/feedback/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-core >=1.0.0,<2.0.0
+    - trulens-core >=1.0.0,<3.0.0
     - nltk >=3.9.1,<4.0.0
     - pydantic >=2.4.2,<3.0.0
     - numpy >=1.23.0

--- a/src/feedback/meta.yaml
+++ b/src/feedback/meta.yaml
@@ -1,19 +1,19 @@
 {% set name = "trulens-feedback" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "1.5.2" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  {% if environ.get('CONDA_SOURCE_USE_PATH') == '1' %}
+  # {% if environ.get('CONDA_SOURCE_USE_PATH') == '1' %}
   path: ./
-  {% else %}
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  # Get SHA256 from https://pypi.org/project/trulens-feedback/#files
-  sha256: 68b46ae1194c3dd82e31b7e0e28b28c8c919230c965c26c7ac22afa687bde5ad
-  {% endif %}
+  # {% else %}
+  # url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  # # Get SHA256 from https://pypi.org/project/trulens-feedback/#files
+  # sha256: 68b46ae1194c3dd82e31b7e0e28b28c8c919230c965c26c7ac22afa687bde5ad
+  # {% endif %}
 
 build:
   noarch: python

--- a/src/feedback/meta.yaml
+++ b/src/feedback/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-feedback" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "1.5.2" %}
+{% set version = "2.0.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/feedback/meta.yaml
+++ b/src/feedback/meta.yaml
@@ -7,13 +7,13 @@ package:
   version: {{ version }}
 
 source:
-  # {% if environ.get('CONDA_SOURCE_USE_PATH') == '1' %}
+  {% if environ.get('CONDA_SOURCE_USE_PATH') == '1' %}
   path: ./
-  # {% else %}
-  # url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  # # Get SHA256 from https://pypi.org/project/trulens-feedback/#files
-  # sha256: 68b46ae1194c3dd82e31b7e0e28b28c8c919230c965c26c7ac22afa687bde5ad
-  # {% endif %}
+  {% else %}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  # Get SHA256 from https://pypi.org/project/trulens-feedback/#files
+  sha256: 68b46ae1194c3dd82e31b7e0e28b28c8c919230c965c26c7ac22afa687bde5ad
+  {% endif %}
 
 build:
   noarch: python
@@ -27,7 +27,7 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-core >=1.0.0,<3.0.0
+    - trulens-core >=2.0.0,<3.0.0
     - nltk >=3.9.1,<4.0.0
     - pydantic >=2.4.2,<3.0.0
     - numpy >=1.23.0

--- a/src/feedback/meta.yaml
+++ b/src/feedback/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-feedback" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.0.0" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}

--- a/src/feedback/meta.yaml
+++ b/src/feedback/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-feedback" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.0.1" %}
+{% set version = "1.5.2" %}
 
 package:
   name: {{ name|lower }}
@@ -27,7 +27,7 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-core >=2.0.0,<3.0.0
+    - trulens-core >=1.0.0,<2.0.0
     - nltk >=3.9.1,<4.0.0
     - pydantic >=2.4.2,<3.0.0
     - numpy >=1.23.0

--- a/src/feedback/pyproject.toml
+++ b/src/feedback/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-feedback"
-version = "2.0.0"
+version = "2.0.1"
 description = "A TruLens extension package implementing feedback functions for LLM App evaluation."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/feedback/pyproject.toml
+++ b/src/feedback/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-feedback"
-version = "1.5.2"
+version = "2.0.0"
 description = "A TruLens extension package implementing feedback functions for LLM App evaluation."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/feedback/pyproject.toml
+++ b/src/feedback/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-trulens-core = { version = "^1.0.0" }
+trulens-core = { version = "^2.0.0" }
 nltk = "^3.9.1"
 pydantic = "^2.4.2"
 numpy = ">=1.23.0"

--- a/src/hotspots/poetry.lock
+++ b/src/hotspots/poetry.lock
@@ -1225,7 +1225,7 @@ files = [
 
 [[package]]
 name = "trulens-core"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -1250,7 +1250,7 @@ python-dotenv = ">=0.21,<2.0"
 requests = "^2.31"
 rich = "^13.6.0"
 sqlalchemy = "^2.0"
-trulens-otel-semconv = "^1.4.9"
+trulens-otel-semconv = "^2.0.0"
 typing_extensions = "^4.9"
 wrapt = ">=1.17.0"
 
@@ -1260,14 +1260,14 @@ url = "../core"
 
 [[package]]
 name = "trulens-otel-semconv"
-version = "1.5.1"
+version = "2.0.0"
 description = "Semantic conventions for spans produced by TruLens."
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "trulens_otel_semconv-1.5.1-py3-none-any.whl", hash = "sha256:be667bb9729bb3d830491b0b0dbac9317cb27796e6b9534fa1e21774b4bfd3f9"},
-    {file = "trulens_otel_semconv-1.5.1.tar.gz", hash = "sha256:fd59986d63c4b42e24f95cf38426f0ae4fa76ca2e2a98a9c6fc3bbe4e28d6dbf"},
+    {file = "trulens_otel_semconv-2.0.0-py3-none-any.whl", hash = "sha256:03d8d23c05c6be4e88bef7bbc78ffa60bdf5b80d6d03c8e2d07274d42159a16b"},
+    {file = "trulens_otel_semconv-2.0.0.tar.gz", hash = "sha256:1c30955bbb2a93112fa4bb3f0646256a5fc857863add17d0ffaaf63f874d6dbe"},
 ]
 
 [package.dependencies]
@@ -1442,4 +1442,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "161e71edc61497e4a3479b07c9e5f6491553cb998c2afbe63b800166ff2f6a7b"
+content-hash = "d25e8034f5449fd4378ad53ee194ed4ebeb6e9844bf4184cd69d795523df267e"

--- a/src/hotspots/pyproject.toml
+++ b/src/hotspots/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-trulens-core = { version = "^1.0.0" }
+trulens-core = { version = "^2.0.0" }
 pandas = ">=1.0.0"
 regex = ">2021.8.28"
 scipy = "^1.11.1"

--- a/src/hotspots/pyproject.toml
+++ b/src/hotspots/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-hotspots"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library and command-line tool to list features lowering your evaluation score."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/hotspots/pyproject.toml
+++ b/src/hotspots/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-hotspots"
-version = "2.0.0"
+version = "2.0.1"
 description = "Library and command-line tool to list features lowering your evaluation score."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/otel/semconv/meta.yaml
+++ b/src/otel/semconv/meta.yaml
@@ -12,7 +12,7 @@ source:
   {% else %}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-otel-semconv/#files
-  sha256: fd1d681b0c8d56c8df794628063759731d9603ee7d37199e13174d43da206a28
+  sha256: 1c30955bbb2a93112fa4bb3f0646256a5fc857863add17d0ffaaf63f874d6dbe
   {% endif %}
 
 build:

--- a/src/otel/semconv/meta.yaml
+++ b/src/otel/semconv/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-otel-semconv" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "1.5.2" %}
+{% set version = "2.0.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/otel/semconv/meta.yaml
+++ b/src/otel/semconv/meta.yaml
@@ -12,7 +12,7 @@ source:
   {% else %}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-otel-semconv/#files
-  sha256: 1c30955bbb2a93112fa4bb3f0646256a5fc857863add17d0ffaaf63f874d6dbe
+  sha256: 553a14a9033ddbe0d7c78a5d0101c68c62fac97beafa5cbb7c6f4742150d3b3c
   {% endif %}
 
 build:

--- a/src/otel/semconv/meta.yaml
+++ b/src/otel/semconv/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-otel-semconv" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.0.0" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}

--- a/src/otel/semconv/pyproject.toml
+++ b/src/otel/semconv/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-otel-semconv"
-version = "2.0.0"
+version = "2.0.1"
 description = "Semantic conventions for spans produced by TruLens."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/otel/semconv/pyproject.toml
+++ b/src/otel/semconv/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-otel-semconv"
-version = "1.5.2"
+version = "2.0.0"
 description = "Semantic conventions for spans produced by TruLens."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/bedrock/pyproject.toml
+++ b/src/providers/bedrock/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-trulens-core = { version = "^1.0.0" }
-trulens-feedback = { version = "^1.0.0" }
+trulens-core = { version = "^2.0.0" }
+trulens-feedback = { version = "^2.0.0" }
 boto3 = "^1.33"
 botocore = "^1.33"
 

--- a/src/providers/bedrock/pyproject.toml
+++ b/src/providers/bedrock/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-bedrock"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/bedrock/pyproject.toml
+++ b/src/providers/bedrock/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-bedrock"
-version = "2.0.0"
+version = "2.0.1"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   run:
     - python >=3.9,<3.13
     - trulens-core >=2.0.0,<3.0.0
-    - trulens-feedback >=2.0.0,<2.0.0
+    - trulens-feedback >=2.0.0,<3.0.0
     - trulens-otel-semconv >=2.0.0,<3.0.0
     - packaging >=23.0
     - snowflake-connector-python >=3.11.0,<4.0.0

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-core >=1.0.0,<2.0.0
+    - trulens-core >=1.0.0,<3.0.0
     - trulens-feedback >=1.0.0,<2.0.0
     - packaging >=23.0
     - snowflake-connector-python >=3.11.0,<4.0.0

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -27,8 +27,8 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-core >=1.0.0,<2.0.0
-    - trulens-feedback >=1.0.0,<2.0.0
+    - trulens-core >=2.0.0,<3.0.0
+    - trulens-feedback >=2.0.0,<3.0.0
     - packaging >=23.0
     - snowflake-connector-python >=3.11.0,<4.0.0
     - snowflake-ml-python >=1.7.2,<2.0.0

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-providers-cortex" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.0.1" %}
+{% set version = "1.5.2" %}
 
 package:
   name: {{ name|lower }}
@@ -27,8 +27,8 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-core >=2.0.0,<3.0.0
-    - trulens-feedback >=2.0.0,<3.0.0
+    - trulens-core >=1.0.0,<2.0.0
+    - trulens-feedback >=1.0.0,<2.0.0
     - packaging >=23.0
     - snowflake-connector-python >=3.11.0,<4.0.0
     - snowflake-ml-python >=1.7.2,<2.0.0

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-providers-cortex" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.0.0" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -1,19 +1,19 @@
 {% set name = "trulens-providers-cortex" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "1.5.2" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  {% if environ.get('CONDA_SOURCE_USE_PATH') == '1' %}
+  # {% if environ.get('CONDA_SOURCE_USE_PATH') == '1' %}
   path: ./
-  {% else %}
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  # Get SHA256 from https://pypi.org/project/trulens-providers-cortex/#files
-  sha256: 5347ca1229fc9741227687ccbfe12b9d0d6834bab58914906a9d83eb22075df6
-  {% endif %}
+  # {% else %}
+  # url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  # # Get SHA256 from https://pypi.org/project/trulens-providers-cortex/#files
+  # sha256: 5347ca1229fc9741227687ccbfe12b9d0d6834bab58914906a9d83eb22075df6
+  # {% endif %}
 
 build:
   noarch: python

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -27,8 +27,8 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.13
-    - trulens-core >=1.0.0,<3.0.0
-    - trulens-feedback >=1.0.0,<2.0.0
+    - trulens-core >=2.0.0,<3.0.0
+    - trulens-feedback >=2.0.0,<2.0.0
     - trulens-otel-semconv >=2.0.0,<3.0.0
     - packaging >=23.0
     - snowflake-connector-python >=3.11.0,<4.0.0

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -7,13 +7,13 @@ package:
   version: {{ version }}
 
 source:
-  # {% if environ.get('CONDA_SOURCE_USE_PATH') == '1' %}
+  {% if environ.get('CONDA_SOURCE_USE_PATH') == '1' %}
   path: ./
-  # {% else %}
-  # url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  # # Get SHA256 from https://pypi.org/project/trulens-providers-cortex/#files
-  # sha256: 5347ca1229fc9741227687ccbfe12b9d0d6834bab58914906a9d83eb22075df6
-  # {% endif %}
+  {% else %}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  # Get SHA256 from https://pypi.org/project/trulens-providers-cortex/#files
+  sha256: 5347ca1229fc9741227687ccbfe12b9d0d6834bab58914906a9d83eb22075df6
+  {% endif %}
 
 build:
   noarch: python

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-providers-cortex" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "1.5.2" %}
+{% set version = "2.0.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - python >=3.9,<3.13
     - trulens-core >=1.0.0,<3.0.0
     - trulens-feedback >=1.0.0,<2.0.0
+    - trulens-otel-semconv >=2.0.0,<3.0.0
     - packaging >=23.0
     - snowflake-connector-python >=3.11.0,<4.0.0
     - snowflake-ml-python >=1.7.2,<2.0.0

--- a/src/providers/cortex/pyproject.toml
+++ b/src/providers/cortex/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-cortex"
-version = "2.0.0"
+version = "2.0.1"
 description = "A TruLens extension package adding Snowflake Cortex support for LLM App evaluation."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/cortex/pyproject.toml
+++ b/src/providers/cortex/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-cortex"
-version = "1.5.2"
+version = "2.0.0"
 description = "A TruLens extension package adding Snowflake Cortex support for LLM App evaluation."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/cortex/pyproject.toml
+++ b/src/providers/cortex/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9,<3.13"
-trulens-core = { version = "^1.0.0" }
-trulens-feedback = { version = "^1.0.0" }
+trulens-core = { version = "^2.0.0" }
+trulens-feedback = { version = "^2.0.0" }
 packaging = ">=23.0"
 snowflake-connector-python = "^3.11"
 snowflake-ml-python = "^1.7.2"

--- a/src/providers/huggingface/pyproject.toml
+++ b/src/providers/huggingface/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-huggingface"
-version = "2.0.0"
+version = "2.0.1"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/huggingface/pyproject.toml
+++ b/src/providers/huggingface/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-huggingface"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/huggingface/pyproject.toml
+++ b/src/providers/huggingface/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-trulens-core = { version = "^1.0.0" }
-trulens-feedback = { version = "^1.0.0" }
+trulens-core = { version = "^2.0.0" }
+trulens-feedback = { version = "^2.0.0" }
 requests = "^2.31"
 numpy = ">=1.23.0"
 nltk = "^3.9.1"

--- a/src/providers/langchain/pyproject.toml
+++ b/src/providers/langchain/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-trulens-core = { version = "^1.0.0" }
-trulens-feedback = { version = "^1.0.0" }
+trulens-core = { version = "^2.0.0" }
+trulens-feedback = { version = "^2.0.0" }
 langchain-core = ">=0.2.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/src/providers/langchain/pyproject.toml
+++ b/src/providers/langchain/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-langchain"
-version = "2.0.0"
+version = "2.0.1"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/langchain/pyproject.toml
+++ b/src/providers/langchain/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-langchain"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/litellm/pyproject.toml
+++ b/src/providers/litellm/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-litellm"
-version = "2.0.0"
+version = "2.0.1"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/litellm/pyproject.toml
+++ b/src/providers/litellm/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-litellm"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/litellm/pyproject.toml
+++ b/src/providers/litellm/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-trulens-core = { version = "^1.0.0" }
-trulens-feedback = { version = "^1.0.0" }
+trulens-core = { version = "^2.0.0" }
+trulens-feedback = { version = "^2.0.0" }
 litellm = "^1.25"
 
 [tool.poetry.group.dev.dependencies]

--- a/src/providers/openai/pyproject.toml
+++ b/src/providers/openai/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-openai"
-version = "2.0.0"
+version = "2.0.1"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/openai/pyproject.toml
+++ b/src/providers/openai/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-trulens-core = { version = "^1.0.0" }
-trulens-feedback = { version = "^1.0.0" }
+trulens-core = { version = "^2.0.0" }
+trulens-feedback = { version = "^2.0.0" }
 openai = ">=1.52.1"
 langchain-community = ">=0.0.20"
 

--- a/src/providers/openai/pyproject.toml
+++ b/src/providers/openai/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-openai"
-version = "1.5.2"
+version = "2.0.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/trulens_eval/pyproject.toml
+++ b/src/trulens_eval/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens_eval"
-version = "2.0.0"
+version = "2.0.1"
 description = "Backwards-compatibility package for API of trulens_eval<1.0.0 using API of trulens-*>=1.0.0."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/trulens_eval/pyproject.toml
+++ b/src/trulens_eval/pyproject.toml
@@ -32,9 +32,9 @@ python = "^3.9,!=3.9.7"
 # the latest trulens-* versions for users who are still installing
 # "trulens_eval".
 # trulens = { version = "^1.0" }
-trulens-core = { version = "^1.0.0" }
-trulens-feedback = { version = "^1.0.0" }
-trulens-dashboard = { version = "^1.0.0" }
+trulens-core = { version = "^2.0.0" }
+trulens-feedback = { version = "^2.0.0" }
+trulens-dashboard = { version = "^2.0.0" }
 
 [tool.poetry.group.dev.dependencies]
 # Is this needed?

--- a/src/trulens_eval/pyproject.toml
+++ b/src/trulens_eval/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens_eval"
-version = "1.5.2"
+version = "2.0.0"
 description = "Backwards-compatibility package for API of trulens_eval<1.0.0 using API of trulens-*>=1.0.0."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -4,7 +4,7 @@ trulens:
   lows: {}
 trulens.benchmark:
   __class__: builtins.module
-  __version__: 1.5.2
+  __version__: 2.0.0
   highs: {}
   lows:
     __version__: builtins.str
@@ -60,7 +60,7 @@ trulens.benchmark.test_cases:
     generate_summeval_groundedness_golden_set: builtins.function
 trulens.core:
   __class__: builtins.module
-  __version__: 1.5.2
+  __version__: 2.0.0
   highs:
     Feedback: pydantic._internal._model_construction.ModelMetaclass
     FeedbackMode: enum.EnumType
@@ -1910,7 +1910,7 @@ trulens.core.utils.trulens.Other:
   attributes: {}
 trulens.dashboard:
   __class__: builtins.module
-  __version__: 1.5.2
+  __version__: 2.0.0
   highs:
     run_dashboard: builtins.function
     run_dashboard_sis: builtins.function
@@ -2221,7 +2221,7 @@ trulens.dashboard.ux.styles.ResultCategoryType:
     value: enum.property
 trulens.feedback:
   __class__: builtins.module
-  __version__: 1.5.2
+  __version__: 2.0.0
   highs:
     Embeddings: pydantic._internal._model_construction.ModelMetaclass
     GroundTruthAggregator: pydantic._internal._model_construction.ModelMetaclass
@@ -3150,7 +3150,7 @@ trulens.feedback.v2.provider.base.Provider:
     tru_class_info: trulens.core.utils.pyschema.Class
 trulens.hotspots:
   __class__: builtins.module
-  __version__: 1.5.2
+  __version__: 2.0.0
   highs:
     HotspotsConfig: builtins.type
     get_skipped_columns: builtins.function


### PR DESCRIPTION
# Description
Version bumping everything for now but only releasing core and otel-semconv now

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Version bump to 2.0.1 across multiple TruLens modules, updating dependencies and Python constraints.
> 
>   - **Version Updates**:
>     - Bump version to `2.0.1` in `pyproject.toml` and `meta.yaml` for `trulens`, `trulens-core`, `trulens-feedback`, `trulens-dashboard`, `trulens-otel-semconv`, and other modules.
>     - Update dependencies to use `trulens-core`, `trulens-feedback`, `trulens-dashboard`, and `trulens-otel-semconv` version `^2.0.0` in various `pyproject.toml` files.
>   - **Dependency Management**:
>     - Adjust Python version constraints to `>=3.9,<3.13` in several `meta.yaml` files.
>     - Update SHA256 checksums in `meta.yaml` files for package verification.
>   - **Miscellaneous**:
>     - Update `tests/unit/static/golden/api.trulens.3.11.yaml` to reflect version `2.0.0` for modules like `trulens.benchmark`, `trulens.core`, `trulens.dashboard`, `trulens.feedback`, and `trulens.hotspots`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for b57c6553216626a34f1e316961921b3a07e3c59f. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->