### PR TITLE
Docs: Update docs website year, fix homepage link

### DIFF
--- a/docs/assets/favicon/site.webmanifest
+++ b/docs/assets/favicon/site.webmanifest
@@ -1,6 +1,6 @@
 {
-    "name": "TrueLens",
-    "short_name": "TrueLens",
+    "name": "TruLens",
+    "short_name": "TruLens",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -155,7 +155,7 @@
                                         fill="#0A2C37" />
                                 </svg>
                                 <div class="header__btn--text d-f fd-c">
-                                    <span class="strong">GIVE A STAR</span>
+                                    <span class="strong">GIVE US A STAR ⭐️</span>
                                     <!-- <span>trulens 0.13.3 (Mar 8, 2023)</span> -->
                                 </div>
                             </a>
@@ -502,7 +502,7 @@
                                 install trulens</a>.</span>
                     </div>
                     <div class="box__shadow">
-                        <a href="https://truera.github.io/trulens/" target="_blank" class="btn__shadow">
+                        <a href="https://www.trulens.org/getting_started/" target="_blank" class="btn__shadow">
                             <svg width="126" height="126" viewBox="0 0 126 126" fill="none"
                                 xmlns="http://www.w3.org/2000/svg">
                                 <path fill="#fff" d="M0 0h100v100H0z" />
@@ -679,7 +679,7 @@
                     </defs>
                 </svg>
                 <div>
-                    <p>TruLens 2023</p>
+                    <p>TruLens 2025</p>
                 </div>
             </div>
         </footer>


### PR DESCRIPTION
# Description

- Update year on docs homepage
- Fix webmanifest spelling of TruLens
- Update links

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update TruLens documentation website with new year, corrected homepage link, and branding consistency.
> 
>   - **Homepage Updates**:
>     - Update homepage link in `home.html` from `https://truera.github.io/trulens/` to `https://www.trulens.org/getting_started/`.
>     - Change "GIVE A STAR" to "GIVE US A STAR ⭐️" in `home.html`.
>   - **Branding**:
>     - Correct "TrueLens" to "TruLens" in `site.webmanifest`.
>   - **Year Update**:
>     - Update footer year from 2023 to 2025 in `home.html`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 7d95b6bbeb248ebd3aaeb02a3adbf16fe9448e06. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->