### PR TITLE
Minor evaluator improvements.

### DIFF
--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -573,7 +573,8 @@ class App(
 
         if self.feedback_mode == feedback_schema.FeedbackMode.WITH_APP_THREAD:
             if is_otel_tracing_enabled():
-                self.start_evaluator()
+                if kwargs.get("start_evaluator", True):
+                    self.start_evaluator()
             else:
                 self._start_manage_pending_feedback_results()
 

--- a/src/core/trulens/core/utils/evaluator.py
+++ b/src/core/trulens/core/utils/evaluator.py
@@ -157,7 +157,8 @@ class Evaluator:
                     TruSession().force_flush()
                 if in_evaluator_thread and self._stop_event.is_set():
                     break
-        self._processed_time = new_processed_time - _PROCESSED_TIME_DELTA
+        if not record_ids:
+            self._processed_time = new_processed_time - _PROCESSED_TIME_DELTA
 
     def _run_evaluator(self) -> None:
         """Background thread that periodically computes feedback for events."""


### PR DESCRIPTION
# Description
Minor evaluator improvements:
1. Allow to not start the evaluator immediately via passing in `start_evaluator=False` into the `App`.
2. Don't update processed time when given a record id since that technically may be a problem.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
