### PR TITLE
Fix conda build issues by restricting `smmap` version.

### DIFF
--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -50,6 +50,8 @@ requirements:
     - tqdm >=4.2.0
     - openai >=1.0.0
     - httpx >=0.27
+    - gitdb >=4.0.12
+    - smmap >=5.0.0,<6.0.0
 
 test:
   imports:

--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -50,8 +50,6 @@ requirements:
     - tqdm >=4.2.0
     - openai >=1.0.0
     - httpx >=0.27
-    - gitdb >=4.0.12
-    - smmap >=5.0.0,<6.0.0
 
 test:
   imports:

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -41,7 +41,6 @@ requirements:
     - tqdm >=4.2.0
     - openai >=1.0.0
     - httpx >=0.27
-    - gitdb >=4.0.7,<4.0.8
     - smmap >=3.0.1,<5.0.0
 
 test:

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -41,9 +41,9 @@ requirements:
     - tqdm >=4.2.0
     - openai >=1.0.0
     - httpx >=0.27
-    - gitdb >=4.0.12
-    - smmap >=5.0.0,<6.0.0
-    - gitpython >=3.1.44
+    - gitdb >=4.0.7,<4.0.8
+    - smmap >=3.0.1,<5.0.0
+    - gitpython >=3.1.43,<3.2.0
 
 test:
   imports:

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -41,6 +41,8 @@ requirements:
     - tqdm >=4.2.0
     - openai >=1.0.0
     - httpx >=0.27
+    - gitdb >=4.0.12
+    - smmap >=5.0.0,<6.0.0
 
 test:
   imports:

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - httpx >=0.27
     - gitdb >=4.0.12
     - smmap >=5.0.0,<6.0.0
+    - gitpython >=3.1.44
 
 test:
   imports:

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -42,8 +42,6 @@ requirements:
     - openai >=1.0.0
     - httpx >=0.27
     - gitdb >=4.0.7,<4.0.8
-    - smmap >=3.0.1,<5.0.0
-    - gitpython >=3.1.43,<3.2.0
 
 test:
   imports:

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -42,6 +42,7 @@ requirements:
     - openai >=1.0.0
     - httpx >=0.27
     - gitdb >=4.0.7,<4.0.8
+    - smmap >=3.0.1,<5.0.0
 
 test:
   imports:


### PR DESCRIPTION
# Description
Fix conda build issues by restricting `gitdb` and `smmap` versions.

The PR pipeline is broken due to a weird issue where if I understand it correctly, we have that the default conda channel has:
1. Latest version of `gitdb` is `4.0.7`.
2. The pip`gitdb=4.0.7` package requires `smmap<5`.
3. The conda `gitdb=4.0.7` package doesn't require `smmap<5`.
So we install `gitdb` and because there's no version restriction, `smmap=5` is allowed to be installed but then later it realizes there's a conflict.

## Other details good to know for developers

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add version constraint for `smmap` in `meta.yaml` to fix conda build issues with `gitdb`.
> 
>   - **Dependency Management**:
>     - Add version constraint `smmap >=3.0.1,<5.0.0` in `meta.yaml` to resolve conda build issues.
>     - Addresses conflict where `gitdb=4.0.7` requires `smmap<5` but conda did not enforce this restriction.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for a4948e47fa2626830a2871dc58f002d4088695a1. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->