### PR TITLE
Lower Langgraph version required in `trulens-apps-langgraph` 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: src\/(core|feedback|providers/.+)\/meta.yaml
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: check-added-large-files

--- a/src/apps/langgraph/pyproject.toml
+++ b/src/apps/langgraph/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 python = "^3.9"
 trulens-core = { version = "^2.0.0" }
 trulens-apps-langchain = { version = "^2.0.0" }
-langgraph = ">=0.5.2"
+langgraph = ">=0.3.18"
 pydantic = "^2.4.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description
For some of the TruLens client that is still on older langgraph version ( i.e.  in AI migrator project the version is locked currently to 0.3.18.)
## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Lower `langgraph` version requirement and update pre-commit hook version.
> 
>   - **Dependencies**:
>     - Lower `langgraph` version requirement from `>=0.5.2` to `>=0.3.18` in `pyproject.toml`.
>     - Update pre-commit hook version from `v4.6.0` to `v5.0.0` in `.pre-commit-config.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for cbed281a9ee8237cfba04b4d8f3ff4a5ad3df2f4. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->