### PR TITLE
Make trulens-core no longer depend on trulens-feedback

### DIFF
--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -50,6 +50,7 @@ requirements:
     - tqdm >=4.2.0
     - openai >=1.0.0
     - httpx >=0.27
+    - trulens-feedback >=2.0.0
 
 test:
   imports:

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -54,6 +54,12 @@ optional = true
 [tool.poetry.group.tqdm.dependencies]
 tqdm = { version = ">=4.2.0", optional = true }
 
+[tool.poetry.group.feedback]
+optional = true
+
+[tool.poetry.group.feedback.dependencies]
+trulens-feedback = { version = "^2.0.0", optional = true }
+
 [tool.poetry.group.dev]
 optional = true
 

--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -63,7 +63,6 @@ from trulens.core.utils import python as python_utils
 from trulens.core.utils import serial as serial_utils
 from trulens.core.utils import signature as signature_utils
 from trulens.core.utils import threading as threading_utils
-from trulens.feedback.computer import compute_feedback_by_span_group
 from trulens.otel.semconv.constants import (
     TRULENS_APP_SPECIFIC_INSTRUMENT_WRAPPER_FLAG,
 )
@@ -1991,12 +1990,22 @@ you use the `%s` wrapper to make sure `%s` does get instrumented. `%s` method
             raise ValueError(
                 "This method is only supported for OTEL Tracing. Please enable OTEL tracing in the environment!"
             )
+
+        try:
+            from trulens.feedback.computer import compute_feedback_by_span_group
+        except ImportError:
+            logger.error(
+                "trulens.feedback package is not installed. Please install it to use feedback computation functionality."
+            )
+            raise
+
         if events is None:
             # Get all events associated with this app name and version.
             # TODO(otel): Should probably handle the case where there are a lot of events with pagination.
             events = self.connector.get_events(
                 app_name=self.app_name, app_version=self.app_version
             )
+
         for feedback in self.feedbacks:
             compute_feedback_by_span_group(
                 events,


### PR DESCRIPTION
# Description
So that we don't introduce `trulens-feedback` as a hard requirement whenever trulens-core is installed

This is needed for LLM GA too

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `trulens-feedback` an optional dependency for `trulens-core` by updating dependency management and import logic.
> 
>   - **Dependencies**:
>     - `trulens-feedback` is now an optional dependency in `meta.yaml` and `pyproject.toml`.
>     - Added `trulens-feedback` under `[tool.poetry.group.feedback.dependencies]` in `pyproject.toml`.
>   - **Code Changes**:
>     - In `app.py`, moved import of `compute_feedback_by_span_group` from `trulens.feedback.computer` inside `compute_feedbacks()` function and added error handling for missing `trulens-feedback` package.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for f9fba9e7fde9673d8b15e53e0e3dfafd54a2ec8b. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->