### PR TITLE
add trulens-apps-langgraph to optional requirements

### DIFF
--- a/src/core/trulens/core/utils/requirements.optional.txt
+++ b/src/core/trulens/core/utils/requirements.optional.txt
@@ -86,6 +86,7 @@ snowflake-sqlalchemy >= 1.6.0
 # Optional trulens packages
 trulens-apps-llamaindex >= 1.0.0
 trulens-apps-langchain >= 1.0.0
+trulens-apps-langgraph >= 1.0.0
 trulens-apps-nemo >= 1.0.0
 trulens-connectors-snowflake >= 1.0.0
 trulens-providers-bedrock >= 1.0.0


### PR DESCRIPTION
# Description

trulens-apps-langgraph was missing from optional requirements, leading to this warning:

`Package trulens-apps-langgraph not present in requirements`

## Other details good to know for developers

Is this check something we still need to do? Can we remove it?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `trulens-apps-langgraph` to optional requirements to fix missing package warning.
> 
>   - **Bug Fix**:
>     - Add `trulens-apps-langgraph >= 1.0.0` to `requirements.optional.txt` to resolve missing package warning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 2b97aef0622e78f8b895ecbc22781bd2df5199d8. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->