### PR TITLE
Supply host to dashboard.

### DIFF
--- a/src/dashboard/trulens/dashboard/run.py
+++ b/src/dashboard/trulens/dashboard/run.py
@@ -154,6 +154,7 @@ def run_dashboard(
             ("--snowflake-database", snowpark_session.get_current_database()),
             ("--snowflake-schema", snowpark_session.get_current_schema()),
             ("--snowflake-warehouse", snowpark_session.get_current_warehouse()),
+            ("--snowflake-host", snowpark_session.connection.host),
         ]
         for arg, val in args_to_add:
             if val:

--- a/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
@@ -116,6 +116,7 @@ def get_session() -> core_session.TruSession:
     parser.add_argument("--snowflake-schema", default=None)
     parser.add_argument("--snowflake-warehouse", default=None)
     parser.add_argument("--snowflake-authenticator", default=None)
+    parser.add_argument("--snowflake-host", default=None)
     parser.add_argument(
         "--snowflake-use-account-event-table", action="store_true"
     )
@@ -151,6 +152,7 @@ def get_session() -> core_session.TruSession:
             "schema": args.snowflake_schema,
             "warehouse": args.snowflake_warehouse,
             "authenticator": args.snowflake_authenticator,
+            "host": args.snowflake_host,
         }
         use_account_event_table = bool(args.snowflake_use_account_event_table)
         snowpark_session = Session.builder.configs(connection_params).create()


### PR DESCRIPTION
# Description
Supply host to dashboard.

In some cases, the account isn't enough info to glean where to connect to as in the case of when we have:
host: cortexsearch.qa6.us-west-2.aws.snowflakecomputing.com
account: cortexsearch

## Other details good to know for developers

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `--snowflake-host` argument to specify Snowflake host in dashboard configuration.
> 
>   - **Behavior**:
>     - Adds `--snowflake-host` argument in `run_dashboard()` in `run.py` to specify Snowflake host.
>     - Updates `get_session()` in `dashboard_utils.py` to parse and use `--snowflake-host` argument.
>   - **Misc**:
>     - Updates Snowflake connection parameters to include host in `run.py` and `dashboard_utils.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 2d7d729c549ebb321118aec87820ba37918c0143. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->