### PR TITLE
Use app versions instead of app ids when we can.

### DIFF
--- a/src/core/trulens/core/database/base.py
+++ b/src/core/trulens/core/database/base.py
@@ -344,6 +344,7 @@ class DB(serial_utils.SerialModel, abc.ABC, text_utils.WithIdentString):
         app_ids: Optional[List[types_schema.AppID]] = None,
         app_name: Optional[types_schema.AppName] = None,
         app_version: Optional[types_schema.AppVersion] = None,
+        app_versions: Optional[List[types_schema.AppVersion]] = None,
         record_ids: Optional[List[types_schema.RecordID]] = None,
         offset: Optional[int] = None,
         limit: Optional[int] = None,
@@ -355,6 +356,7 @@ class DB(serial_utils.SerialModel, abc.ABC, text_utils.WithIdentString):
                 Otherwise all apps are retrieved.
             app_name: If given, retrieve only the records for the given app name.
             app_version: If given, retrieve only the records for the given app version.
+            app_versions: If given, retrieve only the records for the given app versions.
             record_ids: Optional list of record IDs to filter by. Defaults to None.
             offset: Database row offset.
             limit: Limit on rows (records) returned.

--- a/src/core/trulens/core/database/connector/base.py
+++ b/src/core/trulens/core/database/connector/base.py
@@ -331,6 +331,7 @@ class DBConnector(ABC, text_utils.WithIdentString):
         app_ids: Optional[List[types_schema.AppID]] = None,
         app_name: Optional[types_schema.AppName] = None,
         app_version: Optional[types_schema.AppVersion] = None,
+        app_versions: Optional[List[types_schema.AppVersion]] = None,
         record_ids: Optional[List[types_schema.RecordID]] = None,
         offset: Optional[int] = None,
         limit: Optional[int] = None,
@@ -343,6 +344,12 @@ class DBConnector(ABC, text_utils.WithIdentString):
 
             app_name: A name of the app to filter records by. If given, only records for
                 this app will be returned.
+
+            app_version: A version of the app to filter records by. If given, only records for
+                this app version will be returned.
+
+            app_versions: A list of app versions to filter records by. If given, only records for
+                these app versions will be returned.
 
             record_ids: An optional list of record ids to filter records by.
 
@@ -360,6 +367,7 @@ class DBConnector(ABC, text_utils.WithIdentString):
             app_ids=app_ids,
             app_name=app_name,
             app_version=app_version,
+            app_versions=app_versions,
             record_ids=record_ids,
             offset=offset,
             limit=limit,

--- a/src/core/trulens/core/session.py
+++ b/src/core/trulens/core/session.py
@@ -794,6 +794,7 @@ class TruSession(
         app_ids: Optional[List[types_schema.AppID]] = None,
         app_name: Optional[types_schema.AppName] = None,
         app_version: Optional[types_schema.AppVersion] = None,
+        app_versions: Optional[List[types_schema.AppVersion]] = None,
         record_ids: Optional[List[types_schema.RecordID]] = None,
         offset: Optional[int] = None,
         limit: Optional[int] = None,
@@ -810,6 +811,9 @@ class TruSession(
             app_version: A version of the app to filter records by. If given, only records for
                 this app version will be returned.
 
+            app_versions: A list of app versions to filter records by. If given, only records for
+                these app versions will be returned.
+
             record_ids: An optional list of record ids to filter records by.
 
             offset: Record row offset.
@@ -825,6 +829,7 @@ class TruSession(
             app_ids=app_ids,
             app_name=app_name,
             app_version=app_version,
+            app_versions=app_versions,
             record_ids=record_ids,
             offset=offset,
             limit=limit,

--- a/src/dashboard/trulens/dashboard/tabs/Compare.py
+++ b/src/dashboard/trulens/dashboard/tabs/Compare.py
@@ -685,8 +685,9 @@ def _render_version_selectors(
             )
 
             records, feedback_cols = get_records_and_feedback(
-                app_ids=current_app_ids,
                 app_name=app_name,
+                app_ids=current_app_ids,
+                # TODO(this_pr): Probably should make this use app versions.
             )
             records = _preprocess_df(records)
             col_data = {

--- a/src/dashboard/trulens/dashboard/tabs/Compare.py
+++ b/src/dashboard/trulens/dashboard/tabs/Compare.py
@@ -687,7 +687,7 @@ def _render_version_selectors(
             records, feedback_cols = get_records_and_feedback(
                 app_name=app_name,
                 app_ids=current_app_ids,
-                # TODO(this_pr): Probably should make this use app versions.
+                # TODO: Probably should make this use app versions.
             )
             records = _preprocess_df(records)
             col_data = {

--- a/src/dashboard/trulens/dashboard/tabs/Leaderboard.py
+++ b/src/dashboard/trulens/dashboard/tabs/Leaderboard.py
@@ -786,16 +786,18 @@ def render_leaderboard(app_name: str):
     if versions_df.empty:
         st.error(f"No app versions found for app `{app_name}`.")
         return
-    app_ids = versions_df["app_id"].tolist()
+    app_versions = versions_df["app_version"].tolist()
 
     # Get records and feedback data
     records_limit = st.session_state.get(dashboard_utils.ST_RECORDS_LIMIT, None)
     records_df, feedback_col_names = dashboard_utils.get_records_and_feedback(
-        app_name=app_name, app_ids=app_ids, limit=records_limit
+        app_name=app_name,
+        app_versions=app_versions,
+        limit=records_limit,
     )
     if records_df.empty:
         # Check for cross-format records before showing generic error
-        _show_no_records_error(app_name=app_name, app_ids=app_ids)
+        _show_no_records_error(app_name=app_name, app_versions=app_versions)
         return
     elif records_limit is not None and len(records_df) >= records_limit:
         cols = st_columns([0.9, 0.1], vertical_alignment="center")

--- a/src/dashboard/trulens/dashboard/tabs/Records.py
+++ b/src/dashboard/trulens/dashboard/tabs/Records.py
@@ -660,12 +660,12 @@ def render_records(app_name: str):
     if versions_df.empty:
         st.error(f"No app versions found for app `{app_name}`.")
         return
-    app_ids = versions_df["app_id"].tolist()
+    app_versions = versions_df["app_version"].tolist()
 
     # Get records and feedback data
     records_limit = st.session_state.get(ST_RECORDS_LIMIT, None)
     records_df, feedback_col_names = get_records_and_feedback(
-        app_ids=app_ids, app_name=app_name, limit=records_limit
+        app_name=app_name, app_versions=app_versions, limit=records_limit
     )
 
     feedback_col_names = list(feedback_col_names)
@@ -687,7 +687,7 @@ def render_records(app_name: str):
             st.error(f"No records found for app version(s): {versions_str}.")
         else:
             # Check for cross-format records before showing generic error
-            _show_no_records_error(app_name=app_name, app_ids=app_ids)
+            _show_no_records_error(app_name=app_name, app_versions=app_versions)
         return
     elif records_limit is not None and len(records_df) >= records_limit:
         cols = st_columns([0.9, 0.1], vertical_alignment="center")

--- a/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
@@ -679,9 +679,7 @@ def _get_event_otel_spans(record_id: str) -> List[OtelSpan]:
 
 
 def _check_cross_format_records(
-    app_name: Optional[str] = None,
-    app_ids: Optional[List[str]] = None,
-    app_versions: Optional[List[str]] = None,
+    app_name: Optional[str] = None, app_versions: Optional[List[str]] = None
 ) -> tuple[int, int]:
     """Check record counts in both OTEL and non-OTEL formats.
 
@@ -705,12 +703,6 @@ def _check_cross_format_records(
                     "resource_attributes", ResourceAttributes.APP_NAME
                 )
                 query = query.where(app_name_expr == app_name)
-            if app_ids:
-                # For OTEL events, app_id is in resource_attributes JSON
-                app_id_expr = db._json_extract_otel(
-                    "resource_attributes", ResourceAttributes.APP_ID
-                )
-                query = query.where(app_id_expr.in_(app_ids))
             if app_versions:
                 app_version_expr = db._json_extract_otel(
                     "resource_attributes", ResourceAttributes.APP_VERSION
@@ -728,8 +720,6 @@ def _check_cross_format_records(
                 query = query.join(db.orm.Record.app).where(  # type: ignore
                     db.orm.AppDefinition.app_name == app_name  # type: ignore
                 )
-            if app_ids:
-                query = query.where(db.orm.Record.app_id.in_(app_ids))  # type: ignore
             if app_versions:
                 query = query.where(db.orm.Record.app_version.in_(app_versions))  # type: ignore
 
@@ -740,14 +730,12 @@ def _check_cross_format_records(
 
 
 def _show_no_records_error(
-    app_name: Optional[str] = None,
-    app_ids: Optional[List[str]] = None,  # TODO(this_pr): do we need this?
-    app_versions: Optional[List[str]] = None,
+    app_name: Optional[str] = None, app_versions: Optional[List[str]] = None
 ) -> None:
     """Show helpful error message when no records found, with cross-format record counts."""
     is_otel_mode = is_otel_tracing_enabled()
     otel_count, non_otel_count = _check_cross_format_records(
-        app_name, app_ids, app_versions
+        app_name=app_name, app_versions=app_versions
     )
 
     if is_otel_mode and otel_count == 0 and non_otel_count > 0:

--- a/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
@@ -186,6 +186,7 @@ def get_session() -> core_session.TruSession:
 def get_records_and_feedback(
     app_ids: Optional[List[str]] = None,
     app_name: Optional[str] = None,
+    app_versions: Optional[List[str]] = None,
     offset: Optional[int] = None,
     limit: Optional[int] = None,
 ):
@@ -196,6 +197,7 @@ def get_records_and_feedback(
     records_df, feedback_col_names = lms.get_records_and_feedback(
         app_ids=app_ids,
         app_name=app_name,
+        app_versions=app_versions,
         offset=offset,
         limit=limit,
     )
@@ -679,6 +681,7 @@ def _get_event_otel_spans(record_id: str) -> List[OtelSpan]:
 def _check_cross_format_records(
     app_name: Optional[str] = None,
     app_ids: Optional[List[str]] = None,
+    app_versions: Optional[List[str]] = None,
 ) -> tuple[int, int]:
     """Check record counts in both OTEL and non-OTEL formats.
 
@@ -702,12 +705,17 @@ def _check_cross_format_records(
                     "resource_attributes", ResourceAttributes.APP_NAME
                 )
                 query = query.where(app_name_expr == app_name)
-            elif app_ids:
+            if app_ids:
                 # For OTEL events, app_id is in resource_attributes JSON
                 app_id_expr = db._json_extract_otel(
                     "resource_attributes", ResourceAttributes.APP_ID
                 )
                 query = query.where(app_id_expr.in_(app_ids))
+            if app_versions:
+                app_version_expr = db._json_extract_otel(
+                    "resource_attributes", ResourceAttributes.APP_VERSION
+                )
+                query = query.where(app_version_expr.in_(app_versions))
 
             result = session_ctx.execute(query).scalar()
             otel_count = result or 0
@@ -720,8 +728,10 @@ def _check_cross_format_records(
                 query = query.join(db.orm.Record.app).where(  # type: ignore
                     db.orm.AppDefinition.app_name == app_name  # type: ignore
                 )
-            elif app_ids:
+            if app_ids:
                 query = query.where(db.orm.Record.app_id.in_(app_ids))  # type: ignore
+            if app_versions:
+                query = query.where(db.orm.Record.app_version.in_(app_versions))  # type: ignore
 
             result = session_ctx.execute(query).scalar()
             non_otel_count = result or 0
@@ -730,11 +740,15 @@ def _check_cross_format_records(
 
 
 def _show_no_records_error(
-    app_name: Optional[str] = None, app_ids: Optional[List[str]] = None
+    app_name: Optional[str] = None,
+    app_ids: Optional[List[str]] = None,  # TODO(this_pr): do we need this?
+    app_versions: Optional[List[str]] = None,
 ) -> None:
     """Show helpful error message when no records found, with cross-format record counts."""
     is_otel_mode = is_otel_tracing_enabled()
-    otel_count, non_otel_count = _check_cross_format_records(app_name, app_ids)
+    otel_count, non_otel_count = _check_cross_format_records(
+        app_name, app_ids, app_versions
+    )
 
     if is_otel_mode and otel_count == 0 and non_otel_count > 0:
         st.error(


### PR DESCRIPTION
# Description
Use app versions instead of app ids when we can.

Generally, if people like SI are making their own spans they can't replicate the same `app_id = f(app_name, app_version)` logic for `f`. So we should use app versions whenever we can.

## Other details good to know for developers

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace app IDs with app versions in `get_records_and_feedback` across core and dashboard components, deprecating `app_ids` and `app_version`.
> 
>   - **Behavior**:
>     - Replace `app_ids` with `app_versions` in `get_records_and_feedback` in `base.py`, `connector/base.py`, and `sqlalchemy.py`.
>     - Deprecate `app_ids` and `app_version` with warnings in `get_records_and_feedback` in `sqlalchemy.py`.
>   - **Dashboard**:
>     - Update `get_records_and_feedback` calls in `Compare.py`, `Leaderboard.py`, and `Records.py` to use `app_versions`.
>     - Modify `render_leaderboard` and `render_records` to handle app versions instead of app IDs.
>   - **Misc**:
>     - Add `app_versions` parameter to `get_records_and_feedback` in `session.py` and `dashboard_utils.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 8e9c073448af6f3e6b83f1c49ebbeab77e89c3b0. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->