### PR TITLE
silence get_group warning

### DIFF
--- a/examples/quickstart/quickstart.ipynb
+++ b/examples/quickstart/quickstart.ipynb
@@ -252,7 +252,7 @@
     "from trulens.core import Feedback\n",
     "from trulens.providers.openai import OpenAI\n",
     "\n",
-    "provider = OpenAI(model_engine=\"gpt-4.1-mini\")\n",
+    "provider = OpenAI(model_engine=\"gpt-4o\")\n",
     "\n",
     "# Define a groundedness feedback function\n",
     "f_groundedness = (\n",
@@ -378,7 +378,7 @@
    "source": [
     "from trulens.core.guardrails.base import context_filter\n",
     "\n",
-    "guardrail_provider = OpenAI(model_engine=\"gpt-4.1-mini\")\n",
+    "guardrail_provider = OpenAI(model_engine=\"gpt-4.1\")\n",
     "\n",
     "# note: feedback function used for guardrail must only return a score, not also reasons\n",
     "f_context_relevance_score = Feedback(\n",
@@ -462,7 +462,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "release21",
+   "display_name": "dlai_course",
    "language": "python",
    "name": "python3"
   },

--- a/examples/quickstart/quickstart.ipynb
+++ b/examples/quickstart/quickstart.ipynb
@@ -300,8 +300,8 @@
     "\n",
     "tru_rag = TruApp(\n",
     "    rag,\n",
-    "    app_name=\"OTEL-RAG\",\n",
-    "    app_version=\"4.1-mini\",\n",
+    "    app_name=\"RAG\",\n",
+    "    app_version=\"base\",\n",
     "    feedbacks=[f_groundedness, f_answer_relevance, f_context_relevance],\n",
     ")"
    ]
@@ -387,7 +387,13 @@
     "\n",
     "\n",
     "class FilteredRAG(RAG):\n",
-    "    @instrument\n",
+    "    @instrument(\n",
+    "        span_type=SpanAttributes.SpanType.RETRIEVAL,\n",
+    "        attributes={\n",
+    "            SpanAttributes.RETRIEVAL.QUERY_TEXT: \"query\",\n",
+    "            SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS: \"return\",\n",
+    "        },\n",
+    "    )\n",
     "    @context_filter(\n",
     "        feedback=f_context_relevance_score,\n",
     "        threshold=0.75,\n",
@@ -456,7 +462,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "oss_rag_stack",
+   "display_name": "release21",
    "language": "python",
    "name": "python3"
   },

--- a/src/feedback/trulens/feedback/computer.py
+++ b/src/feedback/trulens/feedback/computer.py
@@ -574,7 +574,7 @@ def _remove_already_computed_feedbacks(
         curr_eval_root_attributes = []
         if record_id in record_id_to_eval_root_attributes.groups:
             curr_eval_root_attributes = (
-                record_id_to_eval_root_attributes.get_group(record_id)
+                record_id_to_eval_root_attributes.get_group((record_id,))
             )
         if not _feedback_already_computed(
             span_group, inputs, feedback_name, curr_eval_root_attributes

--- a/src/feedback/trulens/feedback/computer.py
+++ b/src/feedback/trulens/feedback/computer.py
@@ -575,6 +575,8 @@ def _remove_already_computed_feedbacks(
         if record_id in record_id_to_eval_root_attributes.groups:
             curr_eval_root_attributes = (
                 record_id_to_eval_root_attributes.get_group((record_id,))
+                # DEV NOTE: In pandas 2.1.0: `get_group` deprecated grouping on
+                # non-tuple keys.
             )
         if not _feedback_already_computed(
             span_group, inputs, feedback_name, curr_eval_root_attributes


### PR DESCRIPTION
# Description

Silence warning:

```
FutureWarning: When grouping with a length-1 list-like, you will need to pass a length-1 tuple to get_group in a future version of pandas. Pass `(name,)` instead of `name` to silence this warning.
  record_id_to_eval_root_attributes.get_group(record_id)
```

Also fix issues with the quickstart.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Silence `FutureWarning` in `computer.py` by updating `get_group` usage to be compatible with future pandas versions.
> 
>   - **Behavior**:
>     - Silence `FutureWarning` in `_remove_already_computed_feedbacks` in `computer.py` by changing `get_group(record_id)` to `get_group((record_id,))`.
>   - **Misc**:
>     - Comment added about `get_group` deprecation in pandas 2.1.0.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for c1fa03434050afab95ab60b1127edc78c8102d28. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->