### PR TITLE
Convert dicts (or strings that represent to dicts) as prettified strings in colored DataFrames so that they render correctly in Streamlit.

### DIFF
--- a/src/dashboard/trulens/dashboard/utils/records_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/records_utils.py
@@ -1,4 +1,5 @@
 from functools import partial
+import json
 import pprint as pp
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
@@ -190,6 +191,8 @@ def display_feedback_call(
         st.warning("No feedback details found.")
         return
 
+    df = _convert_dicts_to_str(df.copy())
+
     # Style and display the DataFrame
     style_highlight_fn = partial(
         highlight,
@@ -207,6 +210,35 @@ def display_feedback_call(
         styled_df = styled_df.format({col: "{:.2f}"})
 
     st.dataframe(styled_df, hide_index=True)
+
+
+def _convert_dicts_to_str(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Convert dicts to strings in a DataFrame. This is necessary for Streamlit
+    when the rows are colored with some transparency/alpha as Streamlit can't
+    handle the linear combination of colors correctly as it can be
+    non-integral.
+    NB: Not only do we convert dicts, but also strings that are valid JSON. This
+    is because Streamlit seems to convert such strings to dicts.
+
+
+    Args:
+        df: DataFrame possibly containing dicts.
+
+    Returns:
+        DataFrame with dicts converted to strings.
+    """
+    for i in range(df.shape[0]):
+        for j in range(df.shape[1]):
+            curr = df.iloc[i, j]
+            if isinstance(curr, dict):
+                df.iloc[i, j] = pp.pformat(json.dumps(curr))
+            elif isinstance(curr, str):
+                try:
+                    json.loads(curr)
+                    df.iloc[i, j] = pp.pformat(curr)
+                except json.JSONDecodeError:
+                    pass
 
 
 def _filter_duplicate_span_calls(df: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
# Description
Convert dicts (or strings that represent to dicts) as prettified strings in colored DataFrames so that they render correctly in Streamlit.

## Other details good to know for developers
This was bothering Stella.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
