### PR TITLE
Fix groundedness support for bedrock.

### DIFF
--- a/src/dashboard/trulens/dashboard/utils/records_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/records_utils.py
@@ -1,4 +1,5 @@
 from functools import partial
+import json
 import pprint as pp
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
@@ -190,6 +191,8 @@ def display_feedback_call(
         st.warning("No feedback details found.")
         return
 
+    df = _convert_dicts_to_str(df.copy())
+
     # Style and display the DataFrame
     style_highlight_fn = partial(
         highlight,
@@ -207,6 +210,35 @@ def display_feedback_call(
         styled_df = styled_df.format({col: "{:.2f}"})
 
     st.dataframe(styled_df, hide_index=True)
+
+
+def _convert_dicts_to_str(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Convert dicts to strings in a DataFrame. This is necessary for Streamlit
+    when the rows are colored with some transparency/alpha as Streamlit can't
+    handle the linear combination of colors correctly as it can be
+    non-integral.
+    NB: Not only do we convert dicts, but also strings that are valid JSON. This
+    is because Streamlit seems to convert such strings to dicts.
+
+
+    Args:
+        df: DataFrame possibly containing dicts.
+
+    Returns:
+        DataFrame with dicts converted to strings.
+    """
+    for i in range(df.shape[0]):
+        for j in range(df.shape[1]):
+            curr = df.iloc[i, j]
+            if isinstance(curr, dict):
+                df.iloc[i, j] = pp.pformat(json.dumps(curr))
+            elif isinstance(curr, str):
+                try:
+                    json.loads(curr)
+                    df.iloc[i, j] = pp.pformat(curr)
+                except json.JSONDecodeError:
+                    pass
 
 
 def _filter_duplicate_span_calls(df: pd.DataFrame) -> pd.DataFrame:

--- a/src/dashboard/trulens/dashboard/utils/records_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/records_utils.py
@@ -1,5 +1,4 @@
 from functools import partial
-import json
 import pprint as pp
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
@@ -191,8 +190,6 @@ def display_feedback_call(
         st.warning("No feedback details found.")
         return
 
-    df = _convert_dicts_to_str(df.copy())
-
     # Style and display the DataFrame
     style_highlight_fn = partial(
         highlight,
@@ -210,35 +207,6 @@ def display_feedback_call(
         styled_df = styled_df.format({col: "{:.2f}"})
 
     st.dataframe(styled_df, hide_index=True)
-
-
-def _convert_dicts_to_str(df: pd.DataFrame) -> pd.DataFrame:
-    """
-    Convert dicts to strings in a DataFrame. This is necessary for Streamlit
-    when the rows are colored with some transparency/alpha as Streamlit can't
-    handle the linear combination of colors correctly as it can be
-    non-integral.
-    NB: Not only do we convert dicts, but also strings that are valid JSON. This
-    is because Streamlit seems to convert such strings to dicts.
-
-
-    Args:
-        df: DataFrame possibly containing dicts.
-
-    Returns:
-        DataFrame with dicts converted to strings.
-    """
-    for i in range(df.shape[0]):
-        for j in range(df.shape[1]):
-            curr = df.iloc[i, j]
-            if isinstance(curr, dict):
-                df.iloc[i, j] = pp.pformat(json.dumps(curr))
-            elif isinstance(curr, str):
-                try:
-                    json.loads(curr)
-                    df.iloc[i, j] = pp.pformat(curr)
-                except json.JSONDecodeError:
-                    pass
 
 
 def _filter_duplicate_span_calls(df: pd.DataFrame) -> pd.DataFrame:

--- a/src/feedback/trulens/feedback/prompts.py
+++ b/src/feedback/trulens/feedback/prompts.py
@@ -22,11 +22,6 @@ Supporting Evidence: {supporting_evidence}
 Score: {score}
 """
 
-LLM_GROUNDEDNESS_FULL_PROMPT = """Give me the INFORMATION OVERLAP of this SOURCE and STATEMENT.
-SOURCE: {premise}
-STATEMENT: {hypothesis}
-"""
-
 LLM_GROUNDEDNESS_SYSTEM = v2.Groundedness.system_prompt
 LLM_GROUNDEDNESS_USER = """SOURCE: {premise}
 

--- a/src/providers/bedrock/trulens/providers/bedrock/provider.py
+++ b/src/providers/bedrock/trulens/providers/bedrock/provider.py
@@ -231,70 +231,14 @@ class Bedrock(llm_provider.LLMProvider):
         max_score_val: int = 3,
         temperature: float = 0.0,
     ) -> Union[float, Tuple[float, Dict]]:
-        """
-        Base method to generate a score and reason, used for evaluation.
-
-        Args:
-            system_prompt: A pre-formatted system prompt.
-            user_prompt: An optional user prompt.
-            min_score_val: The minimum score value. Default is 0.
-            max_score_val: The maximum score value. Default is 3.
-            temperature: The temperature value for LLM score generation. Default is 0.0.
-
-        Returns:
-            The score on a 0-1 scale.
-
-            Reason metadata if returned by the LLM.
-        """
-
         if temperature != 0.0:
             logger.warning(
                 "The `temperature` argument is ignored for Bedrock provider."
             )
-
-        llm_messages = [{"role": "system", "content": system_prompt}]
-        if user_prompt is not None:
-            llm_messages.append({"role": "user", "content": user_prompt})
-
-        response = self.endpoint.run_in_pace(
-            func=self._create_chat_completion, messages=llm_messages
+        return super().generate_score_and_reasons(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
-        if "Supporting Evidence" in response:
-            score = 0.0
-            supporting_evidence = None
-            criteria = None
-            for line in response.split("\n"):
-                if "Score" in line:
-                    score = (
-                        feedback_generated.re_configured_rating(
-                            line,
-                            min_score_val=min_score_val,
-                            max_score_val=max_score_val,
-                        )
-                        - min_score_val
-                    ) / (max_score_val - min_score_val)
-                if "Criteria" in line:
-                    parts = line.split(":")
-                    if len(parts) > 1:
-                        criteria = ":".join(parts[1:]).strip()
-                if "Supporting Evidence" in line:
-                    supporting_evidence = line[
-                        line.index("Supporting Evidence:")
-                        + len("Supporting Evidence:") :
-                    ].strip()
-            reasons = {
-                "reason": (
-                    f"{'Criteria: ' + str(criteria)}\n"
-                    f"{'Supporting Evidence: ' + str(supporting_evidence)}"
-                )
-            }
-            return score, reasons
-        else:
-            return (
-                feedback_generated.re_configured_rating(
-                    response,
-                    min_score_val=min_score_val,
-                    max_score_val=max_score_val,
-                )
-                - min_score_val
-            ) / (max_score_val - min_score_val)

--- a/src/providers/bedrock/trulens/providers/bedrock/provider.py
+++ b/src/providers/bedrock/trulens/providers/bedrock/provider.py
@@ -3,7 +3,6 @@ import logging
 from typing import ClassVar, Dict, Optional, Sequence, Tuple, Type, Union
 
 from pydantic import BaseModel
-from trulens.feedback import generated as feedback_generated
 from trulens.feedback import llm_provider
 from trulens.providers.bedrock import endpoint as bedrock_endpoint
 
@@ -182,7 +181,6 @@ class Bedrock(llm_provider.LLMProvider):
 
         return response_body
 
-    # overwrite base to use prompt instead of messages
     def generate_score(
         self,
         system_prompt: str,
@@ -204,25 +202,18 @@ class Bedrock(llm_provider.LLMProvider):
         Returns:
             The score on a 0-1 scale.
         """
-
         if temperature != 0.0:
             logger.warning(
                 "The `temperature` argument is ignored for Bedrock provider."
             )
-
-        llm_messages = [{"role": "system", "content": system_prompt}]
-        if user_prompt is not None:
-            llm_messages.append({"role": "user", "content": user_prompt})
-
-        response = self.endpoint.run_in_pace(
-            func=self._create_chat_completion, messages=llm_messages
+        return super().generate_score(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            min_score_val=min_score_val,
+            max_score_val=max_score_val,
+            temperature=temperature,
         )
 
-        return (
-            feedback_generated.re_configured_rating(response) - min_score_val
-        ) / (max_score_val - min_score_val)
-
-    # overwrite base to use prompt instead of messages
     def generate_score_and_reasons(
         self,
         system_prompt: str,

--- a/src/trulens_eval/trulens_eval/feedback/prompts.py
+++ b/src/trulens_eval/trulens_eval/feedback/prompts.py
@@ -36,7 +36,6 @@ from trulens.feedback.prompts import LANGCHAIN_PROMPT_TEMPLATE_USER
 from trulens.feedback.prompts import (
     LANGCHAIN_PROMPT_TEMPLATE_WITH_COT_REASONS_SYSTEM,
 )
-from trulens.feedback.prompts import LLM_GROUNDEDNESS_FULL_PROMPT
 from trulens.feedback.prompts import LLM_GROUNDEDNESS_SYSTEM
 from trulens.feedback.prompts import LLM_GROUNDEDNESS_USER
 from trulens.feedback.prompts import REMOVE_Y_N

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -4,7 +4,7 @@ trulens:
   lows: {}
 trulens.benchmark:
   __class__: builtins.module
-  __version__: 2.2.0
+  __version__: 2.2.4
   highs: {}
   lows:
     __version__: builtins.str
@@ -60,7 +60,7 @@ trulens.benchmark.test_cases:
     generate_summeval_groundedness_golden_set: builtins.function
 trulens.core:
   __class__: builtins.module
-  __version__: 2.2.0
+  __version__: 2.2.4
   highs:
     Feedback: pydantic._internal._model_construction.ModelMetaclass
     FeedbackMode: enum.EnumType
@@ -1922,7 +1922,7 @@ trulens.core.utils.trulens.Other:
   attributes: {}
 trulens.dashboard:
   __class__: builtins.module
-  __version__: 2.2.0
+  __version__: 2.2.4
   highs:
     run_dashboard: builtins.function
     run_dashboard_sis: builtins.function
@@ -2224,7 +2224,7 @@ trulens.dashboard.ux.styles.ResultCategoryType:
     value: enum.property
 trulens.feedback:
   __class__: builtins.module
-  __version__: 2.2.0
+  __version__: 2.2.4
   highs:
     Embeddings: pydantic._internal._model_construction.ModelMetaclass
     GroundTruthAggregator: pydantic._internal._model_construction.ModelMetaclass
@@ -2540,7 +2540,6 @@ trulens.feedback.prompts:
     LLM_ABSTENTION_USER: builtins.str
     LLM_ANSWERABILITY_SYSTEM: builtins.str
     LLM_ANSWERABILITY_USER: builtins.str
-    LLM_GROUNDEDNESS_FULL_PROMPT: builtins.str
     LLM_GROUNDEDNESS_SENTENCES_SPLITTER: builtins.str
     LLM_GROUNDEDNESS_SYSTEM: builtins.str
     LLM_GROUNDEDNESS_USER: builtins.str
@@ -3219,7 +3218,7 @@ trulens.feedback.v2.provider.base.Provider:
     tru_class_info: trulens.core.utils.pyschema.Class
 trulens.hotspots:
   __class__: builtins.module
-  __version__: 2.2.0
+  __version__: 2.2.4
   highs:
     HotspotsConfig: builtins.type
     get_skipped_columns: builtins.function

--- a/tests/unit/static/golden/api.trulens_eval.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens_eval.3.11.yaml
@@ -3487,7 +3487,6 @@ trulens_eval.feedback.prompts:
     LANGCHAIN_PROMPT_TEMPLATE_SYSTEM: builtins.str
     LANGCHAIN_PROMPT_TEMPLATE_USER: builtins.str
     LANGCHAIN_PROMPT_TEMPLATE_WITH_COT_REASONS_SYSTEM: builtins.str
-    LLM_GROUNDEDNESS_FULL_PROMPT: builtins.str
     LLM_GROUNDEDNESS_SYSTEM: builtins.str
     LLM_GROUNDEDNESS_USER: builtins.str
     QS_RELEVANCE_VERB_2S_TOP1: trulens.core.utils.imports.Dummy


### PR DESCRIPTION
# Description
Fix groundedness support for bedrock.

The issue is that the function `generate_score_and_reasons` is overridden for Bedrock and was not updated when the prompts were updated. AFAICT, the only reason this is is because Bedrock doesn't handle temperatures. This is not entirely clear to me though. @sfc-gh-jreini , do you know if this is the only reason?

## Other details good to know for developers


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix groundedness support for Bedrock by updating `generate_score_and_reasons` and removing outdated prompts.
> 
>   - **Behavior**:
>     - Updated `generate_score_and_reasons` in `provider.py` to call superclass method, aligning with updated prompts.
>     - Removed `LLM_GROUNDEDNESS_FULL_PROMPT` from `prompts.py` and related files.
>   - **Misc**:
>     - Updated version numbers in `api.trulens.3.11.yaml` and `api.trulens_eval.3.11.yaml` from 2.2.0 to 2.2.4.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for eb4bd5f5c4d7ec697c526bb70b30a1f5cda83e82. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->