### PR TITLE
Ensure all OTel spans to be exported to Snowflake before the process running the main thread terminates

### DIFF
--- a/src/connectors/snowflake/trulens/connectors/snowflake/otel_exporter.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/otel_exporter.py
@@ -194,7 +194,7 @@ class TruLensSnowflakeSpanExporter(SpanExporter):
             ],
         )
         if not dry_run:
-            sql_cmd.collect()
+            sql_cmd.collect()  # Blocking call: ensures spans are ingested before process exit; may delay if ingestion hangs and force_flush is called
 
     def _export_to_snowflake_stage_for_app_and_run(
         self,


### PR DESCRIPTION
# Description

Recently, we discovered a critical bug when users are running the live tracing decorator `@trace_with_run`. 

When the process for the user's app exits (i.e. app run as an CLI / script, etc),  the worker threads responsible for uploading spans to Snowflake stage could be terminated prematurely, resulting in failed `INGESTION_MULTIPLE_BATCHES` query as the span being written could be incomplete / corrupted. 

The solution (or the best one I can think of now) is to switch from using the non-blocking `collect_nowait` to the synchronous `collect` when running the Snowflake `INGESTION_MULTIPLE_BATCHES` sproc query.  The key for this to work is that we always call  the `force_flush` from otel trace provider prior to flush all enqueued spans from BatchSpanProcessor to the exporter and export, as `force_flush` switches to the main thread to invoke `export` method of the exporter, making it synchronous.


I think it's fine to not make this configurable at the moment and always use the blocking `collect`, b/c as long as users don't call `force_flush` explicitly, the spans export steps are still done by worker thread and hence non-blocking. 

 
OLD WAY:
```
Main Thread                    Background Thread
-----------                    -----------------
force_flush() ───────────────► export() called
    │                          │
    │                          collect_nowait() ← starts async operation
    │                          │
    │                          return SUCCESS ← returns immediately
    │                          
force_flush() returns ←───────┘
main thread exits
                               [uploading to stage operation not finished yet but process dies]
```

NEW WAY:
```
Main Thread                    
-----------                    
force_flush() ───────────────► export() called (on main thread!)
    │                          │
    │                          collect() ← blocks until span exporting to Snowflake stage completes
    │                          │
    │                          [Snowflake operation finishes]
    │                          │
    │                          return SUCCESS
    │                          
force_flush() returns ←───────┘
main thread exits ← but only after spans being all uploaded to snowflake stage!
```


## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Switch from non-blocking `collect_nowait()` to blocking `collect()` in `otel_exporter.py` to ensure complete span export before process exit.
> 
>   - **Behavior**:
>     - Switch from `collect_nowait()` to `collect()` in `_ingest_spans_from_stage()` in `otel_exporter.py` to ensure spans are fully exported before process exit.
>     - Addresses issue where worker threads could terminate prematurely, causing incomplete span uploads.
>   - **Misc**:
>     - Update comments in `otel_exporter.py` to reflect the change to a blocking call.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for b5fff8fe69ac29f6692c40c506fb660c8af91691. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->