### PR TITLE
[Small fix] Properly set pypi token in make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ CONDA_BUILD_DIRS := $(shell find . \
 	-name "*meta.yaml" \
 	-exec dirname {} \;)
 LAST_TRULENS_EVAL_COMMIT := 4cadb05 # commit that includes the last pre-namespace trulens_eval package
+TOKEN ?= $(shell echo $$TOKEN)
+
 
 # Global setting: execute all commands of a target in a single shell session.
 # Note for MAC OS, the default make is too old to support this. "brew install


### PR DESCRIPTION
# Description

Make variable vs environment variable: Make doesn't automatically import environment variables as Make variables. The `$(TOKEN)` syntax looks for a Make variable, not an environment variable

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
