### PR TITLE
style: cleanup bedrock provider imports

### DIFF
--- a/src/providers/bedrock/trulens/providers/bedrock/endpoint.py
+++ b/src/providers/bedrock/trulens/providers/bedrock/endpoint.py
@@ -1,10 +1,11 @@
 import inspect
+import json
 import logging
 import pprint
 from typing import Any, Callable, Iterable, Optional
 
 import boto3
-from botocore.client import ClientCreator
+from botocore import client as botocore_client
 import pydantic
 from trulens.core.feedback import endpoint as core_endpoint
 from trulens.core.utils import python as python_utils
@@ -44,8 +45,6 @@ class BedrockCallback(core_endpoint.EndpointCallback):
         data = chunk.get("bytes")
         if data is None:
             return
-
-        import json
 
         data = json.loads(data.decode())
 
@@ -165,10 +164,11 @@ class BedrockEndpoint(core_endpoint.Endpoint):
         # Note here was are instrumenting a method that outputs a function which
         # we also want to instrument:
         if not python_utils.safe_hasattr(
-            ClientCreator._create_api_method, core_endpoint.INSTRUMENT
+            botocore_client.ClientCreator._create_api_method,
+            core_endpoint.INSTRUMENT,
         ):
             self._instrument_class_wrapper(
-                ClientCreator,
+                botocore_client.ClientCreator,
                 wrapper_method_name="_create_api_method",
                 wrapped_method_filter=lambda f: f.__name__
                 in ["invoke_model", "invoke_model_with_response_stream"],

--- a/src/providers/bedrock/trulens/providers/bedrock/provider.py
+++ b/src/providers/bedrock/trulens/providers/bedrock/provider.py
@@ -2,7 +2,7 @@ import json
 import logging
 from typing import ClassVar, Dict, Optional, Sequence, Tuple, Type, Union
 
-from pydantic import BaseModel
+import pydantic
 from trulens.feedback import llm_provider
 from trulens.providers.bedrock import endpoint as bedrock_endpoint
 
@@ -60,7 +60,7 @@ class Bedrock(llm_provider.LLMProvider):
         self,
         prompt: Optional[str] = None,
         messages: Optional[Sequence[Dict]] = None,
-        response_format: Optional[Type[BaseModel]] = None,
+        response_format: Optional[Type[pydantic.BaseModel]] = None,
         **kwargs,
     ) -> str:
         assert self.endpoint is not None


### PR DESCRIPTION
# Description
Fixes Part of #2197 
Cleaned up issues with certain import styling in the providers/bedrock/trulens/bedrock folder.Looking for approval and feedback as to make changes.So i can go ahead and fix other import styling issues in providers folder.

## Other details good to know for developers

endpoint.py -imports json from the top instead of the middle of the file.
- import client as botocore_client to follow import module,not class rule.
provider.py - import pydantic to follow how it is imported in endpoint.py for consistency and also to follow import module only rule.
Note:__init__.py has an importing change but i didnt go forward with it since there is was a comment warning against it.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
- [x] Code style/formatting change (non-functional)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Clean up import statements in `endpoint.py` and `provider.py` for consistency and adherence to import conventions.
> 
>   - **Imports**:
>     - Move `json` import to the top in `endpoint.py`.
>     - Change `from botocore.client import ClientCreator` to `from botocore import client as botocore_client` in `endpoint.py`.
>     - Change `from pydantic import BaseModel` to `import pydantic` in `provider.py`.
>   - **Code Consistency**:
>     - Use `botocore_client.ClientCreator` instead of `ClientCreator` in `endpoint.py`.
>     - Use `pydantic.BaseModel` instead of `BaseModel` in `provider.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 4fe7614e7a3b03b1fa9e210fcfd7410050250dbe. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->