### PR TITLE
Use Feedback class instead of underlying function when running evals

### DIFF
--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -2123,7 +2123,7 @@ you use the `%s` wrapper to make sure `%s` does get instrumented. `%s` method
             compute_feedback_by_span_group(
                 events,
                 feedback.name,
-                feedback,  # Pass the entire Feedback object instead of just feedback.imp
+                feedback,
                 feedback.higher_is_better,
                 feedback.selectors,
                 feedback.aggregator,

--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -2123,7 +2123,7 @@ you use the `%s` wrapper to make sure `%s` does get instrumented. `%s` method
             compute_feedback_by_span_group(
                 events,
                 feedback.name,
-                feedback.imp,
+                feedback,  # Pass the entire Feedback object instead of just feedback.imp
                 feedback.higher_is_better,
                 feedback.selectors,
                 feedback.aggregator,

--- a/src/core/trulens/core/feedback/feedback.py
+++ b/src/core/trulens/core/feedback/feedback.py
@@ -168,9 +168,8 @@ class Feedback(feedback_schema.FeedbackDefinition):
     examples: Optional[List[Tuple]] = pydantic.Field(None, exclude=True)
     """Examples to use when evaluating the feedback function."""
 
-    criteria: Optional[str] = pydantic.Field(None, exclude=True)
+    criteria: Optional[str] = pydantic.Field(None)
     """Criteria for the feedback function."""
-
     min_score_val: Optional[int] = pydantic.Field(None, exclude=True)
     """Minimum score value for the feedback function."""
 
@@ -272,6 +271,12 @@ class Feedback(feedback_schema.FeedbackDefinition):
                 # Default aggregator if neither serialized `aggregator` or
                 # loaded `agg` were specified.
                 agg = np.mean
+
+        # Pass custom parameters to parent class for serialization
+        if criteria is not None:
+            kwargs["criteria"] = criteria
+        if examples is not None:
+            kwargs["examples"] = examples
 
         super().__init__(**kwargs)
 

--- a/src/core/trulens/core/feedback/feedback.py
+++ b/src/core/trulens/core/feedback/feedback.py
@@ -168,7 +168,7 @@ class Feedback(feedback_schema.FeedbackDefinition):
     examples: Optional[List[Tuple]] = pydantic.Field(None, exclude=True)
     """Examples to use when evaluating the feedback function."""
 
-    criteria: Optional[str] = pydantic.Field(None)
+    criteria: Optional[str] = pydantic.Field(None, exclude=True)
     """Criteria for the feedback function."""
     min_score_val: Optional[int] = pydantic.Field(None, exclude=True)
     """Minimum score value for the feedback function."""

--- a/src/feedback/trulens/feedback/computer.py
+++ b/src/feedback/trulens/feedback/computer.py
@@ -151,8 +151,7 @@ def compute_feedback_by_span_group(
         raise_error_on_no_feedbacks_computed:
             Raise an error if no feedbacks were computed. Default is True.
     """
-    # Always use the Feedback object directly
-    actual_feedback_function = feedback_function
+
     kwarg_groups = _group_kwargs_by_selectors(kwarg_to_selector)
     unflattened_inputs = _collect_inputs_from_events(
         events, kwarg_groups, kwarg_to_selector
@@ -171,7 +170,7 @@ def compute_feedback_by_span_group(
     num_feedbacks_computed = _run_feedback_on_inputs(
         flattened_inputs,
         feedback_name,
-        actual_feedback_function,  # Pass the Feedback object or raw callable
+        feedback_function,
         higher_is_better,
         feedback_aggregator,
         record_id_to_record_root,

--- a/src/feedback/trulens/feedback/computer.py
+++ b/src/feedback/trulens/feedback/computer.py
@@ -20,7 +20,6 @@ from opentelemetry.trace import INVALID_SPAN_ID
 from opentelemetry.trace.span import Span
 import pandas as pd
 
-# Import Feedback for runtime isinstance checks
 from trulens.core.feedback.feedback import Feedback
 from trulens.core.feedback.feedback_function_input import FeedbackFunctionInput
 from trulens.core.feedback.selector import ProcessedContentNode

--- a/src/feedback/trulens/feedback/computer.py
+++ b/src/feedback/trulens/feedback/computer.py
@@ -13,7 +13,6 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
-    Union,
 )
 
 from opentelemetry import trace
@@ -28,7 +27,6 @@ from trulens.core.feedback.selector import ProcessedContentNode
 from trulens.core.feedback.selector import Selector
 from trulens.core.feedback.selector import Trace
 from trulens.core.otel.instrument import OtelFeedbackComputationRecordingContext
-from trulens.core.otel.instrument import get_func_name
 from trulens.experimental.otel_tracing.core.session import TRULENS_SERVICE_NAME
 from trulens.experimental.otel_tracing.core.span import (
     set_function_call_attributes,
@@ -94,9 +92,7 @@ class RecordGraphNode:
 def _compute_feedback(
     record_root: RecordGraphNode,
     feedback_name: str,
-    feedback_function: Callable[
-        [Any], Union[float, Tuple[float, Dict[str, Any]]]
-    ],
+    feedback_function: Feedback,
     higher_is_better: bool,
     selector_function: Callable[[RecordGraphNode], List[Dict[str, Any]]],
 ) -> None:
@@ -107,7 +103,7 @@ def _compute_feedback(
     Args:
         record_root: Record root of record to compute feedback for.
         feedback_name: Name of feedback.
-        feedback_function: Function to compute feedback.
+        feedback_function: Feedback object to compute feedback.
         higher_is_better: Whether higher values are better.
         selector_function:
             Function to select inputs for feedback computation. Given a record
@@ -136,10 +132,7 @@ def _compute_feedback(
 def compute_feedback_by_span_group(
     events: pd.DataFrame,
     feedback_name: str,
-    feedback_function: Union[
-        Callable[[Any], Union[float, Tuple[float, Dict[str, Any]]]],
-        Feedback,  # Can now accept Feedback objects
-    ],
+    feedback_function: Feedback,
     higher_is_better: bool,
     kwarg_to_selector: Dict[str, Selector],
     feedback_aggregator: Optional[Callable[[List[float]], float]] = None,
@@ -151,21 +144,15 @@ def compute_feedback_by_span_group(
     Args:
         events: DataFrame containing trace events.
         feedback_name: Name of the feedback function.
-        feedback_function: Function to compute feedback or Feedback object.
+        feedback_function: Feedback object to compute feedback.
         higher_is_better: Whether higher values are better.
         kwarg_to_selector: Mapping from function kwargs to span selectors
         feedback_aggregator: Aggregator function to combine feedback scores.
         raise_error_on_no_feedbacks_computed:
             Raise an error if no feedbacks were computed. Default is True.
     """
-    # If we received a Feedback object, extract the implementation but keep the object for later use
+    # Always use the Feedback object directly
     actual_feedback_function = feedback_function
-    if isinstance(feedback_function, Feedback):
-        # We'll pass the Feedback object through the call chain
-        actual_feedback_function = feedback_function
-    else:
-        # For backward compatibility with raw callables
-        actual_feedback_function = feedback_function
     kwarg_groups = _group_kwargs_by_selectors(kwarg_to_selector)
     unflattened_inputs = _collect_inputs_from_events(
         events, kwarg_groups, kwarg_to_selector
@@ -644,10 +631,7 @@ def _run_feedback_on_inputs(
         Tuple[str, Optional[str], Dict[str, FeedbackFunctionInput]]
     ],
     feedback_name: str,
-    feedback_function: Union[
-        Callable[[Any], Union[float, Tuple[float, Dict[str, Any]]]],
-        Feedback,  # Can now accept Feedback objects
-    ],
+    feedback_function: Feedback,
     higher_is_better: bool,
     feedback_aggregator: Optional[Callable[[List[float]], float]],
     record_id_to_record_root: Dict[str, pd.Series],
@@ -657,7 +641,7 @@ def _run_feedback_on_inputs(
     Args:
         flattened_inputs: Flattened inputs. Each entry is a tuple of (record_id, span_group, inputs).
         feedback_name: Name of the feedback function.
-        feedback_function: Function to compute feedback.
+        feedback_function: Feedback object to compute feedback.
         higher_is_better: Whether higher values are better.
         feedback_aggregator: Aggregator function to combine feedback scores.
         record_id_to_record_root: Mapping from record_id to record root.
@@ -688,10 +672,7 @@ def _run_feedback_on_inputs(
 
 def _call_feedback_function_with_record_root_info(
     feedback_name: str,
-    feedback_function: Union[
-        Callable[[Any], Union[float, Tuple[float, Dict[str, Any]]]],
-        Feedback,  # Can now accept Feedback objects
-    ],
+    feedback_function: Feedback,
     higher_is_better: bool,
     feedback_aggregator: Optional[Callable[[List[float]], float]],
     kwarg_inputs: Dict[str, FeedbackFunctionInput],
@@ -703,7 +684,7 @@ def _call_feedback_function_with_record_root_info(
 
     Args:
         feedback_name: Name of the feedback function.
-        feedback_function: Function to compute feedback.
+        feedback_function: Feedback object to compute feedback.
         higher_is_better: Whether higher values are better.
         feedback_aggregator: Aggregator function to combine feedback scores.
         kwarg_inputs: kwarg inputs to feedback function.
@@ -741,10 +722,7 @@ def _call_feedback_function_with_record_root_info(
 
 def _call_feedback_function(
     feedback_name: str,
-    feedback_function: Union[
-        Callable[[Any], Union[float, Tuple[float, Dict[str, Any]]]],
-        Feedback,  # Can now accept Feedback objects
-    ],
+    feedback_function: Feedback,
     higher_is_better: bool,
     feedback_aggregator: Optional[Callable[[List[float]], float]],
     kwarg_inputs: Dict[str, FeedbackFunctionInput],
@@ -760,7 +738,7 @@ def _call_feedback_function(
 
     Args:
         feedback_name: Name of the feedback function.
-        feedback_function: Function to compute feedback.
+        feedback_function: Feedback object to compute feedback.
         higher_is_better: Whether higher values are better.
         feedback_aggregator: Aggregator function to combine feedback scores.
         kwarg_inputs: kwarg inputs to feedback function.
@@ -844,10 +822,7 @@ def _call_feedback_function(
 
 
 def _call_feedback_function_under_eval_span(
-    feedback_function: Union[
-        Callable[[Any], Union[float, Tuple[float, Dict[str, Any]]]],
-        Feedback,  # Can now accept Feedback objects
-    ],
+    feedback_function: Feedback,
     kwargs: Dict[str, Any],
     eval_root_span: Span,
     is_only_child: bool,
@@ -876,12 +851,8 @@ def _call_feedback_function_under_eval_span(
         res = None
         exc = None
         try:
-            # Check if feedback_function is a Feedback object and use its __call__ method
-            # to ensure custom parameters like criteria and custom_instructions are used
-            if isinstance(feedback_function, Feedback):
-                res = feedback_function(**kwargs)
-            else:
-                res = feedback_function(**kwargs)
+            # Directly call the Feedback object to ensure custom parameters are used
+            res = feedback_function(**kwargs)
             metadata = {}
             if isinstance(res, tuple):
                 # If the result is a tuple, it must be (score, metadata) where
@@ -895,7 +866,7 @@ def _call_feedback_function_under_eval_span(
                     ])
                 ):
                     raise ValueError(
-                        "Feedback functions must be of type `Callable[Any, Union[float, Tuple[float, Dict[str, Any]]]]`!"
+                        "Feedback functions must return either a float score or a (score, metadata) tuple."
                     )
                 res, metadata = res[0], res[1]
             res = float(res)
@@ -909,11 +880,8 @@ def _call_feedback_function_under_eval_span(
             eval_span.set_attribute(SpanAttributes.EVAL.ERROR, str(e))
             raise e
         finally:
-            # Handle both Feedback objects and raw functions for get_func_name
-            if isinstance(feedback_function, Feedback):
-                func_name = feedback_function.name
-            else:
-                func_name = get_func_name(feedback_function)
+            # Use Feedback.name for function call attributes
+            func_name = feedback_function.name
 
             set_function_call_attributes(eval_span, res, func_name, exc, kwargs)
 


### PR DESCRIPTION
# Description

Feedback class was not being directly run in otel recording, instead the underlying function was being called via feedback.imp. This change uses the Feedback class call so that we use all of the available parameters, such as criteria and custom instructions.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
