### PR TITLE
Fix typo in model cost JSON key

### DIFF
--- a/src/providers/cortex/trulens/providers/cortex/config/cortex_model_costs.json
+++ b/src/providers/cortex/trulens/providers/cortex/config/cortex_model_costs.json
@@ -20,5 +20,5 @@
     "opeani-gpt-5-mini": 0.32,
     "openai-gpt-5-nano": 0.06,
     "openai-gpt-oss-120b": 0.11,
-    "opeani-gpt-oss-20b": 0.05
+    "openai-gpt-oss-20b": 0.05
 }


### PR DESCRIPTION
# Description

Fix typo in model cost JSON key

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix typo in `cortex_model_costs.json` key from `"opeani-gpt-oss-20b"` to `"openai-gpt-oss-20b"`.
> 
>   - **Bug Fix**:
>     - Corrected typo in `cortex_model_costs.json` from `"opeani-gpt-oss-20b"` to `"openai-gpt-oss-20b"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 14665ec8d72d257dcd72f7cbac4916993919a4a7. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->