### PR TITLE
Fix Cortex cost/usage tracking with latest REST API

### DIFF
--- a/src/providers/cortex/trulens/providers/cortex/endpoint.py
+++ b/src/providers/cortex/trulens/providers/cortex/endpoint.py
@@ -20,12 +20,16 @@ class CortexCostComputer:
     def handle_response(response: Any) -> Dict[str, Any]:
         model = None
         usage = {}
+
         for curr in response:
             data = json.loads(curr.data)
-            logger.warning(f"[daniel]data: {data}")
 
             choice = data["choices"][0]
             if "finish_reason" in choice and choice["finish_reason"] == "stop":
+                model = data["model"]
+                usage = data["usage"]
+                break
+            elif "usage" in data and data["usage"]:
                 model = data["model"]
                 usage = data["usage"]
                 break

--- a/src/providers/cortex/trulens/providers/cortex/endpoint.py
+++ b/src/providers/cortex/trulens/providers/cortex/endpoint.py
@@ -22,6 +22,8 @@ class CortexCostComputer:
         usage = {}
         for curr in response:
             data = json.loads(curr.data)
+            logger.warning(f"[daniel]data: {data}")
+
             choice = data["choices"][0]
             if "finish_reason" in choice and choice["finish_reason"] == "stop":
                 model = data["model"]
@@ -29,7 +31,9 @@ class CortexCostComputer:
                 break
 
         if model is None or not usage:
-            logger.warning("No model usage found in response.")
+            logger.warning(
+                f"No model usage found in response. response: {response} usage: {usage}"
+            )
 
         endpoint = CortexEndpoint()
         callback = CortexCallback(endpoint=endpoint)


### PR DESCRIPTION
# Description

"finish_reason" at the moment is not returned from Cortex REST API when invoked in cortex (snowflake-ml-python) python SDK.


ref: https://snowflakecomputing.atlassian.net/browse/SNOW-2191550?atlOrigin=eyJpIjoiZDhkYzMwMmQzYzM5NDc0NGI0OGZjNTIzNTEzZGZhYzQiLCJwIjoiamlyYS1zbGFjay1pbnQifQ
<img width="2914" height="545" alt="image" src="https://github.com/user-attachments/assets/9eb3cd6c-e559-4739-97b2-9e48f68eca20" />


## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
