### PR TITLE
Tracing for LlamaIndex AgentWorkflow + notebook example with GPA evals

### DIFF
--- a/examples/expositional/frameworks/llamaindex/llama_index_evaluate_agent_workflow_multi.ipynb
+++ b/examples/expositional/frameworks/llamaindex/llama_index_evaluate_agent_workflow_multi.ipynb
@@ -1,0 +1,445 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tracing and Evaluating Multi-Agent Systems with TruLens and LlamaIndex AgentWorkflow\n",
+    "\n",
+    "In this notebook, we demonstrate how to use **TruLens** to trace, monitor, and evaluate multi-agent systems built with LlamaIndex's `AgentWorkflow`. \n",
+    "\n",
+    "## What You'll Learn\n",
+    "\n",
+    "- How to instrument LlamaIndex `AgentWorkflow` with TruLens for comprehensive tracing\n",
+    "- How to capture agent-level spans and tool calls in the TruLens dashboard\n",
+    "- How to evaluate multi-agent system performance using TruLens feedback functions\n",
+    "- How to monitor execution efficiency and logical consistency across agent handoffs\n",
+    "\n",
+    "## The Multi-Agent System\n",
+    "\n",
+    "We'll build a report generation system with three specialized agents:\n",
+    "- **ResearchAgent**: Searches the web and records research notes\n",
+    "- **WriteAgent**: Creates markdown reports based on research\n",
+    "- **ReviewAgent**: Reviews and provides feedback on reports\n",
+    "\n",
+    "The key focus is on **observability and evaluation** - understanding how agents interact, where bottlenecks occur, and how to measure system performance."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "This example requires several key components:\n",
+    "\n",
+    "- **TruLens**: For tracing, monitoring, and evaluating the multi-agent system\n",
+    "- **LlamaIndex**: For the `AgentWorkflow` and agent implementations  \n",
+    "- **OpenAI**: As the LLM provider for all agents\n",
+    "- **Tavily**: For web search capabilities\n",
+    "\n",
+    "We'll use OpenAI's GPT-4 as our LLM across all agents for consistency. TruLens will capture every interaction, tool call, and agent handoff, providing complete visibility into the system's behavior."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index trulens-apps-llamaindex trulens-providers-openai tavily-python -q"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-proj-...\"\n",
+    "os.environ[\"TAVILY_API_KEY\"] = \"tvly-dev-...\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.llms.openai import OpenAI\n",
+    "\n",
+    "llm = OpenAI(model=\"gpt-4o\", api_key=os.getenv(\"OPENAI_API_KEY\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## System Design & Tracing Architecture\n",
+    "\n",
+    "Our multi-agent system consists of three specialized agents that work together in a coordinated workflow:\n",
+    "\n",
+    "### Agent Roles\n",
+    "1. **ResearchAgent**: Searches the web and records research notes\n",
+    "2. **WriteAgent**: Creates markdown reports based on research findings  \n",
+    "3. **ReviewAgent**: Reviews reports and provides feedback for improvements\n",
+    "\n",
+    "### Tools & Observability\n",
+    "Each agent uses specific tools that TruLens will trace:\n",
+    "- `web_search`: Web search queries and results\n",
+    "- `record_notes`: Note-taking and knowledge storage\n",
+    "- `write_report`: Report generation process\n",
+    "- `review_report`: Review and feedback generation\n",
+    "\n",
+    "### What TruLens Captures\n",
+    "With TruLens instrumentation, we'll observe:\n",
+    "- **Agent-level spans**: Each agent's execution time and context\n",
+    "- **Tool call traces**: Individual tool invocations and their results\n",
+    "- **Agent handoffs**: When and why control passes between agents\n",
+    "- **State transitions**: How the shared context evolves\n",
+    "- **Performance metrics**: Execution efficiency and logical consistency\n",
+    "\n",
+    "The `Context` class enables state sharing between agents, and TruLens will track how this state evolves throughout the workflow execution.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tavily import AsyncTavilyClient\n",
+    "from llama_index.core.workflow import Context\n",
+    "\n",
+    "\n",
+    "async def search_web(query: str) -> str:\n",
+    "    \"\"\"Useful for using the web to answer questions.\"\"\"\n",
+    "    client = AsyncTavilyClient(api_key=os.getenv(\"TAVILY_API_KEY\"))\n",
+    "    return str(await client.search(query))\n",
+    "\n",
+    "\n",
+    "async def record_notes(ctx: Context, notes: str, notes_title: str) -> str:\n",
+    "    \"\"\"Useful for recording notes on a given topic. Your input should be notes with a title to save the notes under.\"\"\"\n",
+    "    async with ctx.store.edit_state() as ctx_state:\n",
+    "        if \"research_notes\" not in ctx_state[\"state\"]:\n",
+    "            ctx_state[\"state\"][\"research_notes\"] = {}\n",
+    "        ctx_state[\"state\"][\"research_notes\"][notes_title] = notes\n",
+    "    return \"Notes recorded.\"\n",
+    "\n",
+    "\n",
+    "async def write_report(ctx: Context, report_content: str) -> str:\n",
+    "    \"\"\"Useful for writing a report on a given topic. Your input should be a markdown formatted report.\"\"\"\n",
+    "    async with ctx.store.edit_state() as ctx_state:\n",
+    "        ctx_state[\"state\"][\"report_content\"] = report_content\n",
+    "    return \"Report written.\"\n",
+    "\n",
+    "\n",
+    "async def review_report(ctx: Context, review: str) -> str:\n",
+    "    \"\"\"Useful for reviewing a report and providing feedback. Your input should be a review of the report.\"\"\"\n",
+    "    async with ctx.store.edit_state() as ctx_state:\n",
+    "        ctx_state[\"state\"][\"review\"] = review\n",
+    "    return \"Report reviewed.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating Traceable Agents\n",
+    "\n",
+    "Now we'll create our three agents using LlamaIndex's `FunctionAgent` class. Each agent has:\n",
+    "- **Unique names**: Essential for TruLens to distinguish agents in traces\n",
+    "- **Clear descriptions**: Help with agent handoff decisions and trace clarity\n",
+    "- **Specific tools**: Each tool call will appear as a distinct span in TruLens\n",
+    "- **Handoff capabilities**: TruLens will track when and why agents transfer control\n",
+    "\n",
+    "The agent names (`ResearchAgent`, `WriteAgent`, `ReviewAgent`) will appear as span names in the TruLens dashboard, making it easy to follow the execution flow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.agent.workflow import FunctionAgent, ReActAgent\n",
+    "\n",
+    "research_agent = FunctionAgent(\n",
+    "    name=\"ResearchAgent\",\n",
+    "    description=\"Useful for searching the web for information on a given topic and recording notes on the topic.\",\n",
+    "    system_prompt=(\n",
+    "        \"You are the ResearchAgent that can search the web for information on a given topic and record notes on the topic. \"\n",
+    "        \"Once notes are recorded and you are satisfied, you should hand off control to the WriteAgent to write a report on the topic. \"\n",
+    "        \"You should have at least some notes on a topic before handing off control to the WriteAgent.\"\n",
+    "    ),\n",
+    "    llm=llm,\n",
+    "    tools=[search_web, record_notes],\n",
+    "    can_handoff_to=[\"WriteAgent\"],\n",
+    ")\n",
+    "\n",
+    "write_agent = FunctionAgent(\n",
+    "    name=\"WriteAgent\",\n",
+    "    description=\"Useful for writing a report on a given topic.\",\n",
+    "    system_prompt=(\n",
+    "        \"You are the WriteAgent that can write a report on a given topic. \"\n",
+    "        \"Your report should be in a markdown format. The content should be grounded in the research notes. \"\n",
+    "        \"Once the report is written, you should get feedback at least once from the ReviewAgent.\"\n",
+    "    ),\n",
+    "    llm=llm,\n",
+    "    tools=[write_report],\n",
+    "    can_handoff_to=[\"ReviewAgent\", \"ResearchAgent\"],\n",
+    ")\n",
+    "\n",
+    "review_agent = FunctionAgent(\n",
+    "    name=\"ReviewAgent\",\n",
+    "    description=\"Useful for reviewing a report and providing feedback.\",\n",
+    "    system_prompt=(\n",
+    "        \"You are the ReviewAgent that can review the write report and provide feedback. \"\n",
+    "        \"Your review should either approve the current report or request changes for the WriteAgent to implement. \"\n",
+    "        \"If you have feedback that requires changes, you should hand off control to the WriteAgent to implement the changes after submitting the review.\"\n",
+    "    ),\n",
+    "    llm=llm,\n",
+    "    tools=[review_report],\n",
+    "    can_handoff_to=[\"WriteAgent\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating the AgentWorkflow\n",
+    "\n",
+    "With our agents defined, we create the `AgentWorkflow` that orchestrates their interactions. The workflow configuration includes:\n",
+    "- **Agent list**: All participating agents\n",
+    "- **Root agent**: The starting point (`ResearchAgent`)\n",
+    "- **Initial state**: Shared context that TruLens will track as it evolves\n",
+    "\n",
+    "This workflow will be instrumented by TruLens to capture the complete execution trace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.agent.workflow import AgentWorkflow\n",
+    "\n",
+    "agent_workflow = AgentWorkflow(\n",
+    "    agents=[research_agent, write_agent, review_agent],\n",
+    "    root_agent=research_agent.name,\n",
+    "    initial_state={\n",
+    "        \"research_notes\": {},\n",
+    "        \"report_content\": \"Not written yet.\",\n",
+    "        \"review\": \"Review required.\",\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize TruLens for Tracing\n",
+    "\n",
+    "We start by initializing a TruLens session that will:\n",
+    "- **Store all traces**: Every agent call, tool usage, and handoff\n",
+    "- **Enable OTEL tracing**: Advanced OpenTelemetry-based instrumentation\n",
+    "- **Prepare for evaluation**: Set up the infrastructure for feedback functions\n",
+    "\n",
+    "The database will capture detailed execution traces that we can analyze in the TruLens dashboard."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from trulens.core import TruSession\n",
+    "\n",
+    "session = TruSession()\n",
+    "session.reset_database()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define Evaluation Metrics\n",
+    "\n",
+    "For multi-agent systems, we focus on evaluating:\n",
+    "\n",
+    "### Execution Efficiency\n",
+    "- Measures how effectively the agents coordinate and complete tasks\n",
+    "- Identifies bottlenecks and unnecessary steps in the workflow\n",
+    "- Evaluates resource utilization across agent handoffs\n",
+    "\n",
+    "### Logical Consistency  \n",
+    "- Ensures agents make coherent decisions throughout the workflow\n",
+    "- Validates that handoffs occur at appropriate times\n",
+    "- Checks that the final output aligns with the initial request\n",
+    "\n",
+    "These trace-level evaluations analyze the entire workflow execution, providing insights into system-wide performance rather than individual component behavior."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.core import Feedback\n",
+    "from trulens.core.feedback.selector import Selector\n",
+    "from trulens.providers.openai import OpenAI as OpenAIProvider\n",
+    "\n",
+    "llm_judge = OpenAIProvider(model_engine=\"gpt-4.1\")\n",
+    "\n",
+    "f_execution_efficiency = Feedback(\n",
+    "    llm_judge.execution_efficiency_with_cot_reasons,\n",
+    "    name=\"Execution Efficiency\",\n",
+    ").on({\n",
+    "    \"trace\": Selector(trace_level=True),\n",
+    "})\n",
+    "\n",
+    "f_logical_consistency = Feedback(\n",
+    "    llm_judge.logical_consistency_with_cot_reasons,\n",
+    "    name=\"Logical Consistency\",\n",
+    ").on({\n",
+    "    \"trace\": Selector(trace_level=True),\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Instrument the Workflow with TruLens\n",
+    "\n",
+    "Now we wrap our `AgentWorkflow` with `TruLlamaWorkflow` to enable comprehensive tracing:\n",
+    "\n",
+    "- **Automatic instrumentation**: Captures all agent calls and tool usage\n",
+    "- **Agent-level spans**: Each agent execution appears as a distinct trace segment  \n",
+    "- **Tool call tracking**: Individual tool invocations are traced with inputs/outputs\n",
+    "- **Evaluation integration**: Feedback functions run automatically on each trace\n",
+    "\n",
+    "The instrumentation happens transparently - no changes needed to your workflow code!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.apps.llamaindex import TruLlamaWorkflow\n",
+    "\n",
+    "tru_workflow_recorder = TruLlamaWorkflow(\n",
+    "    agent_workflow,\n",
+    "    app_name=\"AgentWorkflow\",\n",
+    "    app_version=\"base\",\n",
+    "    main_method=agent_workflow.run,\n",
+    "    feedbacks=[f_execution_efficiency, f_logical_consistency],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Execute and Trace the Workflow\n",
+    "\n",
+    "Now we run the workflow within a TruLens recording context. This will capture:\n",
+    "\n",
+    "- **Complete execution trace**: Every agent call, tool usage, and state change\n",
+    "- **Timing information**: How long each agent and tool takes to execute  \n",
+    "- **Input/output data**: What each agent receives and produces\n",
+    "- **Agent handoffs**: When and why control transfers between agents\n",
+    "- **Evaluation scores**: Automatic assessment of execution efficiency and logical consistency\n",
+    "\n",
+    "The workflow will execute normally while TruLens captures everything in the background."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with tru_workflow_recorder as recording:\n",
+    "    # For TruLens recording, we need to use the regular run method and await the result\n",
+    "    result = await agent_workflow.run(\n",
+    "        user_msg=(\n",
+    "            \"Write me a report on the history of the internet. \"\n",
+    "            \"Briefly describe the history of the internet, including the development of the internet, the development of the web, \"\n",
+    "            \"and the development of the internet in the 21st century.\"\n",
+    "        )\n",
+    "    )\n",
+    "    print(\"✅ Workflow completed successfully!\")\n",
+    "\n",
+    "from IPython.display import Markdown\n",
+    "\n",
+    "Markdown(result.response.blocks[0].text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Analyze Results in TruLens Dashboard\n",
+    "\n",
+    "Launch the TruLens dashboard to explore your multi-agent system's behavior:\n",
+    "\n",
+    "### What You'll See\n",
+    "- **Trace Timeline**: Visual representation of agent execution and handoffs\n",
+    "- **Agent Spans**: Individual agent executions with timing and context\n",
+    "- **Tool Call Details**: Each tool invocation with inputs, outputs, and duration\n",
+    "- **Evaluation Scores**: Execution efficiency and logical consistency metrics\n",
+    "- **Performance Insights**: Bottlenecks, optimization opportunities, and system health\n",
+    "\n",
+    "### Key Metrics to Monitor\n",
+    "- **Agent utilization**: Which agents are most/least active\n",
+    "- **Handoff patterns**: How control flows between agents\n",
+    "- **Tool effectiveness**: Which tools provide the most value\n",
+    "- **Execution bottlenecks**: Where the system spends the most time\n",
+    "\n",
+    "💡 **Tip**: Evaluations may take a few moments to compute. Refresh the dashboard to see updated results as they become available."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.dashboard import run_dashboard\n",
+    "\n",
+    "run_dashboard()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "trulens_test",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/apps/llamaindex/trulens/apps/llamaindex/tru_llama_workflow.py
+++ b/src/apps/llamaindex/trulens/apps/llamaindex/tru_llama_workflow.py
@@ -9,15 +9,19 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import functools
 import inspect
 import logging
 from typing import Any, Callable, ClassVar, Optional
 
+from opentelemetry.trace import get_current_span
 from pydantic import Field
 from trulens.core import app as core_app
 from trulens.core.otel.instrument import instrument_method
+from trulens.core.otel.utils import is_otel_tracing_enabled
 from trulens.core.session import TruSession
 from trulens.core.utils import pyschema as pyschema_utils
+from trulens.otel.semconv.constants import TRULENS_INSTRUMENT_WRAPPER_FLAG
 from trulens.otel.semconv.trace import SpanAttributes  # type: ignore
 
 logger = logging.getLogger(__name__)
@@ -155,7 +159,14 @@ class TruLlamaWorkflow(core_app.App):
 
     @classmethod
     def _ensure_workflows_instrumentation(cls) -> None:
+        """Ensure class-level instrumentation for workflow components."""
+        if cls._is_instrumented:
+            return
+
         cls._is_instrumented = True
+
+        # Set up FunctionAgent instrumentation at class level
+        cls._setup_function_agent_instrumentation()
 
     def __init__(
         self,
@@ -168,6 +179,9 @@ class TruLlamaWorkflow(core_app.App):
 
         # Store the original workflow
         self._original_workflow = app
+
+        # Also instrument any agents within the workflow
+        self._instrument_workflow_agents(app)
 
         # Wrap the workflow's run method to await completion
         import functools
@@ -196,7 +210,13 @@ class TruLlamaWorkflow(core_app.App):
         else:
             TruSession()
 
-            # Instrument only attributes that are instances of Step classes.
+        # Disable default tool instrumentation before setup to prevent duplicates
+        self._disable_default_tool_instrumentation()
+
+        # Set up custom instrumentation that excludes BaseTool methods to avoid duplicates
+        kwargs["instrument"] = self._create_custom_instrument()
+
+        # Instrument only attributes that are instances of Step classes.
         cls = type(app)
         for name, val in cls.__dict__.items():
             # Only instrument coroutine step methods: async def with 'ev' parameter
@@ -262,6 +282,765 @@ class TruLlamaWorkflow(core_app.App):
 
         super().__init__(**kwargs)
 
+    def _create_custom_instrument(self):
+        """Create a custom instrument that excludes BaseTool methods to avoid duplicate spans."""
+        try:
+            from trulens.apps.llamaindex.tru_llama import LlamaInstrument
+
+            # Import the tool classes we want to exclude
+            try:
+                from llama_index.tools.types import AsyncBaseTool
+                from llama_index.tools.types import BaseTool
+
+                # Get the default methods but filter out BaseTool methods
+                default_methods = LlamaInstrument.Default.METHODS
+                filtered_methods = []
+
+                for method in default_methods:
+                    # Skip BaseTool and AsyncBaseTool methods to avoid duplicates
+                    if hasattr(method, "cls") and (
+                        method.cls == BaseTool or method.cls == AsyncBaseTool
+                    ):
+                        continue
+                    filtered_methods.append(method)
+
+                # Create custom instrument with filtered methods
+                class CustomLlamaInstrument(LlamaInstrument):
+                    def __init__(self, *args, **kwargs):
+                        # Override the default methods to exclude BaseTool
+                        kwargs.setdefault("include_methods", filtered_methods)
+                        super().__init__(*args, **kwargs)
+
+                return CustomLlamaInstrument(app=self)
+
+            except ImportError:
+                return LlamaInstrument(app=self)
+
+        except ImportError:
+            return None
+
+    def _disable_default_tool_instrumentation(self):
+        """Disable default BaseTool instrumentation to prevent duplicates."""
+        try:
+            from llama_index.tools.types import AsyncBaseTool
+            from llama_index.tools.types import BaseTool
+            from trulens.otel.semconv.constants import (
+                TRULENS_INSTRUMENT_WRAPPER_FLAG,
+            )
+
+            # Mark BaseTool methods as already instrumented to prevent default instrumentation
+            tool_classes = [BaseTool]
+            try:
+                tool_classes.append(AsyncBaseTool)
+            except ImportError:
+                pass
+
+            for tool_class in tool_classes:
+                for method_name in ["__call__", "call", "acall"]:
+                    if hasattr(tool_class, method_name):
+                        method = getattr(tool_class, method_name)
+                        if not hasattr(method, TRULENS_INSTRUMENT_WRAPPER_FLAG):
+                            # Mark as instrumented to prevent default instrumentation
+                            setattr(
+                                method, TRULENS_INSTRUMENT_WRAPPER_FLAG, True
+                            )
+
+        except ImportError as e:
+            logger.debug(f"Could not disable default tool instrumentation: {e}")
+
+    @classmethod
+    def _update_span_name(cls, span_name: str) -> None:
+        """Update current span name if possible."""
+        try:
+            current_span = get_current_span()
+            if current_span and hasattr(current_span, "update_name"):
+                current_span.update_name(span_name)
+        except Exception as e:
+            logger.debug(f"Failed to update span name to {span_name}: {e}")
+
+    @classmethod
+    def _setup_function_agent_instrumentation(cls) -> None:
+        """Set up class-level instrumentation for FunctionAgent methods."""
+        logger.info(
+            "TruLlamaWorkflow._setup_function_agent_instrumentation called"
+        )
+        # Apply instrumentation when TruLlamaWorkflow is initialized
+        result = _setup_function_agent_instrumentation_on_demand()
+        logger.info(f"FunctionAgent instrumentation result: {result}")
+
+    def _instrument_workflow_agents(self, workflow: Any) -> None:
+        """Instrument individual agents within the workflow."""
+        logger.info(f"Instrumenting agents in workflow: {type(workflow)}")
+
+        # Debug: Show all attributes of the workflow
+        workflow_attrs = [
+            attr for attr in dir(workflow) if not attr.startswith("_")
+        ]
+        logger.info(f"Workflow attributes: {workflow_attrs}")
+
+        # Check if the workflow has agents
+        if hasattr(workflow, "agents") and workflow.agents:
+            logger.info(
+                f"Found {len(workflow.agents)} items in workflow.agents"
+            )
+
+            # Debug: Check what's actually in workflow.agents
+            for i, agent in enumerate(workflow.agents):
+                agent_type = type(agent).__name__
+                agent_module = type(agent).__module__
+                agent_name = getattr(agent, "name", "unnamed")
+                logger.info(
+                    f"Agent {i}: {agent_module}.{agent_type} - name: '{agent_name}' - value: {agent}"
+                )
+
+            # The agents list contains strings, not agent objects. Let's find the actual agents.
+
+            # Check for agent registry or mapping
+            agent_objects = []
+
+            # Search through all attributes for agent objects
+            for attr_name in dir(workflow):
+                if attr_name.startswith("_"):
+                    continue
+                try:
+                    attr_value = getattr(workflow, attr_name)
+                    # Check if it's a FunctionAgent or similar
+                    if hasattr(attr_value, "__class__"):
+                        class_name = attr_value.__class__.__name__
+                        if (
+                            "Agent" in class_name
+                            or "agent" in class_name.lower()
+                        ):
+                            agent_objects.append(attr_value)
+                        # Also check if it's a dict/list that might contain agents
+                        elif isinstance(attr_value, dict):
+                            for key, value in attr_value.items():
+                                if hasattr(value, "__class__") and (
+                                    "Agent" in value.__class__.__name__
+                                    or "agent"
+                                    in value.__class__.__name__.lower()
+                                ):
+                                    agent_objects.append(value)
+                        elif isinstance(attr_value, (list, tuple)):
+                            for i, item in enumerate(attr_value):
+                                if hasattr(item, "__class__") and (
+                                    "Agent" in item.__class__.__name__
+                                    or "agent"
+                                    in item.__class__.__name__.lower()
+                                ):
+                                    agent_objects.append(item)
+                except Exception:
+                    # Skip attributes that can't be accessed
+                    pass
+
+            # Also check private attributes that might contain agents
+            for attr_name in [
+                "_agent_registry",
+                "_agents",
+                "_agent_map",
+                "_agent_dict",
+                "_agent_instances",
+            ]:
+                if hasattr(workflow, attr_name):
+                    try:
+                        attr_value = getattr(workflow, attr_name)
+                        if isinstance(attr_value, dict):
+                            for key, value in attr_value.items():
+                                if hasattr(value, "__class__") and (
+                                    "Agent" in value.__class__.__name__
+                                    or "agent"
+                                    in value.__class__.__name__.lower()
+                                ):
+                                    agent_objects.append(value)
+                        elif isinstance(attr_value, (list, tuple)):
+                            for i, item in enumerate(attr_value):
+                                if hasattr(item, "__class__") and (
+                                    "Agent" in item.__class__.__name__
+                                    or "agent"
+                                    in item.__class__.__name__.lower()
+                                ):
+                                    agent_objects.append(item)
+                    except Exception:
+                        # Skip attributes that can't be accessed
+                        pass
+
+            # Instrument any agent objects we found
+            agent_names = []
+            for i, agent in enumerate(agent_objects):
+                agent_name = getattr(agent, "name", f"Agent_{i}")
+                agent_names.append(agent_name)
+                self._instrument_individual_agent(agent)
+                # Note: Tool child spans are now created within agent method instrumentation
+
+            if len(agent_names) < 3:
+                logger.warning(
+                    f"Expected 3 agents (ResearchAgent, WriteAgent, ReviewAgent) but only found {len(agent_names)}"
+                )
+
+        else:
+            logger.info(
+                "No agents found in workflow or workflow.agents is empty"
+            )
+
+        # Also check for other possible agent containers
+        for attr_name in [
+            "_agents",
+            "agent_list",
+            "nodes",
+            "agent_registry",
+            "_agent_registry",
+        ]:
+            if hasattr(workflow, attr_name):
+                attr_value = getattr(workflow, attr_name)
+                logger.info(
+                    f"Found potential agent container: {attr_name} = {attr_value}"
+                )
+
+    def _instrument_individual_agent(self, agent: Any) -> None:
+        """Instrument an individual agent's methods."""
+        agent_name = getattr(agent, "name", "UnknownAgent")
+        logger.info(f"Instrumenting agent: {agent_name} ({type(agent)})")
+
+        # Get agent tools for function name extraction
+        agent_tools = []
+        if hasattr(agent, "tools") and agent.tools:
+            agent_tools = agent.tools
+            tool_names = [
+                getattr(tool, "__name__", str(tool)) for tool in agent_tools
+            ]
+            logger.info(f"Agent {agent_name} tools: {tool_names}")
+
+        # Get all callable methods of the agent
+        methods = [
+            method
+            for method in dir(agent)
+            if not method.startswith("_") and callable(getattr(agent, method))
+        ]
+        logger.info(f"Agent {agent_name} methods: {methods}")
+
+        # Try to instrument common agent methods - focus on primary execution methods
+        # Note: Excluding 'handle_tool_call_results' as it's a post-processing method that creates redundant spans
+        methods_to_try = [
+            "run",
+            "arun",
+            "chat",
+            "achat",
+            "stream_chat",
+            "astream_chat",
+            "__call__",
+            "acall",
+            "run_agent_step",
+            "take_step",
+            "call_tool",
+            "aggregate_tool_results",
+        ]
+
+        for method_name in methods_to_try:
+            if hasattr(agent, method_name):
+                method = getattr(agent, method_name)
+                if callable(method):
+                    logger.info(f"Instrumenting {agent_name}.{method_name}")
+                    try:
+                        # For Pydantic models, we need to use a different approach
+                        # Instead of replacing the method, we'll monkey-patch the class
+                        original_method = method
+
+                        # Create the instrumented wrapper
+                        def create_instrumented_method(
+                            original_func, agent_name, method_name, agent_tools
+                        ):
+                            from trulens.core.otel.instrument import instrument
+
+                            def agent_attributes(
+                                ret, exception, *args, **kwargs
+                            ):
+                                """Extract attributes from agent method calls."""
+
+                                # Extract input message/query (skip self)
+                                input_msg = None
+                                if len(args) > 1:  # First arg is self
+                                    input_msg = args[1]
+                                elif "message" in kwargs:
+                                    input_msg = kwargs["message"]
+                                elif "query" in kwargs:
+                                    input_msg = kwargs["query"]
+                                elif "user_msg" in kwargs:
+                                    input_msg = kwargs["user_msg"]
+
+                                # Try to extract function/tool name from the response or context
+                                function_name = None
+
+                                # Check if return value has tool call information
+                                if hasattr(ret, "sources") and ret.sources:
+                                    # Check if any sources contain tool call information
+                                    for source in ret.sources:
+                                        if hasattr(source, "tool_name"):
+                                            function_name = source.tool_name
+                                            break
+                                        elif hasattr(
+                                            source, "metadata"
+                                        ) and isinstance(source.metadata, dict):
+                                            function_name = source.metadata.get(
+                                                "tool_name"
+                                            ) or source.metadata.get(
+                                                "function_name"
+                                            )
+                                            if function_name:
+                                                break
+
+                                # Check if return value has tool calls directly
+                                if (
+                                    not function_name
+                                    and hasattr(ret, "tool_calls")
+                                    and ret.tool_calls
+                                ):
+                                    if len(ret.tool_calls) > 0:
+                                        first_tool_call = ret.tool_calls[0]
+                                        if hasattr(
+                                            first_tool_call, "tool_name"
+                                        ):
+                                            function_name = (
+                                                first_tool_call.tool_name
+                                            )
+                                        elif hasattr(
+                                            first_tool_call, "function"
+                                        ) and hasattr(
+                                            first_tool_call.function, "name"
+                                        ):
+                                            function_name = (
+                                                first_tool_call.function.name
+                                            )
+
+                                # If we couldn't extract from response, try to infer from agent tools
+                                if not function_name and agent_tools:
+                                    # Try to get better tool names
+                                    def get_tool_name(tool):
+                                        # Try multiple ways to get a good tool name
+                                        if hasattr(
+                                            tool, "metadata"
+                                        ) and hasattr(tool.metadata, "name"):
+                                            return tool.metadata.name
+                                        elif hasattr(tool, "name"):
+                                            return tool.name
+                                        elif hasattr(tool, "_fn") and hasattr(
+                                            tool._fn, "__name__"
+                                        ):
+                                            return tool._fn.__name__
+                                        elif hasattr(tool, "__name__"):
+                                            return tool.__name__
+                                        else:
+                                            return f"tool_{id(tool) % 1000}"  # Use a short ID instead of full object repr
+
+                                    # For single tool agents, we can be confident about the function name
+                                    if len(agent_tools) == 1:
+                                        function_name = get_tool_name(
+                                            agent_tools[0]
+                                        )
+                                    else:
+                                        # Multiple tools - get clean names for all
+                                        tool_names = [
+                                            get_tool_name(tool)
+                                            for tool in agent_tools
+                                        ]
+                                        function_name = (
+                                            f"one_of[{','.join(tool_names)}]"
+                                        )
+
+                                # Create span name that includes tool information when available
+                                if (
+                                    function_name
+                                    and not function_name.startswith("one_of[")
+                                ):
+                                    span_name = f"{agent_name}.{function_name}"
+                                else:
+                                    span_name = agent_name
+
+                                self._update_span_name(span_name)
+
+                                # Serialize input and output
+                                input_ser = _to_json_safe(input_msg)
+                                output_ser = _to_json_safe(ret)
+                                exception_str = _safe_str(exception)
+
+                                attrs = {
+                                    SpanAttributes.WORKFLOW.AGENT_NAME: agent_name,
+                                    SpanAttributes.WORKFLOW.INPUT_EVENT: input_ser,
+                                    SpanAttributes.WORKFLOW.OUTPUT_EVENT: output_ser,
+                                    SpanAttributes.WORKFLOW.ERROR: exception_str,
+                                    # Also set generic call attributes for UI panels
+                                    SpanAttributes.CALL.RETURN: output_ser,
+                                }
+
+                                # Add function name if we found one
+                                if function_name:
+                                    attrs[
+                                        f"{SpanAttributes.CALL.KWARGS}.function_name"
+                                    ] = function_name
+
+                                # Add input to call kwargs for UI
+                                if input_msg is not None:
+                                    attrs[
+                                        f"{SpanAttributes.CALL.KWARGS}.message"
+                                    ] = input_ser
+
+                                return attrs
+
+                            # Apply the instrument decorator
+                            return instrument(
+                                span_type=SpanAttributes.SpanType.AGENT,
+                                attributes=agent_attributes,
+                            )(original_func)
+
+                        # Create the instrumented method
+                        instrumented_method = create_instrumented_method(
+                            original_method,
+                            agent_name,
+                            method_name,
+                            agent_tools,
+                        )
+
+                        # Try to replace the method on the instance
+                        if hasattr(agent, "__dict__"):
+                            # For regular objects
+                            agent.__dict__[method_name] = (
+                                instrumented_method.__get__(agent, type(agent))
+                            )
+                        else:
+                            # For Pydantic models, try to set the attribute directly
+                            object.__setattr__(
+                                agent,
+                                method_name,
+                                instrumented_method.__get__(agent, type(agent)),
+                            )
+
+                        logger.debug(
+                            f"Successfully wrapped {agent_name}.{method_name}"
+                        )
+                    except Exception as e:
+                        logger.debug(
+                            f"Instance-level instrumentation failed for {agent_name}.{method_name}: {e}"
+                        )
+
+                        # Try alternative approach: monkey-patch the class method
+                        try:
+                            agent_class = type(agent)
+                            if hasattr(agent_class, method_name):
+                                # Create attributes function for class-level instrumentation
+                                def create_class_attributes_func():
+                                    def class_agent_attributes(
+                                        ret, exception, *args, **kwargs
+                                    ):
+                                        # Extract agent name from self (first argument)
+                                        current_agent_name = (
+                                            getattr(
+                                                args[0], "name", "UnknownAgent"
+                                            )
+                                            if args
+                                            else "UnknownAgent"
+                                        )
+
+                                        # Extract input
+                                        input_msg = None
+                                        if len(args) > 1:
+                                            input_msg = args[1]
+                                        else:
+                                            input_msg = kwargs.get(
+                                                "message",
+                                                kwargs.get(
+                                                    "query",
+                                                    kwargs.get("user_msg"),
+                                                ),
+                                            )
+
+                                        # Try to extract function name from agent tools
+                                        function_name = None
+                                        if (
+                                            args
+                                            and hasattr(args[0], "tools")
+                                            and args[0].tools
+                                        ):
+                                            current_agent_tools = args[0].tools
+
+                                            # Try to get better tool names
+                                            def get_tool_name(tool):
+                                                if hasattr(
+                                                    tool, "metadata"
+                                                ) and hasattr(
+                                                    tool.metadata, "name"
+                                                ):
+                                                    return tool.metadata.name
+                                                elif hasattr(tool, "name"):
+                                                    return tool.name
+                                                elif hasattr(
+                                                    tool, "_fn"
+                                                ) and hasattr(
+                                                    tool._fn, "__name__"
+                                                ):
+                                                    return tool._fn.__name__
+                                                elif hasattr(tool, "__name__"):
+                                                    return tool.__name__
+                                                else:
+                                                    return f"tool_{id(tool) % 1000}"
+
+                                            if len(current_agent_tools) == 1:
+                                                function_name = get_tool_name(
+                                                    current_agent_tools[0]
+                                                )
+                                            else:
+                                                # Multiple tools - get clean names
+                                                tool_names = [
+                                                    get_tool_name(tool)
+                                                    for tool in current_agent_tools
+                                                ]
+                                                function_name = f"one_of[{','.join(tool_names)}]"
+
+                                        # Create span name that includes tool information when available
+                                        if (
+                                            function_name
+                                            and not function_name.startswith(
+                                                "one_of["
+                                            )
+                                        ):
+                                            span_name = f"{current_agent_name}.{function_name}"
+                                        else:
+                                            span_name = current_agent_name
+
+                                        TruLlamaWorkflow._update_span_name(
+                                            span_name
+                                        )
+
+                                        attrs = {
+                                            SpanAttributes.WORKFLOW.AGENT_NAME: current_agent_name,
+                                            SpanAttributes.WORKFLOW.INPUT_EVENT: _to_json_safe(
+                                                input_msg
+                                            ),
+                                            SpanAttributes.WORKFLOW.OUTPUT_EVENT: _to_json_safe(
+                                                ret
+                                            ),
+                                            SpanAttributes.WORKFLOW.ERROR: _safe_str(
+                                                exception
+                                            ),
+                                            SpanAttributes.CALL.RETURN: _to_json_safe(
+                                                ret
+                                            ),
+                                        }
+
+                                        # Add function name if we found one
+                                        if function_name:
+                                            attrs[
+                                                f"{SpanAttributes.CALL.KWARGS}.function_name"
+                                            ] = function_name
+
+                                        return attrs
+
+                                    return class_agent_attributes
+
+                                # Apply instrumentation at class level
+                                instrument_method(
+                                    cls=agent_class,
+                                    method_name=method_name,
+                                    span_type=SpanAttributes.SpanType.AGENT,
+                                    attributes=create_class_attributes_func(),
+                                )
+                        except Exception as e2:
+                            logger.debug(
+                                f"Class-level instrumentation also failed for {method_name}: {e2}"
+                            )
+
+    def _instrument_agent_tools(self, agent: Any) -> None:
+        """Instrument individual tools within an agent for better span naming."""
+        agent_name = getattr(agent, "name", "UnknownAgent")
+
+        if not hasattr(agent, "tools") or not agent.tools:
+            return
+
+        for i, tool in enumerate(agent.tools):
+            tool_name = getattr(tool, "__name__", f"tool_{i}")
+
+            # Try to get a better name for the tool
+            if hasattr(tool, "metadata") and hasattr(tool.metadata, "name"):
+                tool_name = tool.metadata.name
+            elif hasattr(tool, "name"):
+                tool_name = tool.name
+            elif hasattr(tool, "_fn") and hasattr(tool._fn, "__name__"):
+                tool_name = tool._fn.__name__
+            elif hasattr(tool, "__name__"):
+                tool_name = tool.__name__
+
+            # Instrument the tool's call methods
+            methods_to_instrument = ["__call__", "call", "acall"]
+
+            for method_name in methods_to_instrument:
+                if hasattr(tool, method_name):
+                    try:
+                        original_method = getattr(tool, method_name)
+                        if callable(original_method):
+                            # Create instrumented wrapper for tool
+                            def create_tool_wrapper(
+                                orig_method, t_name, m_name, a_name
+                            ):
+                                def tool_attributes(
+                                    ret, exception, *args, **kwargs
+                                ):
+                                    """Extract attributes from tool calls."""
+
+                                    # Extract input (skip self)
+                                    input_data = None
+                                    if len(args) > 1:
+                                        input_data = args[1]
+                                    elif len(args) == 1 and not hasattr(
+                                        args[0], "__class__"
+                                    ):
+                                        # If first arg is not self (i.e., not an object)
+                                        input_data = args[0]
+                                    elif kwargs:
+                                        input_data = kwargs
+
+                                    # Use just the tool name since this will be a child span under the agent
+                                    span_name = t_name
+                                    self._update_span_name(span_name)
+
+                                    return {
+                                        SpanAttributes.WORKFLOW.AGENT_NAME: a_name,
+                                        SpanAttributes.WORKFLOW.INPUT_EVENT: _to_json_safe(
+                                            input_data
+                                        ),
+                                        SpanAttributes.WORKFLOW.OUTPUT_EVENT: _to_json_safe(
+                                            ret
+                                        ),
+                                        SpanAttributes.WORKFLOW.ERROR: _safe_str(
+                                            exception
+                                        ),
+                                        SpanAttributes.CALL.RETURN: _to_json_safe(
+                                            ret
+                                        ),
+                                        f"{SpanAttributes.CALL.KWARGS}.function_name": t_name,
+                                    }
+
+                                # Create a wrapper that ensures proper parent-child relationship
+                                @functools.wraps(orig_method)
+                                def tool_wrapper(*args, **kwargs):
+                                    from opentelemetry import trace
+                                    from trulens.experimental.otel_tracing.core.session import (
+                                        TRULENS_SERVICE_NAME,
+                                    )
+
+                                    # Get the current span (should be the agent span)
+                                    current_span = trace.get_current_span()
+                                    if (
+                                        current_span
+                                        and current_span.is_recording()
+                                    ):
+                                        # Create a child span explicitly
+                                        tracer = trace.get_tracer_provider().get_tracer(
+                                            TRULENS_SERVICE_NAME
+                                        )
+                                        with tracer.start_as_current_span(
+                                            t_name
+                                        ) as tool_span:
+                                            # Set tool span attributes
+                                            tool_span.set_attribute(
+                                                SpanAttributes.SPAN_TYPE,
+                                                SpanAttributes.SpanType.TOOL,
+                                            )
+                                            tool_span.set_attribute(
+                                                SpanAttributes.WORKFLOW.AGENT_NAME,
+                                                a_name,
+                                            )
+                                            tool_span.set_attribute(
+                                                f"{SpanAttributes.CALL.KWARGS}.function_name",
+                                                t_name,
+                                            )
+
+                                            try:
+                                                result = orig_method(
+                                                    *args, **kwargs
+                                                )
+                                                tool_span.set_attribute(
+                                                    SpanAttributes.CALL.RETURN,
+                                                    _to_json_safe(result),
+                                                )
+                                                return result
+                                            except Exception as e:
+                                                tool_span.set_attribute(
+                                                    SpanAttributes.WORKFLOW.ERROR,
+                                                    _safe_str(e),
+                                                )
+                                                raise
+                                    else:
+                                        # Fallback to original method if no active span
+                                        return orig_method(*args, **kwargs)
+
+                                return tool_wrapper
+
+                            # Create and apply the wrapper
+                            instrumented_method = create_tool_wrapper(
+                                original_method,
+                                tool_name,
+                                method_name,
+                                agent_name,
+                            )
+
+                            # Replace the method
+                            setattr(tool, method_name, instrumented_method)
+
+                    except Exception as e:
+                        # Log at debug level since these failures are often expected
+                        logger.debug(
+                            f"Could not instrument {tool_name}.{method_name}: {e}"
+                        )
+
+    def _create_agent_method_wrapper(
+        self, agent: Any, method_name: str, original_method: Callable
+    ) -> Callable:
+        """Create a wrapper for an agent method that adds tracing."""
+        from trulens.core.otel.instrument import instrument
+
+        agent_name = getattr(agent, "name", "UnknownAgent")
+
+        def agent_attributes(ret, exception, *args, **kwargs):
+            """Extract attributes from agent method calls."""
+            # Extract input message/query
+            input_msg = None
+            if len(args) > 0:  # First arg after self
+                input_msg = args[0]
+            elif "message" in kwargs:
+                input_msg = kwargs["message"]
+            elif "query" in kwargs:
+                input_msg = kwargs["query"]
+
+            # Update span name to include agent name
+            span_name = f"{agent_name}.{method_name}"
+            self._update_span_name(span_name)
+
+            # Serialize input and output
+            input_ser = _to_json_safe(input_msg)
+            output_ser = _to_json_safe(ret)
+            exception_str = _safe_str(exception)
+
+            attrs = {
+                SpanAttributes.WORKFLOW.AGENT_NAME: agent_name,
+                SpanAttributes.WORKFLOW.INPUT_EVENT: input_ser,
+                SpanAttributes.WORKFLOW.OUTPUT_EVENT: output_ser,
+                SpanAttributes.WORKFLOW.ERROR: exception_str,
+                # Also set generic call attributes for UI panels
+                SpanAttributes.CALL.RETURN: output_ser,
+            }
+
+            # Add input to call kwargs for UI
+            if input_msg is not None:
+                attrs[f"{SpanAttributes.CALL.KWARGS}.message"] = input_ser
+
+            return attrs
+
+        # Apply the instrument decorator
+        instrumented_method = instrument(
+            span_type=SpanAttributes.SpanType.AGENT,
+            attributes=agent_attributes,
+        )(original_method)
+
+        return instrumented_method
+
 
 TruLlamaWorkflow.model_rebuild()
 
@@ -317,3 +1096,127 @@ def _main_input_override(self, func: Callable, sig, bindings):  # type: ignore[o
 
 
 TruLlamaWorkflow.main_input = _main_input_override  # type: ignore[assignment]
+
+
+# Apply FunctionAgent instrumentation when TruLlamaWorkflow is used
+# This ensures FunctionAgent methods are instrumented when the workflow is actually used
+def _setup_function_agent_instrumentation_on_demand():
+    """Set up FunctionAgent instrumentation when needed."""
+    if not is_otel_tracing_enabled():
+        logger.debug("OTEL not enabled, skipping FunctionAgent instrumentation")
+        return
+
+    try:
+        # Try to import FunctionAgent
+        from llama_index.core.agent.workflow import FunctionAgent
+
+        logger.info(f"Successfully imported FunctionAgent: {FunctionAgent}")
+
+        # Debug: Check what methods FunctionAgent actually has
+        all_methods = [
+            method
+            for method in dir(FunctionAgent)
+            if not method.startswith("_")
+        ]
+        logger.info(f"FunctionAgent available methods: {all_methods}")
+
+    except ImportError as e:
+        logger.debug(
+            f"FunctionAgent not available, skipping instrumentation: {e}"
+        )
+        return
+
+    # Check if FunctionAgent methods are already instrumented
+    # Let's start with the most likely methods that exist
+    methods_to_instrument = [
+        "run",
+        "arun",
+        "chat",
+        "achat",
+        "stream_chat",
+        "astream_chat",
+        "__call__",
+        "acall",
+    ]
+
+    instrumented_any = False
+    for method_name in methods_to_instrument:
+        if hasattr(FunctionAgent, method_name):
+            method = getattr(FunctionAgent, method_name)
+            if hasattr(method, TRULENS_INSTRUMENT_WRAPPER_FLAG):
+                logger.debug(
+                    f"FunctionAgent.{method_name} already instrumented"
+                )
+                continue
+
+            logger.info(
+                f"Applying instrumentation to FunctionAgent.{method_name}"
+            )
+
+            # Create attributes function for FunctionAgent calls
+            def create_function_agent_attributes(method_name):
+                def function_agent_attributes(ret, exception, *args, **kwargs):
+                    """Extract attributes from FunctionAgent method calls."""
+                    # Get the agent instance (self)
+                    agent_instance = None
+                    if args and hasattr(args[0], "name"):
+                        agent_instance = args[0]
+
+                    # Extract input message/query
+                    input_msg = None
+                    if len(args) > 1:
+                        input_msg = args[1]
+                    elif "message" in kwargs:
+                        input_msg = kwargs["message"]
+                    elif "query" in kwargs:
+                        input_msg = kwargs["query"]
+
+                    # Extract agent name and update span name
+                    agent_name = None
+                    if agent_instance and hasattr(agent_instance, "name"):
+                        agent_name = agent_instance.name
+                        # Update span name to include agent name
+                        span_name = f"{agent_name}.{method_name}"
+                        TruLlamaWorkflow._update_span_name(span_name)
+
+                    # Serialize input and output
+                    input_ser = _to_json_safe(input_msg)
+                    output_ser = _to_json_safe(ret)
+                    exception_str = _safe_str(exception)
+
+                    attrs = {
+                        SpanAttributes.WORKFLOW.AGENT_NAME: agent_name,
+                        SpanAttributes.WORKFLOW.INPUT_EVENT: input_ser,
+                        SpanAttributes.WORKFLOW.OUTPUT_EVENT: output_ser,
+                        SpanAttributes.WORKFLOW.ERROR: exception_str,
+                        # Also set generic call attributes for UI panels
+                        SpanAttributes.CALL.RETURN: output_ser,
+                    }
+
+                    # Add input to call kwargs for UI
+                    if input_msg is not None:
+                        attrs[f"{SpanAttributes.CALL.KWARGS}.message"] = (
+                            input_ser
+                        )
+
+                    return attrs
+
+                return function_agent_attributes
+
+            try:
+                instrument_method(
+                    cls=FunctionAgent,
+                    method_name=method_name,
+                    span_type=SpanAttributes.SpanType.AGENT,
+                    attributes=create_function_agent_attributes(method_name),
+                )
+                instrumented_any = True
+            except Exception as e:
+                logger.debug(
+                    f"Could not instrument FunctionAgent.{method_name}: {e}"
+                )
+
+    if instrumented_any:
+        logger.info("Successfully instrumented FunctionAgent methods")
+
+    return instrumented_any

--- a/src/otel/semconv/trulens/otel/semconv/trace.py
+++ b/src/otel/semconv/trulens/otel/semconv/trace.py
@@ -100,6 +100,12 @@ class SpanAttributes:
         WORKFLOW_STEP = "workflow_step"
         """A workflow step execution."""
 
+        AGENT = "agent"
+        """An agent execution."""
+
+        TOOL = "tool"
+        """A tool/function call execution."""
+
         RERANKER = "reranking"
         """A reranking operation."""
 
@@ -333,6 +339,9 @@ class SpanAttributes:
 
         ERROR = base + ".error"
         """Error raised during workflow execution."""
+
+        AGENT_NAME = base + ".agent_name"
+        """Name of the agent executing in the workflow."""
 
     class RERANKER:
         """A reranking operation."""


### PR DESCRIPTION
# Description

- Agent-Level Span Instrumentation: Added comprehensive tracing for FunctionAgent instances within AgentWorkflow, capturing each agent execution as distinct spans with meaningful names (e.g., ResearchAgent.search_web, WriteAgent.write_report)
- Notebook showing how to trace + evaluate a LlamaIndex workflow agent

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
