### PR TITLE
Convert `execute_query` to return `pd.DataFrame` instead of `List[Row]`.

### DIFF
--- a/src/connectors/snowflake/trulens/connectors/snowflake/dao/external_agent.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/dao/external_agent.py
@@ -121,8 +121,7 @@ class ExternalAgentDao:
         """Retrieve a list of all External Agents."""
         query = "SHOW EXTERNAL AGENTS;"
 
-        rows = execute_query(self.session, query)
-        result_df = pandas.DataFrame([row.as_dict() for row in rows])
+        result_df = execute_query(self.session, query)
 
         logger.info("Retrieved list of External Agents.")
         return result_df
@@ -143,8 +142,7 @@ class ExternalAgentDao:
         resolved_name = name.upper()
         query = f"""SHOW VERSIONS IN EXTERNAL AGENT "{resolved_name}";"""
 
-        rows = execute_query(self.session, query)
-        result_df = pandas.DataFrame([row.as_dict() for row in rows])
+        result_df = execute_query(self.session, query)
 
         logger.info(f"Retrieved versions for External Agent {resolved_name}.")
 

--- a/src/connectors/snowflake/trulens/connectors/snowflake/dao/run.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/dao/run.py
@@ -197,8 +197,8 @@ class RunDao:
             query,
             parameters=(req_payload_json,),
         )
-
-        return result_df
+        # Assuming the first row contains our JSON result.
+        return result_df.iloc[:1]
 
     def list_all_runs(self, object_name: str, object_type: str) -> pd.DataFrame:
         """

--- a/src/connectors/snowflake/trulens/connectors/snowflake/dao/run.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/dao/run.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 from snowflake.snowpark import Session
-from snowflake.snowpark.row import Row
 from trulens.connectors.snowflake.dao.enums import SourceType
 from trulens.connectors.snowflake.dao.sql_utils import (
     clean_up_snowflake_identifier,
@@ -193,17 +192,13 @@ class RunDao:
         logger.debug(
             f"Executing query: {query} with parameters {req_payload_json}"
         )
-        rows: List[Row] = execute_query(
+        result_df = execute_query(
             self.session,
             query,
             parameters=(req_payload_json,),
         )
 
-        if not rows:
-            return pd.DataFrame()
-        else:
-            # Assuming the first row contains our JSON result.
-            return pd.DataFrame([rows[0].as_dict()])
+        return result_df
 
     def list_all_runs(self, object_name: str, object_type: str) -> pd.DataFrame:
         """
@@ -226,13 +221,13 @@ class RunDao:
             f"Executing query: {query} with parameters {req_payload_json}"
         )
 
-        rows: List[Row] = execute_query(
+        result_df = execute_query(
             self.session,
             query,
             parameters=(req_payload_json,),
         )
 
-        return pd.DataFrame([rows[0].as_dict()])
+        return result_df
 
     def _update_run(
         self,

--- a/src/connectors/snowflake/trulens/connectors/snowflake/dao/sql_utils.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/dao/sql_utils.py
@@ -1,7 +1,7 @@
 import logging
-from typing import List, Optional
+from typing import Optional
 
-from snowflake.snowpark import Row
+import pandas as pd
 from snowflake.snowpark import Session
 
 logger = logging.getLogger(__name__)
@@ -47,12 +47,12 @@ def execute_query(
     session: Session,
     query: str,
     parameters: Optional[tuple] = None,
-) -> List[Row]:
+) -> pd.DataFrame:
     """
     Executes a query with optional parameters with qmark parameter binding (if applicable).
     """
     try:
-        return session.sql(query, params=parameters).collect()
+        return session.sql(query, params=parameters).to_pandas()
     except Exception as e:
         logger.exception(
             f"Error executing query: {query}\nParameters: {parameters}\nError: {e}"

--- a/src/connectors/snowflake/trulens/connectors/snowflake/dao/sql_utils.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/dao/sql_utils.py
@@ -52,7 +52,9 @@ def execute_query(
     Executes a query with optional parameters with qmark parameter binding (if applicable).
     """
     try:
-        return session.sql(query, params=parameters).to_pandas()
+        df = session.sql(query, params=parameters).to_pandas()
+        df.columns = [clean_up_snowflake_identifier(col) for col in df.columns]
+        return df
     except Exception as e:
         logger.exception(
             f"Error executing query: {query}\nParameters: {parameters}\nError: {e}"

--- a/tests/unit/test_snowflake_run_dao.py
+++ b/tests/unit/test_snowflake_run_dao.py
@@ -14,15 +14,6 @@ except Exception:
     RunDao = None
 
 
-# DummyRow simulates a Snowflake Row with an as_dict() method.
-class DummyRow:
-    def __init__(self, d: dict):
-        self._d = d
-
-    def as_dict(self):
-        return self._d
-
-
 @pytest.mark.snowflake
 class TestRunDao(unittest.TestCase):
     def setUp(self):
@@ -97,8 +88,8 @@ class TestRunDao(unittest.TestCase):
 
     @patch("trulens.connectors.snowflake.dao.run.execute_query")
     def test_get_run_no_result(self, mock_execute_query):
-        # Simulate that get_run returns an empty list (no run exists).
-        mock_execute_query.return_value = []
+        # Simulate that get_run returns an empty DataFrame (no run exists).
+        mock_execute_query.return_value = pd.DataFrame()
         result_df = self.dao.get_run(
             run_name="nonexistent_run",
             object_name="MY_AGENT",
@@ -108,9 +99,10 @@ class TestRunDao(unittest.TestCase):
 
     @patch("trulens.connectors.snowflake.dao.run.execute_query")
     def test_get_run_with_result(self, mock_execute_query):
-        # Simulate that get_run returns a single row.
-        dummy = DummyRow({"run_name": "my_run", "run_status": "ACTIVE"})
-        mock_execute_query.return_value = [dummy]
+        # Simulate that get_run returns a DataFrame with a single row.
+        mock_execute_query.return_value = pd.DataFrame([
+            {"run_name": "my_run", "run_status": "ACTIVE"}
+        ])
         result_df = self.dao.get_run(
             run_name="my_run",
             object_name="MY_AGENT",


### PR DESCRIPTION
# Description
Convert `execute_query` to return `pd.DataFrame` instead of `List[Row]`.

This way if the result is empty we can still manage to get a column (it'd still be empty). I ran into this issue when there were no apps.

## Other details good to know for developers

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Convert `execute_query` to return `pd.DataFrame` instead of `List[Row]`, updating affected methods and tests accordingly.
> 
>   - **Behavior**:
>     - `execute_query` in `sql_utils.py` now returns `pd.DataFrame` instead of `List[Row]`.
>     - Methods in `external_agent.py` and `run.py` updated to handle `pd.DataFrame` directly.
>     - Handles empty query results by returning an empty DataFrame.
>   - **Tests**:
>     - Updated tests in `test_snowflake_external_agent_dao.py` and `test_snowflake_run_dao.py` to mock `execute_query` returning `pd.DataFrame`.
>     - Removed `DummyRow` class from tests as it's no longer needed.
>   - **Misc**:
>     - Removed unused imports related to `Row` in `run.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for cdafb5ae89e96f492ecc0fc0989ddaba69cf47a8. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->