### PR TITLE
Remove noisy log msg 

### DIFF
--- a/src/core/trulens/core/utils/python.py
+++ b/src/core/trulens/core/utils/python.py
@@ -460,11 +460,6 @@ def task_factory_with_stack(loop, coro, *args, **kwargs) -> asyncio.Task:
     stack.
     """
 
-    if "context" in kwargs:
-        logger.debug(
-            "Context is being overwritten, TruLens may not be able to record traces."
-        )
-
     parent_task = asyncio.current_task(loop=loop)
     task = asyncio.tasks.Task(coro=coro, loop=loop, *args, **kwargs)
 


### PR DESCRIPTION
# Description

Given OTel is enabled by default, this logger msg is not providing much value anymore AFAICS.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unnecessary debug log message in `task_factory_with_stack` in `python.py` due to default OTel enablement.
> 
>   - **Logging**:
>     - Remove debug log message in `task_factory_with_stack` in `python.py` that warned about context overwriting, as OTel is now enabled by default.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 7750a901f0bd07aa6e819d2170f62aa3136bc9e0. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->