### PR TITLE
[SNOW-2655386] [AI Observability] - Context Relevance and Groundedness Not Computing for Virtual App

### DIFF
--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -903,7 +903,6 @@ class Run(BaseModel):
         # Define attributes that should be treated as arrays based on semantic conventions
         array_attributes = {
             SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS,
-            SpanAttributes.SPAN_GROUPS,
             SpanAttributes.GRAPH_NODE.NODES_EXECUTED,
             SpanAttributes.RERANKER.INPUT_CONTEXT_TEXTS,
             SpanAttributes.RERANKER.INPUT_CONTEXT_SCORES,
@@ -928,7 +927,6 @@ class Run(BaseModel):
         # Attribute names that suggest array content
         array_attribute_names = {
             "retrieved_contexts",
-            "span_groups",
             "nodes_executed",
             "input_context_texts",
             "input_context_scores",

--- a/tests/unit/test_virtual_run.py
+++ b/tests/unit/test_virtual_run.py
@@ -145,3 +145,120 @@ class TestVirtualRunMethods(OtelTestCase):
 
         # Verify OtelRecordingContext was called
         self.assertTrue(mock_otel_context.called)
+
+    def test_should_process_as_array(self):
+        """Test array attribute detection by constant"""
+        mock_app = MagicMock()
+        run = Run(
+            run_dao=MagicMock(),
+            app=mock_app,
+            main_method_name="test",
+            tru_session=MagicMock(),
+            object_name="TEST",
+            object_type="EXTERNAL AGENT",
+            object_version="1.0",
+            run_name="test",
+            run_metadata=Run.RunMetadata(),
+            source_info=Run.SourceInfo(
+                name="test", column_spec={}, source_type="TABLE"
+            ),
+        )
+
+        # Test array attributes
+        self.assertTrue(
+            run._should_process_as_array(
+                SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS
+            )
+        )
+        self.assertTrue(
+            run._should_process_as_array(
+                SpanAttributes.GRAPH_NODE.NODES_EXECUTED
+            )
+        )
+        self.assertTrue(
+            run._should_process_as_array(
+                SpanAttributes.RERANKER.INPUT_CONTEXT_TEXTS
+            )
+        )
+
+        # Test non-array attributes
+        self.assertFalse(
+            run._should_process_as_array(SpanAttributes.RETRIEVAL.QUERY_TEXT)
+        )
+        self.assertFalse(
+            run._should_process_as_array(SpanAttributes.RECORD_ROOT.INPUT)
+        )
+
+    def test_should_process_as_array_by_name(self):
+        """Test array attribute detection by name"""
+        mock_app = MagicMock()
+        run = Run(
+            run_dao=MagicMock(),
+            app=mock_app,
+            main_method_name="test",
+            tru_session=MagicMock(),
+            object_name="TEST",
+            object_type="EXTERNAL AGENT",
+            object_version="1.0",
+            run_name="test",
+            run_metadata=Run.RunMetadata(),
+            source_info=Run.SourceInfo(
+                name="test", column_spec={}, source_type="TABLE"
+            ),
+        )
+
+        # Test array attribute names
+        self.assertTrue(
+            run._should_process_as_array_by_name("retrieved_contexts")
+        )
+        self.assertTrue(run._should_process_as_array_by_name("nodes_executed"))
+        self.assertTrue(
+            run._should_process_as_array_by_name("input_context_texts")
+        )
+
+        # Test non-array attribute names
+        self.assertFalse(run._should_process_as_array_by_name("query_text"))
+        self.assertFalse(run._should_process_as_array_by_name("input"))
+        self.assertFalse(run._should_process_as_array_by_name("output"))
+
+    def test_process_array_attribute(self):
+        """Test array attribute processing with various inputs"""
+        mock_app = MagicMock()
+        run = Run(
+            run_dao=MagicMock(),
+            app=mock_app,
+            main_method_name="test",
+            tru_session=MagicMock(),
+            object_name="TEST",
+            object_type="EXTERNAL AGENT",
+            object_version="1.0",
+            run_name="test",
+            run_metadata=Run.RunMetadata(),
+            source_info=Run.SourceInfo(
+                name="test", column_spec={}, source_type="TABLE"
+            ),
+        )
+
+        # Test comma-separated string
+        result = run._process_array_attribute("Tokyo, capital city, Japan")
+        self.assertEqual(result, ["Tokyo", "capital city", "Japan"])
+
+        # Test JSON array string
+        result = run._process_array_attribute('["doc1", "doc2", "doc3"]')
+        self.assertEqual(result, ["doc1", "doc2", "doc3"])
+
+        # Test already a list
+        result = run._process_array_attribute(["item1", "item2"])
+        self.assertEqual(result, ["item1", "item2"])
+
+        # Test empty/None values
+        self.assertEqual(run._process_array_attribute(""), [])
+        self.assertEqual(run._process_array_attribute(None), [])
+
+        # Test single value
+        result = run._process_array_attribute("single_item")
+        self.assertEqual(result, ["single_item"])
+
+        # Test whitespace handling
+        result = run._process_array_attribute("  item1  ,  item2  ")
+        self.assertEqual(result, ["item1", "item2"])


### PR DESCRIPTION
# Description
JIRA: https://snowflakecomputing.atlassian.net/browse/SNOW-2655386

# Fix for Array Span Attributes Issue

## Problem
Several span attributes that should be arrays were being set as single strings instead of arrays when creating virtual spans. This caused issues with downstream processing that expected array formats.

**Example of the problem:**
```
Set retrieval attribute ai.observability.retrieval.retrieved_contexts = Tokyo, capital city, Japan, Honshu island
```

**Current span attribute emitted:**
```json
"ai.observability.retrieval.retrieved_contexts": "Tokyo, capital city, Japan, Honshu island"
```

**Expected format:**
```json
"ai.observability.retrieval.retrieved_contexts": [
    "Tokyo",
    "capital city",
    "Japan",
    "Honshu island"
]
```

## Root Cause
In the `_set_span_attributes_from_data` method in `src/core/trulens/core/run.py`, all attribute values were being converted to strings using `str(value)`, which converted arrays to comma-separated strings.

## Solution
1. **Generic Array Detection**: Created `_should_process_as_array()` method that identifies span attributes that should be arrays based on the semantic conventions in `trace.py`.

2. **Fallback Name-Based Detection**: Added `_should_process_as_array_by_name()` for cases where we don't have the constant but can infer from the attribute name.

3. **Generic Array Processing**: Created `_process_array_attribute()` method that handles multiple input formats:
   - **Comma-separated strings**: `"Tokyo, capital city, Japan"` → `["Tokyo", "capital city", "Japan"]`
   - **JSON array strings**: `'["Tokyo", "capital city", "Japan"]'` → `["Tokyo", "capital city", "Japan"]`
   - **Already arrays**: `["Tokyo", "capital city", "Japan"]` → `["Tokyo", "capital city", "Japan"]`
   - **Empty/None values**: `""` or `None` → `[]`
   - **Single values**: `"Tokyo"` → `["Tokyo"]`


## Dataset table handling
If we have db schema with `VARCHAR` columns for retrieved contexts, SDK run will automatically parse comma-separated strings into arrays for all supported array attributes.

The fix is backward compatible and doesn't require any database changes. You can continue using:
- Comma-separated strings: `"Tokyo, capital city, Japan"`
- JSON arrays: `'["Tokyo", "capital city", "Japan"]'`
- Mixed formats in the same dataset

## Future Extensibility
To add support for new array OTel span attributes in the future:

1. **Add the constant** to the `array_attributes` set in `_should_process_as_array()`
2. **Add the name** to the `array_attribute_names` set in `_should_process_as_array_by_name()`




## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
