### PR TITLE
Add force_flush() at the end of client-side custom metric computation 

### DIFF
--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -1223,33 +1223,36 @@ class Run(BaseModel):
             return
 
         # Compute each client-side metric
-        for metric_config in metric_configs:
-            try:
-                logger.info(
-                    f"Computing client-side metric: {metric_config.metric_name}"
-                )
+        try:
+            for metric_config in metric_configs:
+                try:
+                    logger.info(
+                        f"Computing client-side metric: {metric_config.metric_name}"
+                    )
 
-                # Create feedback definition from the metric config
-                feedback = metric_config.create_feedback_definition()
+                    # Create feedback definition from the metric config
+                    feedback = metric_config.create_feedback_definition()
 
-                compute_feedback_by_span_group(
-                    events=events,
-                    feedback=feedback,
-                    raise_error_on_no_feedbacks_computed=False,
-                    selectors=feedback.selectors,
-                )
-                logger.info(
-                    f"Successfully computed client-side metric: {metric_config.metric_name}"
-                )
-            except Exception as e:
-                logger.error(
-                    f"Error computing client-side metric {metric_config.metric_name}: {e}"
-                )
-                raise
-        self.tru_session.force_flush()
-        logger.debug(
-            "Flushed OTel eval spans to event table to ensure all spans are ingested before main process exits"
-        )
+                    compute_feedback_by_span_group(
+                        events=events,
+                        feedback=feedback,
+                        raise_error_on_no_feedbacks_computed=False,
+                        selectors=feedback.selectors,
+                    )
+                    logger.info(
+                        f"Successfully computed client-side metric: {metric_config.metric_name}"
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"Error computing client-side metric {metric_config.metric_name}: {e}"
+                    )
+                    raise
+        finally:
+            self.tru_session.force_flush()
+
+            logger.debug(
+                "Flushed OTel eval spans to event table to ensure all spans are ingested before main process exits"
+            )
 
     def _get_events_for_client_metrics(self) -> pd.DataFrame:
         """Get events for client-side metric computation using the appropriate method."""


### PR DESCRIPTION
# Description

We need to synchronize (switch to main thread) using `force_flush` so that all eval spans can be guaranteed to land in event table before the process exits, such as in the case of the app being run in a python script. 

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `force_flush()` at the end of client-side metric computation in `run.py` to ensure all spans are ingested before process exit.
> 
>   - **Behavior**:
>     - Adds `force_flush()` at the end of `_compute_client_side_metrics_from_configs` in `run.py` to ensure all spans are ingested before process exit.
>     - Changes logging level from `info` to `debug` for span flushing messages.
>   - **Logging**:
>     - Updates log message to "Flushed OTel eval spans to event table to ensure all spans are ingested before main process exits".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for e6567d8c3d7694814c6d9b65491ad2be0a1cdbff. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->