### PR TITLE
Check other "run" attributes for the account level event table.

### DIFF
--- a/src/connectors/snowflake/trulens/connectors/snowflake/snowflake_event_table_db.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/snowflake_event_table_db.py
@@ -154,7 +154,7 @@ class SnowflakeEventTableDB(core_db.DB):
         if run_name:
             run_name_str = f"'{run_name}'"
             where_clauses.append(
-                f'RECORD_ATTRIBUTES:"ai.observability.run.name" = {run_name_str}'
+                f'RECORD_ATTRIBUTES:"ai.observability.run.name" = {run_name_str} OR RECORD_ATTRIBUTES:"snow.ai.observability.run.name" = {run_name_str}'
             )
         if record_ids:
             record_ids_str = ", ".join([f"'{curr}'" for curr in record_ids])


### PR DESCRIPTION
# Description
Check other "run" attributes for the account level event table.

## Other details good to know for developers


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `_get_events` in `snowflake_event_table_db.py` to check additional `run.name` attribute for event filtering.
> 
>   - **Behavior**:
>     - Update `_get_events` in `snowflake_event_table_db.py` to check both `ai.observability.run.name` and `snow.ai.observability.run.name` in `RECORD_ATTRIBUTES` for filtering by `run_name`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for ba2bb4d9014d9c3ef168b1a5a674793991b9ae5e. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->