### PR TITLE
address pydantic breaking change by updating jsonify util to read from class mapping

### DIFF
--- a/src/core/trulens/core/utils/json.py
+++ b/src/core/trulens/core/utils/json.py
@@ -340,8 +340,6 @@ def jsonify(
             computed_fields_map = getattr(
                 cls, "__pydantic_computed_fields__", {}
             )
-        if not isinstance(computed_fields_map, dict):
-            computed_fields_map = {}
 
         for k in computed_fields_map.keys():
             if recur_key(k):


### PR DESCRIPTION
# Description

address pydantic breaking change by updating jsonify util to read from class mapping

To address https://github.com/truera/trulens/issues/2294

## Other details good to know for developers
Pydantic changed this in 2.10

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `jsonify` in `json.py` to handle Pydantic 2.10 breaking change by reading computed fields from class mapping.
> 
>   - **Behavior**:
>     - Update `jsonify` in `json.py` to handle Pydantic 2.10 breaking change by reading computed fields from class mapping instead of instance.
>     - Falls back to `__pydantic_computed_fields__` if `model_computed_fields` is not a dict.
>     - Ensures compatibility with Pydantic 2.10 by handling non-dict public attributes for computed fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 0c9c8d7ad89bef051135f2ce15251c414a1d131e. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->