### PR TITLE
Keep host during verification. This also will have downstream effects in that it will use that to build the SQLAlchemy URL.

### DIFF
--- a/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
@@ -187,7 +187,10 @@ class SnowflakeConnector(DBConnector):
             "warehouse": snowpark_session.get_current_warehouse(),
             "role": snowpark_session.get_current_role(),
         }
-
+        if "host" in connection_parameters:
+            snowpark_session_connection_parameters["host"] = (
+                connection_parameters["host"]
+            )
         for k, v in snowpark_session_connection_parameters.items():
             if v and v.startswith('"') and v.endswith('"'):
                 snowpark_session_connection_parameters[k] = v.strip('"')


### PR DESCRIPTION
# Description
Keep host during verification. This also will have downstream effects in that it will use that to build the SQLAlchemy URL.

## Other details good to know for developers

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Retain `host` during Snowpark session verification in `connector.py`, affecting SQLAlchemy URL construction.
> 
>   - **Behavior**:
>     - Retain `host` in `_validate_snowpark_session_with_connection_parameters` in `connector.py` if present in `connection_parameters`.
>     - Affects SQLAlchemy URL construction by including `host` in connection parameters.
>   - **Misc**:
>     - No changes to existing tests or documentation noted.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for b31f4af98147541c9dc8c2fd37e2abc990c3b1e9. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->