### PR TITLE
#2331 Update plotly to >= 6.0.0

### DIFF
--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-dashboard" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.5.4" %}
+{% set version = "2.5.3" %}
 
 package:
   name: {{ name|lower }}

--- a/src/dashboard/pyproject.toml
+++ b/src/dashboard/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-dashboard"
-version = "2.5.4"
+version = "2.5.3"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",


### PR DESCRIPTION
# Description

Update plotly dependency to >= 6.0.0.
Plotly has been on version 6.0.0+ since Jan. 2025, see #2331.

## Other details good to know for developers

None

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `plotly` dependency to `>=6.0.0` and increment `trulens-dashboard` version to `2.5.4`.
> 
>   - **Dependencies**:
>     - Update `plotly` version to `>=6.0.0,<7.0.0` in `meta.yaml` and `^6.0.0` in `pyproject.toml`.
>   - **Versioning**:
>     - Increment `trulens-dashboard` version from `2.5.3` to `2.5.4` in `meta.yaml` and `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 7b582d55438788c62fc82d6c3ff3b133321f73ee. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->