### PR TITLE
[docs] improve crosslinking between attribution instrumentation and eval

### DIFF
--- a/docs/component_guides/evaluation/feedback_selectors/index.md
+++ b/docs/component_guides/evaluation/feedback_selectors/index.md
@@ -9,6 +9,7 @@ synthesis, and more, each component can be a source of error.
 
 This also makes the instrumentation and evaluation of LLM applications inseparable.
 To evaluate the inner components of an application, we first need access to them.
+This access is provided through instrumentation. See the [Instrumentation Guide](../../instrumentation/index.md) to learn how to instrument your application and capture the attributes you want to evaluate.
 
 As a reminder, a typical feedback definition looks like this:
 

--- a/docs/component_guides/evaluation/feedback_selectors/selecting_components.md
+++ b/docs/component_guides/evaluation/feedback_selectors/selecting_components.md
@@ -38,6 +38,10 @@ Let's walk through an example. Take this example where a method named `query` is
 
 Once we've done this, now we can map the inputs to a feedback function to these span attributes:
 
+!!! info "Connection to Instrumentation"
+
+    The span attributes used in evaluation (`RECORD_ROOT.INPUT`, `RETRIEVAL.RETRIEVED_CONTEXTS`, etc.) must first be set during instrumentation. If you're using custom attributes, make sure they are properly instrumented using the techniques described in [Instrumenting Custom Attributes](../../instrumentation/index.md#instrumenting-custom-attributes) and [Manipulating Custom Attributes](../../instrumentation/index.md#manipulating-custom-attributes).
+
 !!! example "Selecting Instrumented Span Attributes for Evaluation"
 
     ```python

--- a/docs/component_guides/instrumentation/index.md
+++ b/docs/component_guides/instrumentation/index.md
@@ -8,6 +8,15 @@ TruLens is a framework designed to help you instrument and evaluate LLM applicat
 
 This instrumentation capability allows you to track the entire execution flow of your app, including inputs, outputs, internal operations, and performance metrics.
 
+## Why Instrument?
+
+Instrumentation serves two key purposes:
+
+1. **Observability**: Track the execution flow of your application
+2. **Evaluation**: Select instrumented attributes for evaluation with feedback functions
+
+The attributes you capture during instrumentation become available for evaluation. For example, if you instrument the retrieved contexts in a RAG application, you can then evaluate those contexts for relevance or groundedness. See [Feedback Selectors](../evaluation/feedback_selectors/index.md) to learn how to evaluate instrumented attributes.
+
 ## Instrumenting Applications with `@instrument`
 
 For applications that you can edit the source code, TruLens provides a framework-agnostic `instrument` decorator to capture the information from decorated functions. More specifically, adding the `instrument()` decorator will allow TruLens to log the function signature as span attributes.
@@ -54,6 +63,10 @@ Adding custom attributes in this way does not capture any additional information
     ) -> List[str]:
         return ["context 3", "context 4"]
     ```
+
+!!! tip "Evaluating Custom Attributes"
+
+    Custom attributes you instrument can be selected for evaluation using feedback functions. See [Selecting Spans for Evaluation](../evaluation/feedback_selectors/selecting_components.md) to learn how to evaluate these instrumented attributes.
 
 ## Instrumenting custom attributes with _TruLens_ semantic conventions
 
@@ -144,6 +157,10 @@ The lambda function dynamically processes both the function's return value and i
                 {"text": "context 6", "source": "doc2.pdf"}
             ]
     ```
+
+!!! tip "Evaluating Manipulated Attributes"
+
+    Attributes you transform using lambda functions are fully available for evaluation. This is particularly useful when your data requires preprocessing before evaluation. See [Selecting Spans for Evaluation](../evaluation/feedback_selectors/selecting_components.md) to learn how to evaluate these instrumented attributes.
 
 ## Instrumenting Common App Frameworks
 


### PR DESCRIPTION
# Description

Make it more clear in docs why instrumentation is useful, particularly manipulating the span attributes. then, better link to evals section and vice versa.
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [x] This change requires a documentation update

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance documentation by adding cross-links and explanations between instrumentation and evaluation sections, focusing on span attributes and their evaluation.
> 
>   - **Documentation Enhancements**:
>     - Add cross-links between instrumentation and evaluation sections in `index.md` and `selecting_components.md`.
>     - Explain the role of instrumentation in enabling evaluation by capturing span attributes in `index.md`.
>     - Clarify the use of custom and manipulated attributes for evaluation in `index.md`.
>   - **Content Additions**:
>     - Add sections on "Why Instrument?" and "Evaluating Custom Attributes" in `index.md`.
>     - Add "Connection to Instrumentation" info box in `selecting_components.md` to highlight the importance of setting span attributes during instrumentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 200fd2f879f63372e08605eeee425e6ce2653033. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->