### PR TITLE
fix: correct typo 'occurences' to 'occurrences'

### DIFF
--- a/src/hotspots/trulens/hotspots/hotspots_streamlit.py
+++ b/src/hotspots/trulens/hotspots/hotspots_streamlit.py
@@ -92,7 +92,7 @@ def hotspots_in_streamlit_with_config(
     column_config = {
         "#": st.column_config.NumberColumn(
             "#",
-            help="number of occurences",
+            help="number of occurrences",
         ),
         "avg. score": st.column_config.NumberColumn(
             "avg. score",


### PR DESCRIPTION
Fix spelling error in hotspots_streamlit.py help text.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix typo in `hotspots_streamlit.py` help text: change 'occurences' to 'occurrences'.
> 
>   - **Misc**:
>     - Fix typo in `hotspots_streamlit.py` help text: change 'occurences' to 'occurrences'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=truera%2Ftrulens&utm_source=github&utm_medium=referral)<sup> for 0b32c2ebb2ae598a93d58bf3d49927c2e59d1394. You can [customize](https://app.ellipsis.dev/truera/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->