### PR TITLE
Fix CI pipeline timeouts with pip dependency caching

### DIFF
--- a/.azure_pipelines/ci-eval-pr.yaml
+++ b/.azure_pipelines/ci-eval-pr.yaml
@@ -13,7 +13,7 @@ jobs:
   - job: PRBranchProtect # name seems to be important but cannot figure out why
     pool:
       vmImage: ubuntu-latest
-    timeoutInMinutes: 30
+    timeoutInMinutes: 45
 
     strategy:
       matrix:

--- a/.azure_pipelines/templates/env-setup.yaml
+++ b/.azure_pipelines/templates/env-setup.yaml
@@ -10,25 +10,27 @@ steps:
       echo "=== Disk space before cleanup ==="
       df -h
       echo ""
-      echo "=== Clearing package caches ==="
-      pip cache purge || true
-      rm -rf ~/.cache/pip || true
-      rm -rf ~/.cache/pypoetry || true
-      rm -rf ~/.local/share/pypoetry || true
-      echo ""
-      echo "=== Clearing apt cache ==="
-      sudo apt-get clean || true
-      sudo rm -rf /var/lib/apt/lists/* || true
-      echo ""
       echo "=== Removing large pre-installed packages ==="
       sudo rm -rf /usr/share/dotnet || true
       sudo rm -rf /usr/local/lib/android || true
       sudo rm -rf /opt/ghc || true
       sudo rm -rf /opt/hostedtoolcache/CodeQL || true
       echo ""
+      echo "=== Clearing apt cache ==="
+      sudo apt-get clean || true
+      sudo rm -rf /var/lib/apt/lists/* || true
+      echo ""
       echo "=== Disk space after cleanup ==="
       df -h
     displayName: Free disk space
+
+  - task: Cache@2
+    inputs:
+      key: 'pip | "$(python-version)" | poetry.lock'
+      restoreKeys: |
+        pip | "$(python-version)"
+      path: $(Pipeline.Workspace)/.pip
+    displayName: Cache pip packages
 
   - bash: |
       # Install poetry
@@ -40,7 +42,7 @@ steps:
 
       # NOTE: workaround for langchain typecheck error
       # https://github.com/truera/trulens/issues/1308
-      poetry run pip install pip==24.1.2
+      PIP_CACHE_DIR=$(Pipeline.Workspace)/.pip poetry run pip install pip==24.1.2
 
       poetry run python --version
       poetry run pip --version

--- a/.azure_pipelines/templates/run-tests.yaml
+++ b/.azure_pipelines/templates/run-tests.yaml
@@ -16,14 +16,8 @@ steps:
   - bash: |
       set -e
       echo "=== Freeing disk space before tests ==="
-      # Clear pip/poetry caches that accumulated during installs
-      pip cache purge || true
-      rm -rf ~/.cache/pip || true
-      rm -rf ~/.cache/pypoetry || true
-      # Clear pytest cache
       rm -rf .pytest_cache || true
       find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
-      # Show disk space
       df -h /
     displayName: Free disk space before ${{ parameters.pytestMarker }} tests
 
@@ -37,6 +31,7 @@ steps:
       make test-${{ parameters.testSuite }}-${{ parameters.pytestMarker }}
     condition: or(ne(variables['python-version'], 3.12), ne('${{ parameters.pytestMarker }}', 'snowflake'))
     env:
+      PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
       # tests make use of various APIs:
       OPENAI_API_KEY: $(OPENAI_API_KEY)
       HUGGINGFACE_API_KEY: $(HUGGINGFACE_API_KEY)

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ env-tests-optional: env env-tests
 	# nemoguardrails requires langchain<0.4.0, but langgraph requires langchain>=1.0.0
 	# Install nemo separately with: poetry install --with nemo (requires langchain<1.0)
 	poetry install --with apps,providers --without nemo
-	poetry run pip install --no-cache-dir \
+	poetry run pip install \
 		chromadb \
 	 	faiss-cpu \
 		"langchain-openai>=0.2.0" \
@@ -81,16 +81,16 @@ env-tests-optional: env env-tests
 
 env-tests-snowflake: env-tests-optional
 	poetry install --with snowflake
-	poetry run pip install --no-cache-dir certifi==2025.1.31
+	poetry run pip install certifi==2025.1.31
 
 env-tests-db: env-tests
-	poetry run pip install --no-cache-dir \
+	poetry run pip install \
 		cryptography \
 		psycopg2-binary \
 		pymysql
 
 env-tests-notebook: env-tests env-tests-optional
-	poetry run pip install --no-cache-dir \
+	poetry run pip install \
 		faiss-cpu \
 		ipytree \
 		llama-index-readers-web \

--- a/docs/component_guides/evaluation/generate_test_cases.md
+++ b/docs/component_guides/evaluation/generate_test_cases.md
@@ -15,7 +15,7 @@ be made up of `breadth` X `depth` prompts organized by prompt category.
     pip install trulens-providers-openai
     ```
 
-Note: Since we will using a LLM provider to generate the access, pick your provider and setup the environment variable, say OpenAI. 
+Note: Since we will using a LLM provider to generate the access, pick your provider and setup the environment variable, say OpenAI.
 
 !!! example
 

--- a/examples/quickstart/generate_testset_for_rag_app.ipynb
+++ b/examples/quickstart/generate_testset_for_rag_app.ipynb
@@ -1,1577 +1,681 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qfjhtKucPS1h"
-      },
-      "source": [
-        "# Generate TestSet Questions to evaluate your RAG pipeline\n",
-        "\n",
-        "> Tech Stack: [LangGraph](https://github.com/langchain-ai/langchain), [Qdrant](https://github.com/qdrant/qdrant), [OpenAI](https://platform.openai.com/) and [TruLens](https://github.com/truera/trulens)\n",
-        "\n",
-        "> TruLens benchmark to generate the questions"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "uUAuQiowPmgF"
-      },
-      "source": [
-        "### Installation"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "oLESZ3ZxZ80v"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install langgraph langchain-community langchain-openai langchain-qdrant pypdfium2\n",
-        "!pip install trulens \"trulens-benchmark\"\n",
-        "!pip install trulens-providers-openai\n",
-        "!pip install trulens-apps-langgraph"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "jCjvj7hpppc2"
-      },
-      "source": [
-        "## Initial Setup\n",
-        "\n",
-        "Install the required libraries and configure API keys for OpenAI and Qdrant. A TruLens session is initialized here to track and store all evaluation data throughout the notebook.\n",
-        "\n",
-        "- Get OpenAI API Key: [https://platform.openai.com/](https://platform.openai.com/)\n",
-        "- Get Qdrant API Key and Endpoint URL: [https://cloud.qdrant.io/](https://cloud.qdrant.io/)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "id": "Ds09pZ8MqNRV"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "from google.colab import userdata\n",
-        "\n",
-        "os.environ[\"OPENAI_API_KEY\"] = userdata.get(\"OPENAI_API_KEY\")\n",
-        "QDRANT_URL = userdata.get(\"QDRANT_URL\")\n",
-        "QDRANT_API_KEY = userdata.get(\"QDRANT_API_KEY\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gf8j1meOpsWj"
-      },
-      "source": [
-        "### Overview\n",
-        "\n",
-        "We will generate a dataset to evaluate the RAG pipeline built using LangGraph and Qdrant, and assess it using the RAG Triad evaluation metrics."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {
-        "id": "LJ8AX9vJpncb"
-      },
-      "outputs": [],
-      "source": [
-        "from langchain_community.document_loaders import PyPDFium2Loader\n",
-        "from langchain_text_splitters import RecursiveCharacterTextSplitter\n",
-        "from langchain_openai import OpenAIEmbeddings\n",
-        "from langchain_qdrant import QdrantVectorStore\n",
-        "from qdrant_client import QdrantClient, models"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 75,
-      "metadata": {
-        "id": "G2iW1aANrCOX",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "29da210d-cb10-4871-a9ea-041a1fc65507"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Updating app_name and app_version in apps table: 0it [00:00, ?it/s]\n",
-            "Updating app_id in records table: 0it [00:00, ?it/s]\n",
-            "Updating app_json in apps table: 0it [00:00, ?it/s]\n"
-          ]
-        }
-      ],
-      "source": [
-        "from trulens.core import TruSession\n",
-        "\n",
-        "session = TruSession()\n",
-        "session.reset_database()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "MTNzU73ErXWe"
-      },
-      "source": [
-        "## Data loading and chunking\n",
-        "\n",
-        "The Economic Survey 2025-26 report is downloaded and parsed using PyPDFium2. It is then split into overlapping chunks using Langchain's RecursiveCharacterTextSplitter to prepare the text for embedding and retrieval.\n",
-        "\n",
-        "> Economic Survey 2025-26 by Government of India: [Survey Report](https://www.indiabudget.gov.in/economicsurvey/doc/eschapter/epreface.pdf)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "8UUAZMO-rk20",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "f96c70a2-9961-44b0-88c6-e65533c0d62d"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
-            "                                 Dload  Upload   Total   Spent    Left  Speed\n",
-            "100 3973k  100 3973k    0     0  1545k      0  0:00:02  0:00:02 --:--:-- 1546k\n"
-          ]
-        }
-      ],
-      "source": [
-        "!curl -L -A \"Mozilla/5.0\" https://www.indiabudget.gov.in/economicsurvey/doc/eschapter/epreface.pdf -o survey.pdf"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "qcn7Rc7yrqV1"
-      },
-      "outputs": [],
-      "source": [
-        "path = \"survey.pdf\"\n",
-        "loader = PyPDFium2Loader(path)\n",
-        "docs = loader.load()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "o1NJ-CrfsSoO",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "8ae272ff-71b5-46b5-90c5-374ab46baab8"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "51\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(len(docs))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "S5l4e5WzsVy0",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "3311e39f-a36d-4082-8846-45bc706109d7"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Government of India\n",
-            "Ministry of Finance\n",
-            "Department of Economic Affairs\n",
-            "Economic Division\n",
-            "Kartavya Bhavan-1\n",
-            "New Delhi-110001\n",
-            "January, 2026\n",
-            "Economic \n",
-            "Survey 2025-26\n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(docs[1].page_content)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "EoAhjoevsdBW",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "4543da1f-8330-4f7a-cbcf-bdff381f3942"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "{'producer': 'PDFium', 'creator': 'PDFium', 'creationdate': 'D:20260128193114', 'title': '', 'author': '', 'subject': '', 'keywords': '', 'moddate': '', 'source': 'survey.pdf', 'total_pages': 51, 'page': 1}\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(docs[1].metadata)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "qsCZyc3jsjCO"
-      },
-      "outputs": [],
-      "source": [
-        "text_splitter = RecursiveCharacterTextSplitter(\n",
-        "    chunk_size = 1536,\n",
-        "    chunk_overlap = 0,\n",
-        ")\n",
-        "chunks = text_splitter.split_documents(docs)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "VxLNgcQksmmm"
-      },
-      "source": [
-        "## Setup your Qdrant Vector Database\n",
-        "\n",
-        "A Qdrant collection is configured using dense vectors generated from OpenAI embeddings, enabling semantic search based on meaning and contextual similarity. Each document or chunk is converted into its corresponding embedding and indexed within the collection along with its associated metadata.\n",
-        "\n",
-        "During retrieval, the query is embedded into the same vector space and matched against the indexed vectors to return the most semantically relevant results."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {
-        "id": "gB0HcbZ0sk0T"
-      },
-      "outputs": [],
-      "source": [
-        "embeddings_model = OpenAIEmbeddings(model=\"text-embedding-3-small\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "2wvyoZAus_Pb",
-        "outputId": "4a4db133-a4ae-498d-db3b-24447ec7b691"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "1536\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(len(embeddings_model.embed_query(\"this is testing to check dimensions\")))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "metadata": {
-        "id": "cnRAkNDXtbaS"
-      },
-      "outputs": [],
-      "source": [
-        "collection_name = \"economicv1\""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "metadata": {
-        "id": "OG5TH1e-tGai"
-      },
-      "outputs": [],
-      "source": [
-        "client = QdrantClient(\n",
-        "    url=QDRANT_URL,\n",
-        "    api_key=QDRANT_API_KEY\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "g1fSYkzltPGj",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "ae2f6ce1-3fad-4ba3-9bd9-135212a29cf8"
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "True"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 22
-        }
-      ],
-      "source": [
-        "client.create_collection(\n",
-        "    collection_name = collection_name,\n",
-        "    vectors_config = {\n",
-        "        \"dense\" : models.VectorParams(\n",
-        "            size = 1536,\n",
-        "            distance = models.Distance.COSINE\n",
-        "        )\n",
-        "    }\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "metadata": {
-        "id": "inmHy6n0uutV"
-      },
-      "outputs": [],
-      "source": [
-        "db = QdrantVectorStore(\n",
-        "    client = client,\n",
-        "    collection_name = collection_name,\n",
-        "    embedding = embeddings_model,\n",
-        "    vector_name =\"dense\",\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "kRbEZ_YEEn1f"
-      },
-      "source": [
-        "### Test the retriver"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "WFT4pVzMu7w_"
-      },
-      "outputs": [],
-      "source": [
-        "db.add_documents(documents=chunks) # just run it once. After the data is indexed, you need not have to add_documents again"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "metadata": {
-        "id": "_W2h8bzpvA_W"
-      },
-      "outputs": [],
-      "source": [
-        "query = \"what is Financial Time wrote on the eve of Christmas 2025\"\n",
-        "relevant_docs = db.max_marginal_relevance_search(query)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 157
-        },
-        "id": "mhJxlUBYvb3a",
-        "outputId": "1dc07ce8-7805-41f6-b058-a4ae8a48052f"
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "'ix\\nremains integrated yet increasingly distrustful. One could attach a subjective probability of \\naround 40% to 45% to this scenario unfolding in 2026. Reflecting this is the Global Economic\\nPolicy Uncertainty Index2\\n, which is near its worst readings of 2020, excluding the sharp spike\\nin April 2025 at the introduction of the reciprocal tariffs. Fear lingers. That brings us to the\\nsecond scenario.\\nIn this scenario, the probability of a disorderly multipolar breakdown rises materially\\nand cannot be treated as a tail risk. Under this outcome, strategic rivalry intensifies, the\\nRussia–Ukraine conflict remains unresolved in a destabilising form, and collective security\\narrangements unravel. Trade becomes increasingly explicitly coercive, sanctions and counter\\ufffemeasures proliferate, supply chains are realigned under political pressure, and financial\\nstress events are transmitted across borders with fewer buffers and weaker institutional shock\\nabsorbers. In this world, policy becomes more nationalised, and countries face sharper trade\\ufffeoffs between autonomy, growth, and stability. One could attach a probability of around 40% to\\n45% to this scenario as well.\\nLet us, for a moment, focus on the possibility that financial stress events are transmitted\\nacross borders with fewer buffers in place.\\nOn the eve of Christmas 2025, the Financial Times wrote, “Tech companies have moved \\nmore than $120bn of data centre spending off their balance sheets using special purpose'"
-            ],
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            }
-          },
-          "metadata": {},
-          "execution_count": 9
-        }
-      ],
-      "source": [
-        "relevant_docs[0].page_content"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Ncm8iBiWEqi7"
-      },
-      "source": [
-        "> Convert to the retriever: i.e., Langchain object"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {
-        "id": "5YQgfXqzEgdX"
-      },
-      "outputs": [],
-      "source": [
-        "retriever = db.as_retriever()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 11,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "7b8xfw2EEuU3",
-        "outputId": "5c57bdcb-0e2d-40f0-c46c-7ad5d72d5a31"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "ix\n",
-            "remains integrated yet increasingly distrustful. One could attach a subjective probability of \n",
-            "around 40% to 45% to this scenario unfolding in 2026. Reflecting this is the Global Economic\n",
-            "Policy Uncertainty Index2\n",
-            ", which is near its worst readings of 2020, excluding the sharp spike\n",
-            "in April 2025 at the introduction of the reciprocal tariffs. Fear lingers. That brings us to the\n",
-            "second scenario.\n",
-            "In this scenario, the probability of a disorderly multipolar breakdown rises materially\n",
-            "and cannot be treated as a tail risk. Under this outcome, strategic rivalry intensifies, the\n",
-            "Russia–Ukraine conflict remains unresolved in a destabilising form, and collective security\n",
-            "arrangements unravel. Trade becomes increasingly explicitly coercive, sanctions and counter￾measures proliferate, supply chains are realigned under political pressure, and financial\n",
-            "stress events are transmitted across borders with fewer buffers and weaker institutional shock\n",
-            "absorbers. In this world, policy becomes more nationalised, and countries face sharper trade￾offs between autonomy, growth, and stability. One could attach a probability of around 40% to\n",
-            "45% to this scenario as well.\n",
-            "Let us, for a moment, focus on the possibility that financial stress events are transmitted\n",
-            "across borders with fewer buffers in place.\n",
-            "On the eve of Christmas 2025, the Financial Times wrote, “Tech companies have moved \n",
-            "more than $120bn of data centre spending off their balance sheets using special purpose\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(retriever.invoke(query)[0].page_content)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XYgK_T6AEhfA"
-      },
-      "source": [
-        "## Build your LangGraph RAG workflow - Answer Generation"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 12,
-      "metadata": {
-        "id": "JJPRFv_kvjJz"
-      },
-      "outputs": [],
-      "source": [
-        "from langchain_openai import ChatOpenAI\n",
-        "from langchain_core.prompts import ChatPromptTemplate"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 13,
-      "metadata": {
-        "id": "d76aG9Ykvm5b"
-      },
-      "outputs": [],
-      "source": [
-        "llm = ChatOpenAI(model_name=\"gpt-5-mini\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 14,
-      "metadata": {
-        "id": "RNeo3q0gvqY1"
-      },
-      "outputs": [],
-      "source": [
-        "SYSTEM_PROMPT = \"\"\"\n",
-        "  You are an expert financial analyst specializing in corporate finance.\n",
-        "  You should be respectful and truthful while answering the user questions, if not you will face serious consequences.\n",
-        "\n",
-        "  The only source information you have is the context provided, if the user query is not from the context\n",
-        "  Just say `I dont know , not enough information provided.`\n",
-        "\"\"\""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 15,
-      "metadata": {
-        "id": "dRZQthT-vr9H"
-      },
-      "outputs": [],
-      "source": [
-        "USER_PROMPT = \"\"\"\n",
-        "  Answer the USER QUERY based on the CONTEXT below.\n",
-        "  If the question cannot be answered using the information provided answer with `I dont know , not enough information provided.`\n",
-        "\n",
-        "  <context>\n",
-        "  CONTEXT: {context}\n",
-        "  </context>\n",
-        "\n",
-        "  <query>\n",
-        "  USER QUERY: {query}\n",
-        "  </query>\n",
-        "\"\"\""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 69,
-      "metadata": {
-        "id": "NfGwSr8pw4j9"
-      },
-      "outputs": [],
-      "source": [
-        "from langgraph.graph import StateGraph # node and edges logic\n",
-        "from langgraph.graph import START,END\n",
-        "from typing import TypedDict, List\n",
-        "from trulens.core.otel.instrument import instrument\n",
-        "from trulens.otel.semconv.trace import SpanAttributes"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 70,
-      "metadata": {
-        "id": "RxtFx4TEw1mZ"
-      },
-      "outputs": [],
-      "source": [
-        "class RAGState(TypedDict):\n",
-        "    query: str\n",
-        "    context: List[str]\n",
-        "    answer: str"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 71,
-      "metadata": {
-        "id": "Picul_eAwwHE"
-      },
-      "outputs": [],
-      "source": [
-        "@instrument(\n",
-        "    span_type=SpanAttributes.SpanType.RETRIEVAL,\n",
-        "    attributes={\n",
-        "        SpanAttributes.RETRIEVAL.QUERY_TEXT: \"query\",\n",
-        "        SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS: \"return\",\n",
-        "    },\n",
-        ")\n",
-        "def retrieve_docs(query: str) -> list:\n",
-        "    results = db.max_marginal_relevance_search(query=query, k=4)\n",
-        "    return [result.page_content for result in results]"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "@instrument(span_type=SpanAttributes.SpanType.GENERATION)\n",
-        "def generate_answer(context: str, query: str) -> str:\n",
-        "    messages = [\n",
-        "        {\"role\": \"system\", \"content\": SYSTEM_PROMPT},\n",
-        "        {\"role\": \"user\", \"content\": USER_PROMPT.format(context=context, query=query)},\n",
-        "    ]\n",
-        "    response = llm.invoke(messages)\n",
-        "    return response.content"
-      ],
-      "metadata": {
-        "id": "mOsR1--6LxhD"
-      },
-      "execution_count": 72,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "@instrument(\n",
-        "    span_type=SpanAttributes.SpanType.RECORD_ROOT,\n",
-        "    attributes={\n",
-        "        SpanAttributes.RECORD_ROOT.INPUT: \"question\",\n",
-        "        SpanAttributes.RECORD_ROOT.OUTPUT: \"return\",\n",
-        "    },\n",
-        ")\n",
-        "def execute_graph(question: str) -> str:\n",
-        "    result = graph.invoke({\"query\": question})\n",
-        "    return result[\"answer\"]"
-      ],
-      "metadata": {
-        "id": "ALRDXVIIL1jq"
-      },
-      "execution_count": 73,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def search(state: RAGState) -> RAGState:\n",
-        "    state['context'] = retrieve_docs(state['query'])\n",
-        "    return state\n",
-        "\n",
-        "def answer(state: RAGState) -> RAGState:\n",
-        "    context = \"\\n\".join(state['context'])\n",
-        "    state['answer'] = generate_answer(context, state['query'])\n",
-        "    return state"
-      ],
-      "metadata": {
-        "id": "dgg-JPKsLz90"
-      },
-      "execution_count": 74,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 46,
-      "metadata": {
-        "id": "HcLiGAYjD5w0"
-      },
-      "outputs": [],
-      "source": [
-        "# Agent - workflows\n",
-        "workflow = StateGraph(RAGState)\n",
-        "workflow.add_node(\"search_context\",search)\n",
-        "workflow.add_node(\"answer_generation\",answer)\n",
-        "\n",
-        "workflow.add_edge(START,\"search_context\")\n",
-        "workflow.add_edge(\"search_context\",\"answer_generation\")\n",
-        "workflow.add_edge(\"answer_generation\",END)\n",
-        "\n",
-        "graph = workflow.compile()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 47,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 350
-        },
-        "id": "mQEVp0M-D6lc",
-        "outputId": "52b6f337-2a44-426a-aed1-b8f178059049"
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "<langgraph.graph.state.CompiledStateGraph object at 0x791587301310>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAALYAAAFNCAIAAAAisAI9AAAQAElEQVR4nOydB3wUxRfHZ68kuXQS0guBhN6SEEoAQekKKAjSEqUqVTpIVwKISJci8kdEUQSkSBEpgnTpBAg9BQghBNLbJVd2/+9uw3GbvdwlJIFN7n3FfHZnZudmZ3/75s3s7oyEYRiCIEUjIQhiFJQIYgKUCGIClAhiApQIYgKUCGKCiieRe1cyYq7lZKcrVUqiyNf02CVSSqVkKBFFGE0XXiSiaJoRiSnYZmgIhyQU7NAMKZQGIgoSi7SJ4X+KsMlp7YEMDZtEE1zwl2LHCCA9/IUAhqY1ybUpdYjFlFrNGUoQiYmVTGzjKK5Wx7p+qCOpUFAVZVzk7P7ku5cyc7M0l0JqQaQykYWFWK3QRIkllFqlvaKM9rqxl1ZzqfU24D+a0qXRCEF7UXWJNbUAIdpLD+mYFxLRhDDcv6QgTzZ/wpMIJSGMilt6SiMnRR6jzKdBVDJbyr+RbdtebqQiUAEkcnrv86jTGXAHu/paNOvs7BVgTSoyTx/JL/yd+vRBHq0mAUE2Hfq7E2EjdIlsnBOryKcD2zi06OpCKhdX/k29/E8atFlD59UgAka4EklLkv+2KMGnpuUHI31I5eXQz0+ir+d2HugW0MiOCBKBSkShUK//Iq77cPdqdWxJZSczJf+X+fFDIvys7YTYexCiRJ4nyLcvSxi9NICYE2unRLf7yLlOsypEYIiI8AB99BzjQcyMUYsDjm5LIcJDcBL5cXZstboyz+o2xPyoF2q3fnoMERjCksiRLUlKBd1tmBcxS97p7SaWiPatf0KEhLAkcu9KVrPOTsSMead/1Ud3c4mQEJBE/v0jCQaqg9uZtURq1LOT2YgObEoggkFAEomOzPapWbFHTsuEGo1s4u/mEcEgIInk5zLt+rzuIdSOHTsmJJT4lo2JienWrRspH97u7aZSMGnJQlGJUCRy4dBzsZRY20vJayQxMTEtLY2UnFu3bpHyRGJBXTr8KgUrD4QikYTofHhcTsoHGB7csmXLgAEDWrVqFR4evnr1arVafenSpe7du0PsBx98MGnSJKK1DYsWLerdu3fLli0h2Y4dO9jDo6OjQ0JCTp8+3aVLl/79+69bt27u3LlPnz6FwN9++42UAzb24tREBREGQhnxzclQWtlSpHzYunXrxo0bx48fDxI5fvz4mjVrbGxsBg8evGLFCgjcs2ePl5emm7106dInT57MnDkTnio/ePAA5OLh4QGHSKUa27Zhw4aPP/44MDCwfv36CoXi8OHD+/fvJ+WDjYM447mKCAOhSEStpmR25WVFrly5Uq9ePdZ76NmzZ9OmTXNzDXQsFy5cmJOT4+npCdtgIfbu3Xv27FmQCCgGQlq0aBEWFkZeC5ZWUrUKJVIIhmLf5ykPGjduvGrVqoiIiKCgoDZt2nh7extMBu0R2JszZ848fPiQDWGtC0vdunXJ64IiNBEMQpGISMyoFGpSPoAXAi3LiRMnwIeQSCTQixk7dqyLC6f3RNP0uHHjoAUZM2YMmBA7O7uhQ4fqJ7C0tCSvi7w8mhJMX1MoErG2F2enlZdpFYlEPbXExsZeuHBh/fr12dnZy5cv109z586dmzdvrl27tlmzZmxIVlaWq6sreRPkZqgsZeVlU0uKULTq4mMlzykv6wp+JfRWYKNGjRr9+vWDXsndu3cLpUlPT4e/Ok3EaiFviOwsVRWP19r/N4JQJNL6fWcYLyLlw8GDB6dMmXLy5MmMjAzoux47dgy8Ewj38/ODv0eOHImKigL1QBu0efPmzMxM6M4sXrwY/FMYODGYoa+vb3JyMnSOdF5L2aKUk0ZvORBhIBSJQFsAD2gO/5pIyoFZs2aBAiZOnNi+fft58+a1bdsWerYQDn4rDI3AOAc4s+7u7vPnz79x40a7du0mTJgwevRoGCAB6cBffoatW7eG3u/kyZMPHTpEyprzf2veGvGuIZTX7QT01tmBjU8e35d/ttCfmDcbZsU6OEs/miCUN3YF9IzmvSGeijwm7mY2MWPkWaq8HFo4+iBC+xrPp7bs6NZnw+YZtrHQ8A8cONBglO47OT49evSAIVRSPkDOkZGRBqMcHBzA9TEYBS1UUU8Bf1/6sIqHsC6K4F5v/n5qTMPW9q3fN/DIFx6sGBwVBeRyuUwmMxgFw+dWVlakfIDyQKkMRimVSnbkng8MsVhYWPDDr51KObU7bcwyYb3XLTiJpD/L++2bx6MFVk2vh7WTozuEudQKEkpfhkVwrzc7ulo16egowLd8y5sNM6MDgqyFpg8i2E+tEqJzd699IjSTW36snhj97iA3f0F+kCfcDzYvHk45fzCteZcqTTs5k8pL1Pm0E9tTajax7TRAoN9/C/qz7+TH8h2rEmR24u6feji5lZfL+abIz8/fvvRJdpq6Y5hbQKBAP+glFWLyiJ2rHj99kGdjL6rT1K7Fe5VhfoBLR1Nu/ZeZmap28bboO9GXCJsKMwXN7jXxzx4paDUjllLWdmJ4MmwpE1NijrvNziVUsK2dZ4Z/cuy0RJyUFBFRlJpmJ5d5MckMpZnZiKapQvnDPs3o/RBFxJRmuhqGeVkAkYjQNKc8jFqtkDPyHHVuljo/j4YEVT0tPhovdHGwVBiJsCQ+yL1+KuP5Y0V+rlqpYBjus2H9Cw8xYkPjaQXX74UU2KMoCHwxukGDLkTamaooUih/opUIw3AOF4kpTYbaHyqY7+rFpEW68ohEtFgisrQRgzLqh9r71q5I0x1UMIm8BkJDQ0+cOGFwaMs8wRkTC6NSqSQSrJaXYF1woLVOBLQzBHkBSoQDmhA+WB0cjDx7M1tQIhzQivDB6uCAEuGD1cEBJcIHq4MD+iJ8UCIc0IrwwerggBLhg9XBASXCB6uDA0qED1YHB5QIH6wODigRPlgdHFAifLA6OKBE+GB1cMChMz4oEQ5oRfhgdXBAifDB6uCAEuGD1cEBJcIHq4MDuqt8UCIc0IrwwergACbEzk64n9e+EVAiHGiaZidgRXSgRDhAK6MSzPz8AgElwgElwgclwkEsFhc1vZ3ZghLhgFaED0qEA0qED0qEA0qED0qEA0qED0qEA0qED0qEA/Zo+KBEOKAV4YMS4YAS4YMS4YAS4YMS4YAS4YMS4YAS4YMS4YA9Gj4oEQ5oRfjg7M0aJk2adOzYMYrSzPgOFaKZ35uiQC7nzp0jZg/OQathzJgx1apVE2mBtgb0QdO0j4+Alrl8g6BENFSvXj00NFTfoEql0j59+hAEJaIjPDzc29tbt+vh4dGzZ0+CoER0eHl5tW3blt0GL+TDDz/EryVYUCIvGThwoK+vZhkhT0/PXr16EURLWfZorp9NeRarVPD6jLqVe7Q9Bs5KU9pFhSj9KP1lh0jBklNEzV06SCxi1Ox6U/pLB1GE5p2KXrze4RShCTF43jEx0Q8ePPTz8/P39+f+YuEy6JcQfoOfmW5tK9MFKrQeF0WKuibQ0WIIU6h+CiWWSBkXH2lQm6qkjCgbiTxPkO9enQADClJLkTKPKfQLIkpE0wWLPrELh5GX51ZQZ5RIW9F6S0KxaJaXgiuq5uQpklC0iiHcCip0SQoWmDJU3ZRI27nlCYrSLlGlUtFs75fzi9rl0ggPNqG2B8QUdQglYpgXC6ixC9fzS8U9EUpXXYXUQLES0T9NUeGltyysREqFGmqjQ1hV/4aOpNSUgURSEvO3LY2v19qhyTuVYW3DysGt8ymXj6R1G+Ze+kXWykAiayZF9xzjZeckI4jA2Dwv+pPp7rbOpVJJad3VP1Y+snYUoT6Eib2LeM+G56R0lFYimckqF6/KtshypcGrum12emmfSpa2669U0BKxmCCCxFImopUUKR2llQitptTq0hYCKSegc6ZWl9bXxAFExAQoEcQEKJHKjObdBsmb9kUQIUPTtFqFvghSzqBEEBOgRCoz8MBSJEJfBDECA8/VBeCLaB5QI4JE84y21BenDCTCvhOEVFawoanMiIiIKvUDNHN5d/Wjvu9u+HENMTMYiiY0KSX4evPro2evjk8SE8irMjdi2oG/95ToEIYhpX/vFCXymnj6NDE9PY2Ugrt3b5E3wRuQyLnzZyZMHP5u19ZhH/dYuOjLlJRkNjw1NWX+gpn9BnTr8WGHBQtnx8c/1B3y33+nFnw9q2//rnDUxEkjrkZeYsN37tra66POp88cb9+x2ao1SyBErVZv3fYLJIN/kyaPvHEjUpeJRCLdtXtbpy6h3d5vO23GuIzMDJNFzczKXLxk3jvtQ6BIULakpKdseG5u7vyvZ/Xu06Xzuy2Hjwj/c88fbPjuP7d/2LvTo0cPBg/tA0cN/bTfwUP7IBwK3D+sO2yEhX8wa84kol3V5If130Gyrt3bfDF97Llzp9kcliydD6eZl5fH7v625Sc4kcSnTyA3+AuF6f7B2+T18rolcu/+nekzxgUFNd20ccfYz6fGxNxb9O1XRHtpJ0waHnnt8oTxMzZu2FbF0WnU6IEJTx5DFNTXgoWz8vPzp30x9+sFK3x9/WbOmgB6gigLC4vc3Jy9e3dMnxbR8wPN95Xr/7dqz54/IuYumTVjgYuL2xfTP4cLxv70iZP/5ORkL/pm1ZTJc6KiIn/66XvjRYWrOG362OSU58uWrvt8zJRnz5OmzRjLzhsAG0+ePJ4XsXT71gNt2rRf+d2i23duEu1nntnZWd+t+nbKpNnH/rnYtk2HbxdHgLCCAkMWLlgBCX77dc/8iKWwAWl27NzSs0ffLb/ta9um/Zdzp544eRTChw8fp1Qqf9n8P9hOTn7+628/jh41ycPd8+CBMxAyZfLsfXuOk2Ij0r40T0rH6+7RRN2ItLKyCg8bAg8h3dzc69SuFxsXDeFwu8O1XLrk++CgprA7csT4M2dP7Ny5BWQE6Tes3yqTyRwcNK/8163TYM/eHTeiIqFm4fxBQP36DWSPAsOw/Y9fx4+b1jSkBew2b94KBJSSmgyqgl1ra5uPw4eyxYDMr9+4aryo586fvn076uefdrCH+/hUg8xBmlBgKC3ouHp1zbc2YQMGn79w5udf1n/z9UqiXRdr4Cef1avXELY7d+r206Z10dF34Uz1cwa5Hzq8f0D/Qe9313zQ9d67H0RFXQNZwBnZ2dqBHL9eOLtr154bNqyGk+3WtTTfjRbx3U5JeN1DZw0aBsJFnT5zfEiT5qGhbby9fOAOg3C45HALsldamycV2LjJtetX2F240ht+XA02Rtcq6bfrdWrXZzcexMVodusU7Eokkoi5i3XJGjYI1G072Dsq8vOJUWJi7ltbW7P6AGrVrDNrxnzYOHrsIKiW1ceLqLoQ+LI8LwpgZ2cPf8GuFMr53r3bCoWiaUioLgRO9u+De0HiDvYO77zd8fCRv2bMHJ+c/Oznn3aSUgBDq8wbHzrTfA5UkvRQ0d8s/O7kyaPQIqz9fnmT4GaDBg5v0KAx1CPcf9Di6id2dKwCf8FQj5swLDio2eyZX8PdCerp2LmFfjJobtgN9mJYJQ7r+wAAEABJREFUWRp+3Vr/G93imF9olSwNZQUytbLivPEPSpLLc4ufOVvOz8cNLRSelpoCEoGNsP6DIRZ0U7Xqm/80qbQS0Yi0hKOrzZu1hH+DB424fPn8zl2/w+2ya+cRZ+eq0JQsmL9cP6VYpBn3OX7iCNxz4IhAAsK1H4WwsdF8MAImh5QF0DDBhadpGtpE7q/Y5OXJ9UNycnOqOpfgWjprL/ykiTO9vDhTmLi6FrRH0Dy1bvU2tHT/Hj8CRoW8Khqtlnro+3W7q5GRl89fOAsbcH907twNfLGs7KynSYn+/rXkcjnUEbQ77D83N4+AgNqQMjMzAyw2qw+i8TqPFpU5pAdToWuewMhCz+XQof3klQA/CdrEu/dus7vgKo2f+Bm0PrVracLvR9/VpQSXxa+6f/Fz9vbytbS0hA3dyfpVq1HNtzpYIwjc/9fumNj7cEuAs7Jq9eIsXjv1mnndEom6ee2ruVP37d8FxuDW7ahdu7eCVtzdPKDFadas5ZIl86BZychIh27kiJEfHzy4Fw6pUaMm2Pa9+3ZCbwLkdeXKBfBbnz17ys/c1ta2Y4f3oEcD7Tr0M6F+wVDVrduAvBIhIS3gLl+//rtTp/+9eOncipXfPH+WVK1adSinp6f3smUL7ty9Bd7rjxvXgkT6fvSx8dx8tD7N8eNH4KxBCtC8gn8Kbi8YSBD95KmjIH9I8Pz5szVrl44cPh5sVdiAITIr2dq1yyAcJOXi4nrp0jk4rxLNxlb652evu0fT56NwEMfqNUuWLf8afIh273Revmw96yVAtxB0EDF/+q1bN6D70KHDux9+2A/C27fr/PBhLFTo8hULoavyxdSvYORjy++bsrIya9WqWyj/cWO/gLpeumwB9KID/GtFfLVY52+WFCjVkm/XLlw0Z86XU2A3NPSthV+vZIsKHdd1P6yAbjmcAih4XsSShg0Djefm5endpXN3aEEa1G+8fNkP/fp+AoZzy9ZNoHhoH+vXazRp0ixNJXwzB8LBvhKtjwWBMLoDPaPAwCagGDj8wsWz234/UMy5T8pkdLW03/SunRxTrZ5dm16uBBEeV4+nXj+eOmZ5ACkF+KQXMYFZSwRaq99/32QwqppfjdXfbSQVHM3oaqm9TbOWSPfuvd55p5PBKIm4MtQMDd4q8+YH4JmK+2IijHbDP1KJYcpgeLX0EqHwxcTKDbqriAlQIpWZMjHvKJHKTJk8o0GJVGY0c3MK4TsapHKDEkFMgBJBTIASQUxQWolIrURSy1J/8IWUDyIRkViQUlJqiVgw6c8VBBEkqYm5YikpJaV9DhgQaJeWpCSIIHkWr/CpZU1KR2kl0vp9FwsLsnNlLEEExp/fx8Dzsy6feJLSUTbr0fyx8mFqktK3lrWHv7VEYsq0cT//4X8MpFvHyCBQXmhiiyo1o3n4TRn8QcbYSKPhSIMlYTQ3lmatm8L5U5r/ilUedk0ao8m056cJ1K8fivu7BkOUKtWzePnju7mWViR8eg1SaspsVauDPyfE35erFURlstkx+YWY8QSv/IGZkeWi3jSGi8a8yvC5REqJJYxHDatuw7xJWYBLORemZcuW//77L/sRA0JwXISPSqXCtTX1wbrgADaVpmkxLp+iB0qEA5oQPlgdHJRKpVRa6sGmygVKhANaET5YHRxQInywOjigRPhgdXBAX4QPSoQDWhE+WB0cUCJ8sDo4oET4YHVwQInwwerggO4qH5QIB7VajVakEFgdHKChwWd4hUCJcEBfhA9WBwf0RfigRDigFeGD1cEBJcIHq4MDSoQPVgcHlAgfrA4O6K7yQYlwQCvCB6uDg6WlpZOTE0H0QIlwUCgUKSkpBNEDJcIBWpkSrfZiDqBEOKBE+KBEOMAzPHjYSxA9UCIc0IrwQYlwQInwQYlwQInwQYlwQInwQYlwQInwQYlwwB4NH5QIB7QifFAiHFAifFAiHFAifFAiHFAifFAiHFAifFAiHLBHwwclwgGtCB+cvVnD4MGDr169KhKJKOplhcDupUuXiNlT2pUkKgfjxo1zcXFhJSJ6gbd32cyhXtFBiWgIDAxs1KgRTXOW5+rUqRNBUCI6hg4d6urqqtv18vLq27cvQVAiOurVq9e8eXN2G8xJ69atnZ2dCYIS0WfQoEHgkcCGh4dHWFgYQbQUq9MbdzuTVpqemEW3NJNuqZ2XqwtR2kjuKjx66Qs2tFGFl2ki3EWfCq3jox/FXcyIm/BFAfhHkZerV7m2bdr3/PnzTQND5MkOMck5pKjc9EJ0P8rmyVl8iPuj/IyMr75koBoNLWNl8IwKZWLwh8RStV9de2IKE53erYvjUpPUcNpq7WCBpnQUZ6PQdlEYXp9JF2py+SausopOrFcVPCnp7xbOo5C4inFGJgppOKDoQ1/tF4vzW0UXghJrYhxcJGFf+JGiMSaRX7+NVeQwb/V0da9uR5DKyPME+eldiSoVM+Qr/6LSFCmRTXNjxZakx8gyWH8PETh///wgI0n16YIAg7GG3dWb/6Xl5dCoDzPh3YF+MCR09sBzg7GGJXL7QqaVLXZ2zAgbB3FcVJbBKMM6yM+jxDiHgjkhs5Yq5YY7rYZ1oFLQDF06DxupUCjyGUWe4bcg0FQgJkCJICZAiSAaNG9BFOFZoEQQLRTDoEQQI2gGUIsYZkeJIFoYwqBEkFfDsEQokdGn1EilQ/cqBh/DEmFogi/GmxeU5uUWgxRhRXBk1Qwp4qFcEVaEwXbGvNBccdpwFD7OFTSxsdHvtA+5fv0qKWdEIkpUhBZQIoIjLi6m34Bu7LajY5VPPh7m6upOyhkantsWYUWw0ys47t67pdt2cnIePGgEeaOUmURA+3v37bhy9eLTp0/8qtV4770eH7zfm43q8WEHOM+MjPSff1kvk8mahoSOGT3Z2bkqRJ07f2bbtl/u3L3p5FS1QYPGnw37PCcne+Dg3iuWrW/cOBgS/HP04IKvZ439fGrPHn1g99GjBxC7ZvWmenUbHDy0b+++nXFx0dWrB7R7p1OvD/tTWjf7y6+misViNzePrdt+mfvVt23eamek2JDD9u2bM7MyW7RoPXTwKLh9Z81c0L5dZ4i6efM6FPjOnZsOjlVCW7w18JPPbGxsIHxuxDT4oQ7t3/3m26/k8tx69RqO+Gxc3boN2AyLKtUHPdt/Ej7s5Olj0Grs+fOYvZ39rt3bzp07dft2lIWlZeNGwUOHjvby9P5p07pfNm+A9NC+jBo5oUlw86Gf9lu5/H+NGgVB4JkzJ6BIDx/FOTg4BgTUHvf5F25u7iaLVBwoqsg+Spk1NGvWLr148b9xY7/4ZuF3oI+V3y2Cy89GSaVS0IFIJPpz99Gff9p5Iypy088/QPi9+3emzxgXFNR008YdIIKYmHuLvv3K19fP1dXt5q3r7LFRUZFQC7de7MKxtja2dWrXA+ks+nZurZp1tvy6d9jQ0Tt2blm9dqnu52LjouHfgnnLGjUMMlLm23duLl+xsG3bDpt/3vV2mw4R86cT7dfe8PdxQvzkqaPy8vNWr/pp3twlsbH3J0z8jJ00QCKRQPGO/HNg3feb//7rtKWF5cJFX7IZGi/V/gO74bou/naNtcz6xo3IVasX16/fOCJiybQv5qalpcKdAMngXurX9xM45X+PXvqoN+dbnkuXz8/5akqnTl23bz3w5exvkpISV3z3DRtlpEjFhSrhuMgrMHv2wtzcHA93T9gOCgw5eHDvhYtnWzRvxcZ6efmEhw3RbNnagRW5d+82bEbdiLSysoJwuCpQKXDh4bpqD28K9xZ74LXrV7p07n7g7z3sLtRsSEgLSH/gwJ9wY40fNw0Cq1RxGjxwxLdLIsIHDIFtuJ/Akq1buxkyN17mw4f3s5Ycqrhlyzb37t++desGG/XPP39LJVIQB9yvsDt50uz+Yd1Pnzn+dtsOsCvPzZ0yeY61tTVst2/XBe7d3Nxc2DVeKnt7h89HT2bzhxv9px+3e3v7siskqZTKGbMmZGRmONg7FFXajT99Dxaxd68BsA2lGjVy4uQpo+7cvQX1ZqRIpHgY/jhHi2Erov1EnpQMhtm1a+sng3qBhYR/UPT0tFRdZK1adXXbdnb20JrARoOGgXl5edNnjv9jx29w18Jpg7YgPDio6fUbGh8e2qYHD2Lf7947JSU5Kekp0VqR4OBmNE1H3bwGUtPlCaYIAtmjgGq+1U3qAwBFgjXWLWPV5q32uqibN6/VqVOf1Qfg7u7h6emty9/H109X+7a2mi9IsrIyTZaqdq16uihoCp88eQxGtNv7baG6QB8QqF9jBkobex+KpNtlc4N20EiRSPFhSMncVfBvi3w2bDg9PW3GOKVS8emwMYGBIXa2dp+PG6qfwKDiwCBDq3Ty5NH1/1u19vvlTYKbDRo4HDySJk2aZ2ZmgNsBl7BmQG240eGeu379SrNmLaFamzVtqVAolErljxvXwj/9DNNeVDG07qQYZGdn6XcWdIJgo0DlcPE4+acWrGYkMtRBNF0qCwtdIHgVs+ZMChswePhn4/z9a0IjMvWLMcRYUbPz8/MtLV/qnhUEWG4jRSoTihxdLdHQGXgVIOcli9fCZWZDoIpdqrqaPLB5s5bwD0z95cvnd+76fcbM8bt2HgFPtnp1f2hco2PuNdS6aeBSwK5ILPb08GIdNKigTh27tmnTXj83T4+SzQgCNQ4WXrebkpqs23ZyrtqwYWCh3oSDvaOR3MBuFb9U4JdA/uCvsLtQXcQorFHMy5PrQnK04nB2qkrKAngqR5XsGU0Jx1ahRYC/Ok1A6wD/qvv5Gz8qMvJyviIfJFK1qkvnzt3c3T3HT/zsaVKit5cPmOhr166AaQ0P11ijhg0C129YBd4iOCLssf7+tbKys9iGiWhXxkxMTAA/l5QE8JDu37+j2z1z5rhu279GzcNH/oKOhu7uhDMC18F4hsUvFZhJdzcP3e6pU8eM5wytYe1adaGTpQtht2v41yRlRPn2aKCXC+ewTdt7hAYCfPWmIS3gYhs/Clrur+ZO3bd/V3p62q3bUbt2bwWtsBUXHAgSuayxIg0CYbdBg8CHD+PA0gS/sFKfDh0DVxTcWGjjwIeNmDd94uQRYOpJSWjVsi1ku+X3TdCsXrx0DvLRRfXuHQY5Q38EvKX4+Ic/rP9uyLC+rDdthOKXKsC/Fvzi1chLoHtwxdhAtsZAiOB7nT59HH5X/5CePfqCv7xz5+9QyXDg2u+XgdMGDTEpCxhS5LP9spEIGP+ZM+bfun3jgx7twPMC+/n++72hVwJjGEaO6vNReNf3eq5es6Rnr47QpbS2tlm+bD3rPIIUoL58fKpBX4Bo/C9bP78aEALWhT0WrPT6db/BGAMcC71T8H/nz1tmWTwXRAd0EGC4BUYaIJPdf24bNkzjDbDr9MK4xY8btsmsZMNHhoMPHnnt8pTJs8F5Mp5h8Us1ZMgoMJ+zZk/s1CUUPHHo90LHZNr0sdBtbtG8NdwYs7+cfPTYITqJQWMAAArCSURBVP1DoLs7dMiobX9shkqG0QFofOfMXkjKCprQRUjE8De9P897wNBUr/HVSKUG7mBoPgICarG7MEwyavTA//2wRRdiPuxfH5+VqvxsoYFPdM36GQ10oT8dPgBG+Z4+TYQRkZUrv6lfv5F/2bXuFQmqhO5qpQEGXaL0PAx9YAh45IjxkybO/Pvg3iHD+sBYQkiTFiNGjKfM8mUZymwlMnniLIXSsA8Lo+Dwt1vXnvCPmD1G+rCGJQKjq3SleKeIfViImKako6uIuVHiJ73aAXiCmA8MfkeDvDIoEUQLPKMp4rtvlAiihSZMET0UlAiiQfOkt0Tf0SDmBs4MgJgCezTIK2NYIhZSSoUzJpoTEgtGIjVsRgy7KJa2FK3ChSbNiHw5I7OVGowyLJHGbexys1AiZkRWqjKgkcxglGGJ+DeqYuso2bkyliBmwJ4fYiytqaZdXAzGGltsZPeaxylP8hq/7VynWRWCVEbuR6Zf/TfF2lrSf2qRbxiaWLJo99r4pIcKtarIz8ZfUoz1eTQf5xh/YadEaxfxML5IlHblKspI4YzMvGNoeSrTRTJy1KtmWMQpFH9xJD00bwlTxNlT2sfoG6jFWspZnibPlptY+IwyMTuaJt5UGkLBMLB+06ddRYyz7Bej+a/Iw3mx2umZdOtcFT1Zk175Rw4fsXLVSgsLS/1jjZS8cJlfFJsYLW2hKOqFZhiDGeowdAq6hcGK+KEitWhhpXZwkhFTFGtcRFZFJjObpib+2U03b5kEF9J4AVYEB7CparUa9aEP1gUHpVLJfkeD6ECJcFCpVGhCCoHVwQGtCB+UCAeUCB+UCAdsaPhgdXBAifDB6uCAEuGD1cEBJcIHq4MDSoQPVgcHlAgfrA4OIBHs9BYCJcIBrQgfrA4OKBE+WB0cUCJ8sDo4oET4YHVwQInwwerggBLhg9XBASXCB6uDA0qED1YHB5QIH6wODigRPlgdHCwsLJydnQmiB0qEQ35+fkpKCkH0QIlwgFaGXUYT0YES4YAS4YMS4YAS4YMS4SAWi9VqnHuHA0qEA1oRPigRDigRPigRDigRPigRDigRPigRDigRPigRDtij4YMS4YBWhA9KhANKhA9KhANKhA9KhANKhA9KhANKhA9KhAP2aPhQuCAvEB4enpycTLSvFGVmZlpZWSmVSpqmL126RMweEUEIGTRoUHZ2NqgkKyuLoigQCujDx8eHICgRlg4dOtStW5fWWwsBmptmzZoRBCWiY/Dgwfb29rpdb2/v/v37EwQloqNly5YNGzZkPTP4GxQU5OfnRxCUiD6ffvqpk5MTbLi5uYWFhRFEC0rkJY0aNQoODgYvpHHjxrVr1yaIlgrZ6T2yJTExVp6drlmhmtaOYjC8VYW0K/UUXqvH4MpDhpeKMrTIFX/5n8Ih3NWlqBe7IhGxc5a4VbPqFOZOKhoVSSIP72Qf2/osJ4OGepfKxNaOVjZVrKQyiUQs4S4LpXelCpaBKtAGHCnSbhTsa2MLrbelXZyN3aG08S8iIA1dsE9xtMZZdks/Qs3QIobk5Spz0/LkWfnKXBWtZqztRaHdneo2cSQVhAojkU0Rcdlpapm9hXegm6VVRR0UhtH9R1eT5BkKKxvx0IjqpCJQASRy40z6iR3JVnaSgNDKM5YVc+GJPD0/qL1dq25uRNgIXSIXDqZcOJTmG+xiX9WWVC4Uecp7px/XaWLXYYCgVSJoiVw6mnr+QGr9DhXDIL8aN/+Jq9/S4e1eLkSoCFcip/YmXT+ZVb99ZdYHy82jcX71rboO9iaCRKDjIllpedf+NQt9AHCacdfzYm5kEkEiUIlsWZTg6GVDzAZXf4dDvzwjgkSIEjm0OVGtJt71XYnZ4OrvJBKLdq99TISHECUScz3Hpbo9MTM86zgnROcR4SE4iZzd9xzGJ12qOxFBkp2TNnl288gb/5Cyxt7NViwmBzc/IQJDcMOUdy9nW9paELPEuoos/o6cCAzBWZGcTLWTrx0xS1z8HfJzBTcGISwrkvgwB1qZKh7l5YhkZqXs+3vFg/jrCkVe7ZotOrQd4upSDcLPnPvjyImNI4d8/8vW6UnPYj3cAtq07N80uBt71NXrhw8e/UEuz6xX5622rcrxPRJrexnRPHBIa9iqChEMwrIiMddyqHIrkVqtXrdxVMyDK726T5s0ZoutjdN364ckp2g6EWKJVC7P+vOvJX16zFgcca5Rg3bb/5yflv4UohKTorfsmBMS9N608TtDArvu+WspKU/EUupJrLCcVmFJJCNZRYkoUj7EPYp8lvygf++5dWqF2ts5d+8y1sba8dR/W9lYtVrZ8Z1h1XwaUhQFUoBB54TEexB+9vxORwf3jm8Ptba2D6jRpHlID1KewOlnpQnrWy9hNTSK/HJsiR88vCYWS2vWCGF3QQr+1YNjH1zVJfD1qs9uWMs0LZ08Lwv+JqfGu7vV0KXx8apHyhOKEqnyiaAQlkQkYqii8jJs8rxsMBXQZdUPtLV52epTlAEDlpubWdX55UsIFhYyUr4wYoGt8Cksidg6igreNCwH7Gyd4QIPCeM4EyJTioT2Ral86Rzk5+eQ8oShaZmtsFp/YUnEK0B263w2KR+8PGopFHJHR7eqTgXPVFNSE/StiEGqOHrcunOKpmlWTLfunibliVrNVPW2JEJCWIKtFezAMESeWS6tcU3/pnVqhv7x5wLoqmTnpJ85v2PlukEXruwzflTj+h1gRPXPv5aCAxsde/ns+R2kPGHUJLi1sB4+CG501VJGJcel+zQulxexhoQv++/irl+3z3oYf8OlarXgxl3eCu1r/JDaNZt36/z5fxd2TZnTAro2YR/NXbNhuKEX6cuAxDvJEgvKQmCDy4J7peivjQnxd/PqvO1HzI+7Jx9W9ZD2GiusV3QFNwDfdYiXWsnIsxXE/FDm0V2GCO49ViF+beDsKY2/llSrVZE306wF7Q2Gq1QKGPkw2Hd1d6kx5rP/kbLjx80T4x5dMxilVOZLpYZdzvkzj5IiiD6XYO8ssRHeI0yBvru6elK0X7CLrZPht95T0ww/Mc/Ly7ayMnyISCRxdCjLd5QyM5NVasOmLic308basMvpVMWTFMHNI3GjlwUQ4SHQb5YatrK7efZ5vfaGr7eRin5t2NtXLSrqFYp3+/jD6g2tiSAR6LurbT90s3eS3D8bT8yA2IsJMhvqvcFvXvcGEe7MAOEz/MRi+ua/caRSc/fkI7VCNWiOcN/1F/rXeFuXxqcnK+q08SOVkXv/PZJQZMhcQX8LUgG+6d389YPMFJVHbWcnn8rzznNmcnZ85HP7KuKPZwn9W6GKMTPAhcMpFw+liaUi95pVHD0rtlCyknOe3E5R5asbhNq17S30b75JxZpfZNfqx4lxeZSIsrCROrhZu/gJ6O09k6Q8Ts94kpOXpaBp4uZj8dEEX1JBqHizFJ3YlRR9LTcvW82wU2BS7IQw3ClndFCaue0KpivSTVCjnWVGf9qYgjS6+WNeZMaZgkgb+3KKGaogScGeJhPCyYFhpykizIupOq3tRL51ZR36e5AKRQWevVmZr7p3JTMjFUawKN1l0J9JytBcVKSo2ax4k2EVSsZVRMGOntD0J0nSJaAZSxvK1lHq38hGZiuwN4WKDU7wjZgAlwlATIASQUyAEkFMgBJBTIASQUyAEkFM8H8AAAD//3czrucAAAAGSURBVAMAxx4cIJZZTj4AAAAASUVORK5CYII=\n"
-          },
-          "metadata": {},
-          "execution_count": 47
-        }
-      ],
-      "source": [
-        "graph"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 48,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "fi3ulhYlEM4R",
-        "outputId": "c3fc21a3-2301-40ee-ccd4-774a442549bf"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "The context records: “On the eve of Christmas 2025, the Financial Times wrote, ‘Tech companies have moved more than $120bn of data centre spending off their balance sheets using special purpose” — the excerpt in the provided context is truncated and the remainder of the sentence is not included.\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(execute_graph(query))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "oPUSaxlVE3p_"
-      },
-      "source": [
-        "## Generate Testset using TruLens"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "sNOkVZ1pIT0D"
-      },
-      "source": [
-        "TruLens allows you to generate a test set of a specified breadth and depth, tailored to your app and data. The resulting test set will be a list of test prompts of length depth, for breadth categories of prompts. This test set will be made up of breadth X depth prompts organized by prompt category."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 50,
-      "metadata": {
-        "id": "tfoqJ-HhJx4W"
-      },
-      "outputs": [],
-      "source": [
-        "from trulens.providers.openai import OpenAI\n",
-        "from trulens.benchmark.generate.generate_test_set import GenerateTestSet"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 51,
-      "metadata": {
-        "id": "9wOymPjOE2sl"
-      },
-      "outputs": [],
-      "source": [
-        "test = GenerateTestSet(app_callable = execute_graph)\n",
-        "provider = OpenAI()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 32,
-      "metadata": {
-        "id": "VCiCzJ4dINsK"
-      },
-      "outputs": [],
-      "source": [
-        "test_set = test.generate_test_set(\n",
-        "    test_breadth=3,\n",
-        "    test_depth=2,\n",
-        ")\n",
-        "\n",
-        "# breadth = 3 → generate 3 categories\n",
-        "# depth = 2 → generate 2 questions"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 52,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "XJTmCFbqLAXu",
-        "outputId": "81868b42-187d-423f-d2db-68c2999a2f52"
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "{'Economic Growth': [\"What is the Survey's revised estimate of India’s potential growth rate, and how does it compare with the estimate from three years ago?\",\n",
-              "  'What nowcasting tool does the Survey introduce to assess near‑term GDP growth, and what type of indicators does it integrate?'],\n",
-              " 'Fiscal Consolidation': ['How does the Economic Survey say India’s fiscal credibility is supported by a deliberate shift toward capital formation and human capital investment?',\n",
-              "  'What risks to fiscal consolidation are identified from rising state revenue deficits and unconditional cash transfers (e.g., crowding out of capital expenditure and impacts on sovereign borrowing costs)?'],\n",
-              " 'Institutional Reform': ['Why does the Survey argue that process reforms are arguably more important than policy reforms for institutional reform?',\n",
-              "  'Which recent state-level initiatives does the Survey cite as grounds for optimism about institutional reform?']}"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 52
-        }
-      ],
-      "source": [
-        "test_set"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "M5b4LT-BMD3S"
-      },
-      "source": [
-        "## Run Evals\n",
-        "\n",
-        "Evaluate with TruLens feedbacks"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 76,
-      "metadata": {
-        "id": "YDXTlTmdMwt2"
-      },
-      "outputs": [],
-      "source": [
-        "import numpy as np\n",
-        "from trulens.core import Metric, Selector, Feedback\n",
-        "from trulens.apps.langgraph import TruGraph"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 77,
-      "metadata": {
-        "id": "pbPsTzwtLz8R"
-      },
-      "outputs": [],
-      "source": [
-        "f_answer_relevance = Metric(\n",
-        "    implementation=provider.relevance_with_cot_reasons,\n",
-        "    name=\"Answer Relevance\",\n",
-        "    selectors={\n",
-        "        \"prompt\": Selector.select_record_input(),\n",
-        "        \"response\": Selector.select_record_output(),\n",
-        "    },\n",
-        ")\n",
-        "\n",
-        "f_context_relevance = Metric(\n",
-        "    implementation=provider.context_relevance_with_cot_reasons,\n",
-        "    name=\"Context Relevance\",\n",
-        "    selectors={\n",
-        "        \"question\": Selector.select_record_input(),\n",
-        "        \"context\": Selector(\n",
-        "            span_type=SpanAttributes.SpanType.RETRIEVAL,\n",
-        "            span_attribute=SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS,\n",
-        "            collect_list=False,\n",
-        "        ),\n",
-        "    },\n",
-        "    agg=np.mean,\n",
-        ")\n",
-        "\n",
-        "f_groundedness = Metric(\n",
-        "    implementation=provider.groundedness_measure_with_cot_reasons,\n",
-        "    name=\"Groundedness\",\n",
-        "    selectors={\n",
-        "        \"source\": Selector(\n",
-        "            span_type=SpanAttributes.SpanType.RETRIEVAL,\n",
-        "            span_attribute=SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS,\n",
-        "            collect_list=True,\n",
-        "        ),\n",
-        "        \"statement\": Selector.select_record_output(),\n",
-        "    },\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 78,
-      "metadata": {
-        "id": "hJBVFyUuNT4H"
-      },
-      "outputs": [],
-      "source": [
-        "tru_recorder = TruGraph(\n",
-        "    execute_graph,\n",
-        "    app_name=\"evals_result\",\n",
-        "    app_version=\"v1\",\n",
-        "    feedbacks=[f_groundedness, f_answer_relevance, f_context_relevance],\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 80,
-      "metadata": {
-        "id": "Mp8xhyvtNa2g"
-      },
-      "outputs": [],
-      "source": [
-        "with tru_recorder as recording:\n",
-        "    for topic, questions in test_set.items():\n",
-        "        for question in questions:\n",
-        "            execute_graph(question)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "session.get_leaderboard()"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 112
-        },
-        "id": "MpiMFXAnqfZb",
-        "outputId": "339fe91e-c34e-4e41-cd79-75eabd63008f"
-      },
-      "execution_count": 81,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "                          Answer Relevance  Context Relevance  Groundedness  \\\n",
-              "app_name     app_version                                                      \n",
-              "evals_result v1                        1.0               0.25           1.0   \n",
-              "\n",
-              "                           latency  total_cost  \n",
-              "app_name     app_version                        \n",
-              "evals_result v1           8.401464    0.001232  "
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-e014ee99-fd25-4bbf-805f-9349d8bcdd04\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th></th>\n",
-              "      <th>Answer Relevance</th>\n",
-              "      <th>Context Relevance</th>\n",
-              "      <th>Groundedness</th>\n",
-              "      <th>latency</th>\n",
-              "      <th>total_cost</th>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>app_name</th>\n",
-              "      <th>app_version</th>\n",
-              "      <th></th>\n",
-              "      <th></th>\n",
-              "      <th></th>\n",
-              "      <th></th>\n",
-              "      <th></th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>evals_result</th>\n",
-              "      <th>v1</th>\n",
-              "      <td>1.0</td>\n",
-              "      <td>0.25</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>8.401464</td>\n",
-              "      <td>0.001232</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-e014ee99-fd25-4bbf-805f-9349d8bcdd04')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-e014ee99-fd25-4bbf-805f-9349d8bcdd04 button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-e014ee99-fd25-4bbf-805f-9349d8bcdd04');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "    </div>\n",
-              "  </div>\n"
-            ],
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "dataframe",
-              "summary": "{\n  \"name\": \"session\",\n  \"rows\": 1,\n  \"fields\": [\n    {\n      \"column\": \"Answer Relevance\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": null,\n        \"min\": 1.0,\n        \"max\": 1.0,\n        \"num_unique_values\": 1,\n        \"samples\": [\n          1.0\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Context Relevance\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": null,\n        \"min\": 0.25,\n        \"max\": 0.25,\n        \"num_unique_values\": 1,\n        \"samples\": [\n          0.25\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Groundedness\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": null,\n        \"min\": 1.0,\n        \"max\": 1.0,\n        \"num_unique_values\": 1,\n        \"samples\": [\n          1.0\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"latency\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": null,\n        \"min\": 8.401463666666666,\n        \"max\": 8.401463666666666,\n        \"num_unique_values\": 1,\n        \"samples\": [\n          8.401463666666666\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"total_cost\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": null,\n        \"min\": 0.0012322916666666667,\n        \"max\": 0.0012322916666666667,\n        \"num_unique_values\": 1,\n        \"samples\": [\n          0.0012322916666666667\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    }\n  ]\n}"
-            }
-          },
-          "metadata": {},
-          "execution_count": 81
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Check what spans are actually being recorded\n",
-        "records = session.get_records_and_feedback()[0]\n",
-        "records"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 929
-        },
-        "id": "KxHLTwVlNVpn",
-        "outputId": "2fe92977-2b59-4fbc-b2dd-4a15a46ae12c"
-      },
-      "execution_count": 83,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "                                      app_id      app_name app_version  \\\n",
-              "0  app_hash_589175e4eb00ba4c5ebdb61570e59ce7  evals_result          v1   \n",
-              "1  app_hash_589175e4eb00ba4c5ebdb61570e59ce7  evals_result          v1   \n",
-              "2  app_hash_589175e4eb00ba4c5ebdb61570e59ce7  evals_result          v1   \n",
-              "3  app_hash_589175e4eb00ba4c5ebdb61570e59ce7  evals_result          v1   \n",
-              "4  app_hash_589175e4eb00ba4c5ebdb61570e59ce7  evals_result          v1   \n",
-              "5  app_hash_589175e4eb00ba4c5ebdb61570e59ce7  evals_result          v1   \n",
-              "\n",
-              "                                            app_json  type  \\\n",
-              "0  {'app_name': 'evals_result', 'app_version': 'v...  SPAN   \n",
-              "1  {'app_name': 'evals_result', 'app_version': 'v...  SPAN   \n",
-              "2  {'app_name': 'evals_result', 'app_version': 'v...  SPAN   \n",
-              "3  {'app_name': 'evals_result', 'app_version': 'v...  SPAN   \n",
-              "4  {'app_name': 'evals_result', 'app_version': 'v...  SPAN   \n",
-              "5  {'app_name': 'evals_result', 'app_version': 'v...  SPAN   \n",
-              "\n",
-              "                              record_id input_id  \\\n",
-              "0  775aedc4-f969-4d5d-adc4-d83196e9a5a0            \n",
-              "1  89ceccfa-0214-4016-ad06-54637649757a            \n",
-              "2  048ad1b1-f213-458b-a7e3-f292d5e1aaf5            \n",
-              "3  0c14b81d-bfcb-48e4-ad51-4aaef58529c1            \n",
-              "4  df773d22-597e-4889-bfd4-bc507755a5e3            \n",
-              "5  b956f68d-a4c9-4f8d-b34c-d4158249370b            \n",
-              "\n",
-              "                                               input  \\\n",
-              "0  What is the Survey's revised estimate of India...   \n",
-              "1  What nowcasting tool does the Survey introduce...   \n",
-              "2  How does the Economic Survey say India’s fisca...   \n",
-              "3  What risks to fiscal consolidation are identif...   \n",
-              "4  Why does the Survey argue that process reforms...   \n",
-              "5  Which recent state-level initiatives does the ...   \n",
-              "\n",
-              "                                              output tags  ...  \\\n",
-              "0  The Survey revises India’s potential growth ra...       ...   \n",
-              "1  The Survey introduces a nowcasting model — a n...       ...   \n",
-              "2  The Survey says India’s fiscal credibility res...       ...   \n",
-              "3  The context identifies several linked risks to...       ...   \n",
-              "4  The Survey argues that process reforms matter ...       ...   \n",
-              "5  The Survey points to recent state-level deregu...       ...   \n",
-              "\n",
-              "  Groundedness feedback cost in USD Groundedness direction Answer Relevance  \\\n",
-              "0                          0.000080                   True              1.0   \n",
-              "1                          0.000086                   True              1.0   \n",
-              "2                          0.000357                   True              1.0   \n",
-              "3                          0.000313                   True              1.0   \n",
-              "4                               NaN                    NaN              NaN   \n",
-              "5                          0.000069                   True              1.0   \n",
-              "\n",
-              "                              Answer Relevance_calls  \\\n",
-              "0  [{'span_type': 'eval', 'args': {'prompt': 'Wha...   \n",
-              "1  [{'span_type': 'eval', 'args': {'prompt': 'Wha...   \n",
-              "2  [{'span_type': 'eval', 'args': {'prompt': 'How...   \n",
-              "3  [{'span_type': 'eval', 'args': {'prompt': 'Wha...   \n",
-              "4                                                NaN   \n",
-              "5  [{'span_type': 'eval', 'args': {'prompt': 'Whi...   \n",
-              "\n",
-              "   Answer Relevance feedback cost in USD  Answer Relevance direction  \\\n",
-              "0                                    0.0                        True   \n",
-              "1                                    0.0                        True   \n",
-              "2                                    0.0                        True   \n",
-              "3                                    0.0                        True   \n",
-              "4                                    NaN                         NaN   \n",
-              "5                                    0.0                        True   \n",
-              "\n",
-              "   Context Relevance                            Context Relevance_calls  \\\n",
-              "0           0.250000  [{'span_type': 'eval', 'args': {'question': 'W...   \n",
-              "1           0.250000  [{'span_type': 'eval', 'args': {'question': 'W...   \n",
-              "2           0.500000  [{'span_type': 'eval', 'args': {'question': 'H...   \n",
-              "3           0.500000  [{'span_type': 'eval', 'args': {'question': 'W...   \n",
-              "4                NaN                                                NaN   \n",
-              "5           0.166667  [{'span_type': 'eval', 'args': {'question': 'W...   \n",
-              "\n",
-              "   Context Relevance feedback cost in USD Context Relevance direction  \n",
-              "0                                     0.0                        True  \n",
-              "1                                     0.0                        True  \n",
-              "2                                     0.0                        True  \n",
-              "3                                     0.0                        True  \n",
-              "4                                     NaN                         NaN  \n",
-              "5                                     0.0                        True  \n",
-              "\n",
-              "[6 rows x 33 columns]"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-0db00144-22da-4a41-ae0e-11e60c51ce11\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>app_id</th>\n",
-              "      <th>app_name</th>\n",
-              "      <th>app_version</th>\n",
-              "      <th>app_json</th>\n",
-              "      <th>type</th>\n",
-              "      <th>record_id</th>\n",
-              "      <th>input_id</th>\n",
-              "      <th>input</th>\n",
-              "      <th>output</th>\n",
-              "      <th>tags</th>\n",
-              "      <th>...</th>\n",
-              "      <th>Groundedness feedback cost in USD</th>\n",
-              "      <th>Groundedness direction</th>\n",
-              "      <th>Answer Relevance</th>\n",
-              "      <th>Answer Relevance_calls</th>\n",
-              "      <th>Answer Relevance feedback cost in USD</th>\n",
-              "      <th>Answer Relevance direction</th>\n",
-              "      <th>Context Relevance</th>\n",
-              "      <th>Context Relevance_calls</th>\n",
-              "      <th>Context Relevance feedback cost in USD</th>\n",
-              "      <th>Context Relevance direction</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>app_hash_589175e4eb00ba4c5ebdb61570e59ce7</td>\n",
-              "      <td>evals_result</td>\n",
-              "      <td>v1</td>\n",
-              "      <td>{'app_name': 'evals_result', 'app_version': 'v...</td>\n",
-              "      <td>SPAN</td>\n",
-              "      <td>775aedc4-f969-4d5d-adc4-d83196e9a5a0</td>\n",
-              "      <td></td>\n",
-              "      <td>What is the Survey's revised estimate of India...</td>\n",
-              "      <td>The Survey revises India’s potential growth ra...</td>\n",
-              "      <td></td>\n",
-              "      <td>...</td>\n",
-              "      <td>0.000080</td>\n",
-              "      <td>True</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>[{'span_type': 'eval', 'args': {'prompt': 'Wha...</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>True</td>\n",
-              "      <td>0.250000</td>\n",
-              "      <td>[{'span_type': 'eval', 'args': {'question': 'W...</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>True</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>app_hash_589175e4eb00ba4c5ebdb61570e59ce7</td>\n",
-              "      <td>evals_result</td>\n",
-              "      <td>v1</td>\n",
-              "      <td>{'app_name': 'evals_result', 'app_version': 'v...</td>\n",
-              "      <td>SPAN</td>\n",
-              "      <td>89ceccfa-0214-4016-ad06-54637649757a</td>\n",
-              "      <td></td>\n",
-              "      <td>What nowcasting tool does the Survey introduce...</td>\n",
-              "      <td>The Survey introduces a nowcasting model — a n...</td>\n",
-              "      <td></td>\n",
-              "      <td>...</td>\n",
-              "      <td>0.000086</td>\n",
-              "      <td>True</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>[{'span_type': 'eval', 'args': {'prompt': 'Wha...</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>True</td>\n",
-              "      <td>0.250000</td>\n",
-              "      <td>[{'span_type': 'eval', 'args': {'question': 'W...</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>True</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>app_hash_589175e4eb00ba4c5ebdb61570e59ce7</td>\n",
-              "      <td>evals_result</td>\n",
-              "      <td>v1</td>\n",
-              "      <td>{'app_name': 'evals_result', 'app_version': 'v...</td>\n",
-              "      <td>SPAN</td>\n",
-              "      <td>048ad1b1-f213-458b-a7e3-f292d5e1aaf5</td>\n",
-              "      <td></td>\n",
-              "      <td>How does the Economic Survey say India’s fisca...</td>\n",
-              "      <td>The Survey says India’s fiscal credibility res...</td>\n",
-              "      <td></td>\n",
-              "      <td>...</td>\n",
-              "      <td>0.000357</td>\n",
-              "      <td>True</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>[{'span_type': 'eval', 'args': {'prompt': 'How...</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>True</td>\n",
-              "      <td>0.500000</td>\n",
-              "      <td>[{'span_type': 'eval', 'args': {'question': 'H...</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>True</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>3</th>\n",
-              "      <td>app_hash_589175e4eb00ba4c5ebdb61570e59ce7</td>\n",
-              "      <td>evals_result</td>\n",
-              "      <td>v1</td>\n",
-              "      <td>{'app_name': 'evals_result', 'app_version': 'v...</td>\n",
-              "      <td>SPAN</td>\n",
-              "      <td>0c14b81d-bfcb-48e4-ad51-4aaef58529c1</td>\n",
-              "      <td></td>\n",
-              "      <td>What risks to fiscal consolidation are identif...</td>\n",
-              "      <td>The context identifies several linked risks to...</td>\n",
-              "      <td></td>\n",
-              "      <td>...</td>\n",
-              "      <td>0.000313</td>\n",
-              "      <td>True</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>[{'span_type': 'eval', 'args': {'prompt': 'Wha...</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>True</td>\n",
-              "      <td>0.500000</td>\n",
-              "      <td>[{'span_type': 'eval', 'args': {'question': 'W...</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>True</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>4</th>\n",
-              "      <td>app_hash_589175e4eb00ba4c5ebdb61570e59ce7</td>\n",
-              "      <td>evals_result</td>\n",
-              "      <td>v1</td>\n",
-              "      <td>{'app_name': 'evals_result', 'app_version': 'v...</td>\n",
-              "      <td>SPAN</td>\n",
-              "      <td>df773d22-597e-4889-bfd4-bc507755a5e3</td>\n",
-              "      <td></td>\n",
-              "      <td>Why does the Survey argue that process reforms...</td>\n",
-              "      <td>The Survey argues that process reforms matter ...</td>\n",
-              "      <td></td>\n",
-              "      <td>...</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>NaN</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>5</th>\n",
-              "      <td>app_hash_589175e4eb00ba4c5ebdb61570e59ce7</td>\n",
-              "      <td>evals_result</td>\n",
-              "      <td>v1</td>\n",
-              "      <td>{'app_name': 'evals_result', 'app_version': 'v...</td>\n",
-              "      <td>SPAN</td>\n",
-              "      <td>b956f68d-a4c9-4f8d-b34c-d4158249370b</td>\n",
-              "      <td></td>\n",
-              "      <td>Which recent state-level initiatives does the ...</td>\n",
-              "      <td>The Survey points to recent state-level deregu...</td>\n",
-              "      <td></td>\n",
-              "      <td>...</td>\n",
-              "      <td>0.000069</td>\n",
-              "      <td>True</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>[{'span_type': 'eval', 'args': {'prompt': 'Whi...</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>True</td>\n",
-              "      <td>0.166667</td>\n",
-              "      <td>[{'span_type': 'eval', 'args': {'question': 'W...</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>True</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "<p>6 rows × 33 columns</p>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-0db00144-22da-4a41-ae0e-11e60c51ce11')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-0db00144-22da-4a41-ae0e-11e60c51ce11 button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-0db00144-22da-4a41-ae0e-11e60c51ce11');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "  <div id=\"id_2231965c-9ccb-49a7-93ba-0f20ad9746c6\">\n",
-              "    <style>\n",
-              "      .colab-df-generate {\n",
-              "        background-color: #E8F0FE;\n",
-              "        border: none;\n",
-              "        border-radius: 50%;\n",
-              "        cursor: pointer;\n",
-              "        display: none;\n",
-              "        fill: #1967D2;\n",
-              "        height: 32px;\n",
-              "        padding: 0 0 0 0;\n",
-              "        width: 32px;\n",
-              "      }\n",
-              "\n",
-              "      .colab-df-generate:hover {\n",
-              "        background-color: #E2EBFA;\n",
-              "        box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "        fill: #174EA6;\n",
-              "      }\n",
-              "\n",
-              "      [theme=dark] .colab-df-generate {\n",
-              "        background-color: #3B4455;\n",
-              "        fill: #D2E3FC;\n",
-              "      }\n",
-              "\n",
-              "      [theme=dark] .colab-df-generate:hover {\n",
-              "        background-color: #434B5C;\n",
-              "        box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "        filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "        fill: #FFFFFF;\n",
-              "      }\n",
-              "    </style>\n",
-              "    <button class=\"colab-df-generate\" onclick=\"generateWithVariable('records')\"\n",
-              "            title=\"Generate code using this dataframe.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "       width=\"24px\">\n",
-              "    <path d=\"M7,19H8.4L18.45,9,17,7.55,7,17.6ZM5,21V16.75L18.45,3.32a2,2,0,0,1,2.83,0l1.4,1.43a1.91,1.91,0,0,1,.58,1.4,1.91,1.91,0,0,1-.58,1.4L9.25,21ZM18.45,9,17,7.55Zm-12,3A5.31,5.31,0,0,0,4.9,8.1,5.31,5.31,0,0,0,1,6.5,5.31,5.31,0,0,0,4.9,4.9,5.31,5.31,0,0,0,6.5,1,5.31,5.31,0,0,0,8.1,4.9,5.31,5.31,0,0,0,12,6.5,5.46,5.46,0,0,0,6.5,12Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "    <script>\n",
-              "      (() => {\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#id_2231965c-9ccb-49a7-93ba-0f20ad9746c6 button.colab-df-generate');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      buttonEl.onclick = () => {\n",
-              "        google.colab.notebook.generateWithVariable('records');\n",
-              "      }\n",
-              "      })();\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "    </div>\n",
-              "  </div>\n"
-            ],
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "dataframe",
-              "variable_name": "records"
-            }
-          },
-          "metadata": {},
-          "execution_count": 83
-        }
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generate TestSet Questions to evaluate your RAG pipeline\n",
+    "\n",
+    "> Tech Stack: [LangGraph](https://github.com/langchain-ai/langchain), [Qdrant](https://github.com/qdrant/qdrant), [OpenAI](https://platform.openai.com/) and [TruLens](https://github.com/truera/trulens)\n",
+    "\n",
+    "> TruLens benchmark to generate the questions"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Installation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install langgraph langchain-community langchain-openai langchain-qdrant pypdfium2\n",
+    "!pip install trulens \"trulens-benchmark\"\n",
+    "!pip install trulens-providers-openai\n",
+    "!pip install trulens-apps-langgraph"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initial Setup\n",
+    "\n",
+    "Install the required libraries and configure API keys for OpenAI and Qdrant. A TruLens session is initialized here to track and store all evaluation data throughout the notebook.\n",
+    "\n",
+    "- Get OpenAI API Key: [https://platform.openai.com/](https://platform.openai.com/)\n",
+    "- Get Qdrant API Key and Endpoint URL: [https://cloud.qdrant.io/](https://cloud.qdrant.io/)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from google.colab import userdata\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = userdata.get(\"OPENAI_API_KEY\")\n",
+    "QDRANT_URL = userdata.get(\"QDRANT_URL\")\n",
+    "QDRANT_API_KEY = userdata.get(\"QDRANT_API_KEY\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Overview\n",
+    "\n",
+    "We will generate a dataset to evaluate the RAG pipeline built using LangGraph and Qdrant, and assess it using the RAG Triad evaluation metrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_community.document_loaders import PyPDFium2Loader\n",
+    "from langchain_openai import OpenAIEmbeddings\n",
+    "from langchain_qdrant import QdrantVectorStore\n",
+    "from langchain_text_splitters import RecursiveCharacterTextSplitter\n",
+    "from qdrant_client import QdrantClient\n",
+    "from qdrant_client import models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.core import TruSession\n",
+    "\n",
+    "session = TruSession()\n",
+    "session.reset_database()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data loading and chunking\n",
+    "\n",
+    "The Economic Survey 2025-26 report is downloaded and parsed using PyPDFium2. It is then split into overlapping chunks using Langchain's RecursiveCharacterTextSplitter to prepare the text for embedding and retrieval.\n",
+    "\n",
+    "> Economic Survey 2025-26 by Government of India: [Survey Report](https://www.indiabudget.gov.in/economicsurvey/doc/eschapter/epreface.pdf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -L -A \"Mozilla/5.0\" https://www.indiabudget.gov.in/economicsurvey/doc/eschapter/epreface.pdf -o survey.pdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = \"survey.pdf\"\n",
+    "loader = PyPDFium2Loader(path)\n",
+    "docs = loader.load()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(len(docs))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(docs[1].page_content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(docs[1].metadata)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text_splitter = RecursiveCharacterTextSplitter(\n",
+    "    chunk_size=1536,\n",
+    "    chunk_overlap=0,\n",
+    ")\n",
+    "chunks = text_splitter.split_documents(docs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup your Qdrant Vector Database\n",
+    "\n",
+    "A Qdrant collection is configured using dense vectors generated from OpenAI embeddings, enabling semantic search based on meaning and contextual similarity. Each document or chunk is converted into its corresponding embedding and indexed within the collection along with its associated metadata.\n",
+    "\n",
+    "During retrieval, the query is embedded into the same vector space and matched against the indexed vectors to return the most semantically relevant results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "embeddings_model = OpenAIEmbeddings(model=\"text-embedding-3-small\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(len(embeddings_model.embed_query(\"this is testing to check dimensions\")))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection_name = \"economicv1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = QdrantClient(url=QDRANT_URL, api_key=QDRANT_API_KEY)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.create_collection(\n",
+    "    collection_name=collection_name,\n",
+    "    vectors_config={\n",
+    "        \"dense\": models.VectorParams(size=1536, distance=models.Distance.COSINE)\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "db = QdrantVectorStore(\n",
+    "    client=client,\n",
+    "    collection_name=collection_name,\n",
+    "    embedding=embeddings_model,\n",
+    "    vector_name=\"dense\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Test the retriver"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "db.add_documents(\n",
+    "    documents=chunks\n",
+    ")  # just run it once. After the data is indexed, you need not have to add_documents again"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"what is Financial Time wrote on the eve of Christmas 2025\"\n",
+    "relevant_docs = db.max_marginal_relevance_search(query)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "relevant_docs[0].page_content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Convert to the retriever: i.e., Langchain object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "retriever = db.as_retriever()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(retriever.invoke(query)[0].page_content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build your LangGraph RAG workflow - Answer Generation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_openai import ChatOpenAI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm = ChatOpenAI(model_name=\"gpt-5-mini\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SYSTEM_PROMPT = \"\"\"\n",
+    "  You are an expert financial analyst specializing in corporate finance.\n",
+    "  You should be respectful and truthful while answering the user questions, if not you will face serious consequences.\n",
+    "\n",
+    "  The only source information you have is the context provided, if the user query is not from the context\n",
+    "  Just say `I dont know , not enough information provided.`\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "USER_PROMPT = \"\"\"\n",
+    "  Answer the USER QUERY based on the CONTEXT below.\n",
+    "  If the question cannot be answered using the information provided answer with `I dont know , not enough information provided.`\n",
+    "\n",
+    "  <context>\n",
+    "  CONTEXT: {context}\n",
+    "  </context>\n",
+    "\n",
+    "  <query>\n",
+    "  USER QUERY: {query}\n",
+    "  </query>\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import List, TypedDict\n",
+    "\n",
+    "from langgraph.graph import END\n",
+    "from langgraph.graph import START\n",
+    "from langgraph.graph import StateGraph  # node and edges logic\n",
+    "from trulens.core.otel.instrument import instrument\n",
+    "from trulens.otel.semconv.trace import SpanAttributes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class RAGState(TypedDict):\n",
+    "    query: str\n",
+    "    context: List[str]\n",
+    "    answer: str"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@instrument(\n",
+    "    span_type=SpanAttributes.SpanType.RETRIEVAL,\n",
+    "    attributes={\n",
+    "        SpanAttributes.RETRIEVAL.QUERY_TEXT: \"query\",\n",
+    "        SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS: \"return\",\n",
+    "    },\n",
+    ")\n",
+    "def retrieve_docs(query: str) -> list:\n",
+    "    results = db.max_marginal_relevance_search(query=query, k=4)\n",
+    "    return [result.page_content for result in results]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@instrument(span_type=SpanAttributes.SpanType.GENERATION)\n",
+    "def generate_answer(context: str, query: str) -> str:\n",
+    "    messages = [\n",
+    "        {\"role\": \"system\", \"content\": SYSTEM_PROMPT},\n",
+    "        {\n",
+    "            \"role\": \"user\",\n",
+    "            \"content\": USER_PROMPT.format(context=context, query=query),\n",
+    "        },\n",
+    "    ]\n",
+    "    response = llm.invoke(messages)\n",
+    "    return response.content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@instrument(\n",
+    "    span_type=SpanAttributes.SpanType.RECORD_ROOT,\n",
+    "    attributes={\n",
+    "        SpanAttributes.RECORD_ROOT.INPUT: \"question\",\n",
+    "        SpanAttributes.RECORD_ROOT.OUTPUT: \"return\",\n",
+    "    },\n",
+    ")\n",
+    "def execute_graph(question: str) -> str:\n",
+    "    result = graph.invoke({\"query\": question})\n",
+    "    return result[\"answer\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def search(state: RAGState) -> RAGState:\n",
+    "    state[\"context\"] = retrieve_docs(state[\"query\"])\n",
+    "    return state\n",
+    "\n",
+    "\n",
+    "def answer(state: RAGState) -> RAGState:\n",
+    "    context = \"\\n\".join(state[\"context\"])\n",
+    "    state[\"answer\"] = generate_answer(context, state[\"query\"])\n",
+    "    return state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Agent - workflows\n",
+    "workflow = StateGraph(RAGState)\n",
+    "workflow.add_node(\"search_context\", search)\n",
+    "workflow.add_node(\"answer_generation\", answer)\n",
+    "\n",
+    "workflow.add_edge(START, \"search_context\")\n",
+    "workflow.add_edge(\"search_context\", \"answer_generation\")\n",
+    "workflow.add_edge(\"answer_generation\", END)\n",
+    "\n",
+    "graph = workflow.compile()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(execute_graph(query))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate Testset using TruLens"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "TruLens allows you to generate a test set of a specified breadth and depth, tailored to your app and data. The resulting test set will be a list of test prompts of length depth, for breadth categories of prompts. This test set will be made up of breadth X depth prompts organized by prompt category."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.benchmark.generate.generate_test_set import GenerateTestSet\n",
+    "from trulens.providers.openai import OpenAI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test = GenerateTestSet(app_callable=execute_graph)\n",
+    "provider = OpenAI()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_set = test.generate_test_set(\n",
+    "    test_breadth=3,\n",
+    "    test_depth=2,\n",
+    ")\n",
+    "\n",
+    "# breadth = 3 → generate 3 categories\n",
+    "# depth = 2 → generate 2 questions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_set"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run Evals\n",
+    "\n",
+    "Evaluate with TruLens feedbacks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from trulens.apps.langgraph import TruGraph\n",
+    "from trulens.core import Metric\n",
+    "from trulens.core import Selector"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f_answer_relevance = Metric(\n",
+    "    implementation=provider.relevance_with_cot_reasons,\n",
+    "    name=\"Answer Relevance\",\n",
+    "    selectors={\n",
+    "        \"prompt\": Selector.select_record_input(),\n",
+    "        \"response\": Selector.select_record_output(),\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "f_context_relevance = Metric(\n",
+    "    implementation=provider.context_relevance_with_cot_reasons,\n",
+    "    name=\"Context Relevance\",\n",
+    "    selectors={\n",
+    "        \"question\": Selector.select_record_input(),\n",
+    "        \"context\": Selector(\n",
+    "            span_type=SpanAttributes.SpanType.RETRIEVAL,\n",
+    "            span_attribute=SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS,\n",
+    "            collect_list=False,\n",
+    "        ),\n",
+    "    },\n",
+    "    agg=np.mean,\n",
+    ")\n",
+    "\n",
+    "f_groundedness = Metric(\n",
+    "    implementation=provider.groundedness_measure_with_cot_reasons,\n",
+    "    name=\"Groundedness\",\n",
+    "    selectors={\n",
+    "        \"source\": Selector(\n",
+    "            span_type=SpanAttributes.SpanType.RETRIEVAL,\n",
+    "            span_attribute=SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS,\n",
+    "            collect_list=True,\n",
+    "        ),\n",
+    "        \"statement\": Selector.select_record_output(),\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tru_recorder = TruGraph(\n",
+    "    execute_graph,\n",
+    "    app_name=\"evals_result\",\n",
+    "    app_version=\"v1\",\n",
+    "    feedbacks=[f_groundedness, f_answer_relevance, f_context_relevance],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with tru_recorder as recording:\n",
+    "    for topic, questions in test_set.items():\n",
+    "        for question in questions:\n",
+    "            execute_graph(question)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session.get_leaderboard()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check what spans are actually being recorded\n",
+    "records = session.get_records_and_feedback()[0]\n",
+    "records"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
## Summary
- **Add Azure Pipelines `Cache@2` task** for pip packages keyed on python version + poetry.lock
- **Stop destroying pip cache** — removed `pip cache purge` and `rm -rf ~/.cache/pip` from `env-setup.yaml` and `run-tests.yaml`
- **Remove `--no-cache-dir`** from all `pip install` commands in Makefile
- **Increase `timeoutInMinutes`** from 30 → 45 as a safety net
- **Propagate `PIP_CACHE_DIR`** env var to test steps via `run-tests.yaml`

## Context
Since April 14, CI builds have been consistently timing out at 30+ minutes. Root cause: pip packages (~30+ transitive deps including heavy ones like `unstructured` → spacy → thinc/blis/cymem) are installed from scratch on every run because the pipeline actively destroys all pip caches before and between test suites.

**Before**: `env-tests-optional` step alone took 1200-1555s (20-26 min) on recent builds.
**Expected after**: First run unchanged, subsequent runs should see significant speedup from cached wheels.

## Test plan
- [ ] Verify CI pipeline passes with caching enabled
- [ ] Compare build times before/after (especially `env-tests-optional` step)
- [ ] Confirm cache hit on second run of same python version

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)