### PR TITLE
Add GOVERNANCE.md and update MAINTAINERS.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,33 @@
+# Governance
+
+## Overview
+
+TruLens is an open source project maintained by Snowflake's AI Observability team. Development is primarily led by a small core team, with contributions welcome from the community.
+
+## Project Lead
+
+Josh Reini ([@joshreini1](https://github.com/joshreini1)) serves as the project lead and primary decision-maker for TruLens. This includes decisions on roadmap, architecture, release cadence, and accepting contributions.
+
+## Maintainers
+
+The current maintainers are listed in [MAINTAINERS.md](./MAINTAINERS.md). Maintainers have write access to the repository and are responsible for reviewing and merging pull requests.
+
+## Decision Making
+
+Day-to-day decisions are made by the project lead. For larger changes (new features, breaking API changes, architectural shifts), the process is:
+
+1. Open a GitHub issue or discussion describing the proposal.
+2. Gather feedback from maintainers and the community.
+3. The project lead makes the final call, documenting the rationale in the issue.
+
+## Contributing
+
+Contributions are welcome via pull requests. All PRs are reviewed by one or more maintainers before merging. See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup and guidelines.
+
+## Evolving Governance
+
+This governance model reflects the current state of the project. As the contributor community grows, we expect to adopt more formal processes (such as shared decision-making among maintainers or a steering committee). Changes to this document will be proposed via pull request and approved by the project lead.
+
+---
+
+Adapted from [GitHub's Minimum Viable Governance](https://github.com/github/MVG). Licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,10 +2,11 @@ The current maintainers of _TruLens_ are:
 
 | Name | Employer | Github Name |
 | ---- | -------- | ---------------- |
-| Daniel Huang | Snowflake | sfc-gh-dhuang |
+| Alex Issa | Snowflake | A5Wagyu32 |
+| Anupam Datta | Snowflake | sfc-gh-adatta |
+| Daniel Huang | Snowflake | daniel-huang-1230 |
 | David Kurokawa | Snowflake | sfc-gh-dkurokawa |
-| Garett Tok Ern Liang | Snowflake | sfc-gh-gtokernliang  |
-| Josh Reini | Snowflake | sfc-gh-jreini |
-| Nikhil Vytla | Snowflake | sfc-gh-nvytla |
-| Prudhvi Dharmana | Snowflake | sfc-gh-pdharmana |
+| Garett Tok Ern Liang | Snowflake | sfc-gh-gtokernliang |
+| Josh Reini | Snowflake | joshreini1 |
 | Shayak Sen | Snowflake | sfc-gh-shsen |
+| Stan Rudenko | Snowflake | sfc-gh-srudenko |


### PR DESCRIPTION
## Summary
- Add lightweight GOVERNANCE.md adapted from [GitHub's MVG framework](https://github.com/github/MVG)
- Update MAINTAINERS.md to reflect the current maintainer team
  - Add Alex Issa, Anupam Datta, and Stan Rudenko
  - Remove Nikhil Vytla and Prudhvi Dharmana
  - Update GitHub handles to current usernames
  - Sort list alphabetically

## Test plan
- [x] Verify markdown tables render correctly
- [x] Verify links between GOVERNANCE.md and MAINTAINERS.md resolve

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)