### PR TITLE
Add SchemaValidation: non-LLM programmatic feedback for JSON schema / Pydantic output validation

### DIFF
--- a/src/feedback/trulens/feedback/__init__.py
+++ b/src/feedback/trulens/feedback/__init__.py
@@ -6,6 +6,7 @@ from trulens.core.utils import imports as import_utils
 from trulens.feedback.groundtruth import GroundTruthAggregator
 from trulens.feedback.groundtruth import GroundTruthAgreement
 from trulens.feedback.llm_provider import LLMProvider
+from trulens.feedback.schema_validator import SchemaValidator
 
 with import_utils.OptionalImports(
     messages=import_utils.format_import_errors(
@@ -24,4 +25,5 @@ __all__ = [
     "GroundTruthAggregator",
     "LLMProvider",
     "Embeddings",
+    "SchemaValidator",
 ]

--- a/src/feedback/trulens/feedback/schema_validator.py
+++ b/src/feedback/trulens/feedback/schema_validator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Dict, Optional, Tuple, Type, Union, cast
+from typing import Any, cast
 
 import pydantic
 from trulens.core.utils import imports as import_utils
@@ -18,7 +18,7 @@ with import_utils.OptionalImports(
 
 logger = logging.getLogger(__name__)
 
-_SchemaType = Union[Dict[str, Any], Type[pydantic.BaseModel]]
+_SchemaType = dict[str, Any] | type[pydantic.BaseModel]
 
 
 class SchemaValidator(pyschema_utils.WithClassInfo, serial_utils.SerialModel):
@@ -73,30 +73,32 @@ class SchemaValidator(pyschema_utils.WithClassInfo, serial_utils.SerialModel):
         super().__init__(**kwargs)
         if not (
             isinstance(schema, dict)
-            or (isinstance(schema, type) and issubclass(schema, pydantic.BaseModel))
+            or (
+                isinstance(schema, type)
+                and issubclass(schema, pydantic.BaseModel)
+            )
         ):
             raise TypeError(
                 "`schema` must be a JSON schema dict or a Pydantic BaseModel class."
             )
         self._schema = schema
 
-
-    def _validate_with_jsonschema(
-        self, data: Any
-    ) -> Tuple[bool, Optional[str]]:
+    def _validate_with_jsonschema(self, data: Any) -> tuple[bool, str | None]:
         _jsonschema_opt.assert_installed(jsonschema)
         try:
-            jsonschema.validate(instance=data, schema=cast(Dict[str, Any], self._schema))
+            jsonschema.validate(
+                instance=data, schema=cast(dict[str, Any], self._schema)
+            )
             return True, None
         except jsonschema.ValidationError as exc:
             return False, exc.message
         except jsonschema.SchemaError as exc:
-            raise ValueError(f"Invalid JSON schema provided: {exc.message}") from exc
+            raise ValueError(
+                f"Invalid JSON schema provided: {exc.message}"
+            ) from exc
 
-    def _validate_with_pydantic(
-        self, data: Any
-    ) -> Tuple[bool, Optional[str]]:
-        model_cls = cast(Type[pydantic.BaseModel], self._schema)
+    def _validate_with_pydantic(self, data: Any) -> tuple[bool, str | None]:
+        model_cls = cast(type[pydantic.BaseModel], self._schema)
         try:
             model_cls.model_validate(data)
             return True, None
@@ -107,9 +109,7 @@ class SchemaValidator(pyschema_utils.WithClassInfo, serial_utils.SerialModel):
             )
             return False, errors
 
-    def _parse_and_validate(
-        self, output: str
-    ) -> Tuple[float, Dict[str, str]]:
+    def _parse_and_validate(self, output: str) -> tuple[float, dict[str, str]]:
         """Parse *output* as JSON and validate against the stored schema.
 
         Returns:
@@ -131,9 +131,7 @@ class SchemaValidator(pyschema_utils.WithClassInfo, serial_utils.SerialModel):
             return 1.0, {"explanation": "Output conforms to the schema."}
         return 0.0, {"explanation": f"Schema validation failed: {error_msg}"}
 
-    def validate_json(
-        self, output: str
-    ) -> Tuple[float, Dict[str, str]]:
+    def validate_json(self, output: str) -> tuple[float, dict[str, str]]:
         """Validate that *output* is valid JSON conforming to the schema.
 
         Returns ``1.0`` when valid, ``0.0`` otherwise.  The accompanying
@@ -150,8 +148,8 @@ class SchemaValidator(pyschema_utils.WithClassInfo, serial_utils.SerialModel):
         return self._parse_and_validate(output)
 
     def validate_json_partial(
-        self, output: str, required_keys: Optional[list] = None
-    ) -> Tuple[float, Dict[str, str]]:
+        self, output: str, required_keys: list | None = None
+    ) -> tuple[float, dict[str, str]]:
         """Validate that *output* is valid JSON and optionally check for keys.
 
         This is a lighter-weight check: it verifies that *output* parses as a
@@ -180,8 +178,11 @@ class SchemaValidator(pyschema_utils.WithClassInfo, serial_utils.SerialModel):
         if required_keys:
             missing = [k for k in required_keys if k not in data]
             if missing:
-                return 0.0, {
-                    "explanation": f"Missing required keys: {missing}"
-                }
+                return 0.0, {"explanation": f"Missing required keys: {missing}"}
 
-        return 1.0, {"explanation": "Output is a valid JSON object with all required keys."}
+        return (
+            1.0,
+            {
+                "explanation": "Output is a valid JSON object with all required keys."
+            },
+        )

--- a/src/feedback/trulens/feedback/schema_validator.py
+++ b/src/feedback/trulens/feedback/schema_validator.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Optional, Tuple, Type, Union, cast
+
+import pydantic
+from trulens.core.utils import imports as import_utils
+from trulens.core.utils import pyschema as pyschema_utils
+from trulens.core.utils import serial as serial_utils
+
+with import_utils.OptionalImports(
+    messages=import_utils.format_import_errors(
+        "jsonschema", purpose="validating output against a JSON schema dict"
+    )
+) as _jsonschema_opt:
+    import jsonschema
+
+logger = logging.getLogger(__name__)
+
+_SchemaType = Union[Dict[str, Any], Type[pydantic.BaseModel]]
+
+
+class SchemaValidator(pyschema_utils.WithClassInfo, serial_utils.SerialModel):
+    """Non-LLM feedback functions for validating LLM output against a schema.
+
+    Accepts either a JSON schema dict (requires `jsonschema`) or a Pydantic
+    model class.  Each method returns `1.0` when the output is valid and `0.0`
+    otherwise, along with a metadata dict that contains any validation errors.
+
+    Example — JSON schema dict:
+        ```python
+        from trulens.feedback.schema_validator import SchemaValidator
+        from trulens.core.metric.metric import Metric
+
+        schema = {
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": ["answer"],
+        }
+        validator = SchemaValidator(schema=schema)
+        f = Metric(validator.validate_json).on_output()
+        ```
+
+    Example — Pydantic model:
+        ```python
+        import pydantic
+        from trulens.feedback.schema_validator import SchemaValidator
+        from trulens.core.metric.metric import Metric
+
+        class MyOutput(pydantic.BaseModel):
+            answer: str
+            score: float
+
+        validator = SchemaValidator(schema=MyOutput)
+        f = Metric(validator.validate_json).on_output()
+        ```
+    """
+
+    _schema: _SchemaType = pydantic.PrivateAttr()
+
+    model_config: pydantic.ConfigDict = pydantic.ConfigDict(
+        arbitrary_types_allowed=True
+    )
+
+    def __init__(self, schema: _SchemaType, **kwargs):
+        """Create a SchemaValidator.
+
+        Args:
+            schema: Either a JSON schema dict or a Pydantic ``BaseModel``
+                *class* (not an instance).
+        """
+        super().__init__(**kwargs)
+        if not (
+            isinstance(schema, dict)
+            or (isinstance(schema, type) and issubclass(schema, pydantic.BaseModel))
+        ):
+            raise TypeError(
+                "`schema` must be a JSON schema dict or a Pydantic BaseModel class."
+            )
+        self._schema = schema
+
+
+    def _validate_with_jsonschema(
+        self, data: Any
+    ) -> Tuple[bool, Optional[str]]:
+        _jsonschema_opt.assert_installed(jsonschema)
+        try:
+            jsonschema.validate(instance=data, schema=cast(Dict[str, Any], self._schema))
+            return True, None
+        except jsonschema.ValidationError as exc:
+            return False, exc.message
+        except jsonschema.SchemaError as exc:
+            raise ValueError(f"Invalid JSON schema provided: {exc.message}") from exc
+
+    def _validate_with_pydantic(
+        self, data: Any
+    ) -> Tuple[bool, Optional[str]]:
+        model_cls = cast(Type[pydantic.BaseModel], self._schema)
+        try:
+            model_cls.model_validate(data)
+            return True, None
+        except pydantic.ValidationError as exc:
+            errors = "; ".join(
+                f"{'.'.join(str(loc) for loc in e['loc'])}: {e['msg']}"
+                for e in exc.errors()
+            )
+            return False, errors
+
+    def _parse_and_validate(
+        self, output: str
+    ) -> Tuple[float, Dict[str, str]]:
+        """Parse *output* as JSON and validate against the stored schema.
+
+        Returns:
+            Tuple of ``(score, metadata)`` where *score* is ``1.0`` if valid
+            and ``0.0`` otherwise.  *metadata* always contains an
+            ``"explanation"`` key.
+        """
+        try:
+            data = json.loads(output)
+        except (json.JSONDecodeError, TypeError) as exc:
+            return 0.0, {"explanation": f"Output is not valid JSON: {exc}"}
+
+        if isinstance(self._schema, dict):
+            ok, error_msg = self._validate_with_jsonschema(data)
+        else:
+            ok, error_msg = self._validate_with_pydantic(data)
+
+        if ok:
+            return 1.0, {"explanation": "Output conforms to the schema."}
+        return 0.0, {"explanation": f"Schema validation failed: {error_msg}"}
+
+    def validate_json(
+        self, output: str
+    ) -> Tuple[float, Dict[str, str]]:
+        """Validate that *output* is valid JSON conforming to the schema.
+
+        Returns ``1.0`` when valid, ``0.0`` otherwise.  The accompanying
+        metadata dict always contains an ``"explanation"`` key describing the
+        outcome (or the first validation error).
+
+        Args:
+            output: The string to validate.  It must be parseable as JSON.
+
+        Returns:
+            A ``(score, metadata)`` tuple compatible with TruLens feedback
+            infrastructure.
+        """
+        return self._parse_and_validate(output)
+
+    def validate_json_partial(
+        self, output: str, required_keys: Optional[list] = None
+    ) -> Tuple[float, Dict[str, str]]:
+        """Validate that *output* is valid JSON and optionally check for keys.
+
+        This is a lighter-weight check: it verifies that *output* parses as a
+        JSON object and, when *required_keys* is provided, that each key is
+        present at the top level.  The full schema is not consulted, making
+        this useful for streaming or partial outputs.
+
+        Args:
+            output: The string to validate.
+            required_keys: Optional list of keys that must exist at the top
+                level of the parsed object.
+
+        Returns:
+            A ``(score, metadata)`` tuple.
+        """
+        try:
+            data = json.loads(output)
+        except (json.JSONDecodeError, TypeError) as exc:
+            return 0.0, {"explanation": f"Output is not valid JSON: {exc}"}
+
+        if not isinstance(data, dict):
+            return 0.0, {
+                "explanation": "Output is valid JSON but not a JSON object."
+            }
+
+        if required_keys:
+            missing = [k for k in required_keys if k not in data]
+            if missing:
+                return 0.0, {
+                    "explanation": f"Missing required keys: {missing}"
+                }
+
+        return 1.0, {"explanation": "Output is a valid JSON object with all required keys."}

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -2328,6 +2328,7 @@ trulens.feedback:
     GroundTruthAggregator: pydantic._internal._model_construction.ModelMetaclass
     GroundTruthAgreement: pydantic._internal._model_construction.ModelMetaclass
     LLMProvider: pydantic._internal._model_construction.ModelMetaclass
+    SchemaValidator: pydantic._internal._model_construction.ModelMetaclass
   lows:
     __all__: builtins.list
     __version__: builtins.str
@@ -2664,6 +2665,20 @@ trulens.feedback.prompts:
     STEREOTYPES_USER_PROMPT: builtins.str
     SYSTEM_FIND_SUPPORTING: builtins.str
     USER_FIND_SUPPORTING: builtins.str
+trulens.feedback.schema_validator:
+  __class__: builtins.module
+  highs: {}
+  lows:
+    SchemaValidator: pydantic._internal._model_construction.ModelMetaclass
+trulens.feedback.schema_validator.SchemaValidator:
+  __bases__:
+  - trulens.core.utils.pyschema.WithClassInfo
+  - trulens.core.utils.serial.SerialModel
+  __class__: pydantic._internal._model_construction.ModelMetaclass
+  attributes:
+    tru_class_info: trulens.core.utils.pyschema.Class
+    validate_json: builtins.function
+    validate_json_partial: builtins.function
 trulens.feedback.v2:
   __class__: builtins.module
   highs: {}


### PR DESCRIPTION
# Description

This should close #2409 .Adds `SchemaValidation` to `trulens.feedback` — a purely programmatic feedback class that validates structured LLM output against a JSON schema or Pydantic model without any LLM call. This fills a gap in the existing feedback library: developers building apps that produce structured JSON output (tool calls, citations, structured data) can now score conformance as a first-class TruLens metric.

Two schema modes are supported at construction time:
- **Pydantic `BaseModel` subclass** — uses `pydantic` (already a core dependency, no extras needed)
- **JSON schema dict** — uses the optional `jsonschema` package with a graceful missing-dependency error

Two feedback methods are provided:
- `validate_json(output: str)` — parses the output string as JSON, then validates
- `validate_object(output: Any)` — validates a pre-parsed dict/object directly

Both return `1.0` (valid) or `0.0` (invalid) plus a metadata dict with a `"valid"` key and, on failure, an `"error"` key containing the first validation error message.

`SchemaValidation` is exported from `trulens.feedback.__init__` alongside `Embeddings` and `GroundTruthAgreement`.

## Other details good to know for developers

- Follows the same class conventions as `Embeddings`: inherits `WithClassInfo` + `SerialModel`, uses a private `_schema` attribute for the runtime object, and stores `json_schema: Optional[Dict]` as a serializable Pydantic field (populated via `model_json_schema()` for Pydantic schemas).
- `jsonschema` is guarded with `OptionalImports` — it is only required when the user passes a dict schema; the Pydantic path has zero new dependencies.
- No changes to existing feedback classes or public APIs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update