### PR TITLE
Fix duplicate Alembic revision 11 and relax importlib-resources bound

### DIFF
--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -45,7 +45,7 @@ nest-asyncio = "^1.5"
 python-dotenv = ">=0.21,<2.0"
 requests = "^2.31"
 packaging = ">=23.0"
-importlib-resources = "^6.0"
+importlib-resources = ">=6.0"
 wrapt = ">=1.17.0"
 
 [tool.poetry.group.tqdm]

--- a/src/core/trulens/core/database/migrations/versions/12_create_runs_table.py
+++ b/src/core/trulens/core/database/migrations/versions/12_create_runs_table.py
@@ -1,15 +1,15 @@
 """create runs table
 
-Revision ID: 11
-Revises: 10
+Revision ID: 12
+Revises: 11
 Create Date: 2025-06-01 00:00:00.000000
 """
 
 from alembic import op
 import sqlalchemy as sa
 
-revision = "11"
-down_revision = "10"
+revision = "12"
+down_revision = "11"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
Two CI fixes:

1. **Fix duplicate Alembic revision 11 causing 44 test failures** — Two migration files both claim revision `"11"` with `down_revision = "10"`, creating a fork in the Alembic migration graph. Renumbers `11_create_runs_table.py` to `12_create_runs_table.py` with `revision = "12"` and `down_revision = "11"`.

2. **Relax importlib-resources upper bound to fix conda build** — `pyproject.toml` had `^6.0` (>=6.0, <7.0) but the conda test environment installs 7.1.0. `pip check` catches the mismatch and fails. Relaxed to `>=6.0` since importlib-resources is a stable stdlib backport with no breaking changes in 7.x.

## Test plan
- [ ] All 44 OTEL unit tests pass (no more MultipleHeads error)
- [ ] BuildCondaPackages job passes (pip check no longer fails)
- [ ] alembic heads reports single head (12)

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)