### PR TITLE
docs: update README with OTEL tracing, agentic evals, providers, MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,26 @@ Diagram](https://www.trulens.org/assets/images/TruLens_Architecture.png)
 Install the trulens pip package from PyPI.
 
 ```bash
-    pip install trulens
+pip install trulens
+```
+
+Install with a specific LLM provider for feedback evaluation:
+
+```bash
+pip install trulens trulens-providers-openai   # OpenAI / Azure OpenAI
+pip install trulens trulens-providers-litellm  # LiteLLM (Anthropic, Cohere, Mistral, …)
+pip install trulens trulens-providers-google   # Google Gemini
+pip install trulens trulens-providers-bedrock  # AWS Bedrock
+pip install trulens trulens-providers-cortex   # Snowflake Cortex
+pip install trulens trulens-providers-huggingface  # HuggingFace
+pip install trulens trulens-providers-langchain    # LangChain models
+```
+
+Install with a specific app framework integration:
+
+```bash
+pip install trulens trulens-apps-langchain    # LangChain / LangGraph
+pip install trulens trulens-apps-llamaindex  # LlamaIndex
 ```
 
 ## Quick Usage
@@ -50,7 +69,98 @@ TruLens.
 [![Open In
 Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/truera/trulens/blob/main/examples/quickstart/quickstart.ipynb)
 
-### 💡 Contributing & Community
+## Key Features
+
+### 🔭 OpenTelemetry-based tracing
+
+TruLens instrumentation is built on [OpenTelemetry](https://opentelemetry.io/).
+Every function call, LLM generation, retrieval, and tool invocation is captured
+as a structured OTEL span. This makes TruLens interoperable with existing
+observability infrastructure — export traces to Jaeger, Grafana Tempo, Datadog,
+or any OTLP-compatible backend.
+
+```python
+from trulens.core.otel.instrument import instrument
+from trulens.otel.semconv.trace import SpanAttributes
+
+class MyRAG:
+    @instrument(
+        span_type=SpanAttributes.SpanType.RETRIEVAL,
+        attributes={
+            SpanAttributes.RETRIEVAL.QUERY_TEXT: "query",
+            SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS: "return",
+        },
+    )
+    def retrieve(self, query: str) -> list:
+        ...
+```
+
+### 🤖 Agentic evaluations
+
+Seven purpose-built evaluators for agentic systems — each measuring a distinct
+aspect of agent behavior:
+
+| Evaluator | What it measures |
+|-----------|-----------------|
+| LogicalConsistency | Reasoning coherence; flags hallucinations and unsupported assertions |
+| ExecutionEfficiency | Redundant steps, unnecessary retries, wasted computation |
+| PlanAdherence | Whether execution followed the stated plan |
+| PlanQuality | Intrinsic plan quality — strategy, not outcome |
+| ToolSelection | Right tool chosen for each subtask |
+| ToolCalling | Argument validity and output interpretation |
+| ToolQuality | External tool/service reliability |
+
+### 📊 Batch and inline evaluation
+
+Run evaluations alongside your app, on existing data, or in offline batch mode:
+
+```python
+# Inline — evaluate as the app runs
+with tru_recorder as recording:
+    response = my_app.query("What is TruLens?")
+
+# Batch — evaluate a pre-collected dataset without a live app
+results = session.evaluate(dataset=df, metrics=[relevance, groundedness])
+```
+
+### 🔌 MCP support
+
+Instrument [Model Context Protocol](https://modelcontextprotocol.io/) tool calls
+with the `MCP` span type to capture tool name, arguments, output, and latency:
+
+```python
+@instrument(span_type=SpanAttributes.SpanType.MCP)
+def call_mcp_tool(self, tool_name: str, arguments: dict) -> str:
+    ...
+```
+
+### 🎯 Selector API
+
+Target any span attribute for evaluation using the flexible Selector API:
+
+```python
+from trulens.core.schema.select import Select
+
+f_context_relevance = (
+    Feedback(provider.context_relevance)
+    .on_input()
+    .on(Select.RecordCalls.retrieve.rets[:])
+)
+```
+
+## Supported LLM Providers
+
+| Provider | Package |
+|----------|---------|
+| OpenAI / Azure OpenAI | `trulens-providers-openai` |
+| LiteLLM (Anthropic, Cohere, Mistral, and more) | `trulens-providers-litellm` |
+| Google Gemini | `trulens-providers-google` |
+| AWS Bedrock | `trulens-providers-bedrock` |
+| Snowflake Cortex | `trulens-providers-cortex` |
+| HuggingFace | `trulens-providers-huggingface` |
+| LangChain models | `trulens-providers-langchain` |
+
+## 💡 Contributing & Community
 
 Interested in contributing? See our [contributing
 guide](https://www.trulens.org/contributing/) for more details.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Diagram](https://www.trulens.org/assets/images/TruLens_Architecture.png)
 Install the trulens pip package from PyPI.
 
 ```bash
-pip install trulens
+pip install trulens-core
 ```
 
 Install with a specific LLM provider for feedback evaluation:
@@ -119,8 +119,20 @@ Run evaluations alongside your app, on existing data, or in offline batch mode:
 with tru_recorder as recording:
     response = my_app.query("What is TruLens?")
 
-# Batch — evaluate a pre-collected dataset without a live app
-results = session.evaluate(dataset=df, metrics=[relevance, groundedness])
+# Batch — evaluate a pre-collected dataset using the TruLens 2.8 Run API
+from trulens.core.run import RunConfig
+
+run_config = RunConfig(
+    run_name="batch_eval_v1",
+    dataset_name="eval_questions",
+    source_type="TABLE",
+    dataset_spec={"input": "QUESTION"},
+    invocation_max_workers=8,
+    metric_max_workers=4,
+)
+run = tru_app.add_run(run_config=run_config)
+run.start()
+run.compute_metrics([relevance, groundedness])
 ```
 
 ### 🔌 MCP support
@@ -139,12 +151,15 @@ def call_mcp_tool(self, tool_name: str, arguments: dict) -> str:
 Target any span attribute for evaluation using the flexible Selector API:
 
 ```python
-from trulens.core.schema.select import Select
+from trulens.core import Metric, Selector
 
-f_context_relevance = (
-    Feedback(provider.context_relevance)
-    .on_input()
-    .on(Select.RecordCalls.retrieve.rets[:])
+f_context_relevance = Metric(
+    name="Context Relevance",
+    implementation=provider.context_relevance,
+    selectors={
+        "input": Selector.select_record_input(),
+        "context": Selector.select_context(),
+    },
 )
 ```
 


### PR DESCRIPTION
## Description

Updates `README.md` to reflect the current TruLens feature set. Closes #2407.

The previous README was ~60 lines and didn't mention OTEL, agentic evals, batch evaluation, MCP, or the Selector API.

Changes:

- **OTEL-based tracing** — new section with code example showing `@instrument` with span types
- **Agentic evaluations** — table of all 7 evaluators with what each measures
- **Batch and inline evaluation** — code examples for both modes
- **MCP support** — snippet showing `SpanAttributes.SpanType.MCP` instrumentation
- **Selector API** — brief example of targeting span attributes for evaluation
- **Full provider list** — table of all 7 supported providers with their package names
- **Installation section** — expanded with per-provider and per-framework install commands

## Type of change

- [x] This change requires a documentation update