### PR TITLE
chore: migrate docs build from mkdocs to properdocs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,25 +136,25 @@ lab: env
 
 # Build the documentation website.
 docs: env-docs $(shell find docs -type f) mkdocs.yml
-	poetry run mkdocs build --clean
+	poetry run properdocs build --clean
 	rm -Rf site/overrides
 
 # Serve the documentation website.
 docs-serve: env-docs
-	poetry run mkdocs serve -a 127.0.0.1:8000
+	poetry run properdocs serve -a 127.0.0.1:8000
 
 # Serve the documentation website.
 docs-serve-debug: env-docs
-	poetry run mkdocs serve -a 127.0.0.1:8000 --verbose
+	poetry run properdocs serve -a 127.0.0.1:8000 --verbose
 
-# The --dirty flag makes mkdocs not regenerate everything when change is
+# The --dirty flag makes properdocs not regenerate everything when change is
 # detected but also seems to break references.
 docs-serve-dirty: env-docs
-	poetry run mkdocs serve --dirty -a 127.0.0.1:8000
+	poetry run properdocs serve --dirty -a 127.0.0.1:8000
 
 docs-upload: clean env-docs $(shell find docs -type f) mkdocs.yml
 	poetry run ggshield secret scan repo ./docs
-	poetry run mkdocs gh-deploy
+	poetry run properdocs gh-deploy
 
 # Check that links in the documentation are valid.
 # Requires the lychee tool (https://github.com/lycheeverse/lychee).
@@ -162,11 +162,11 @@ docs-upload: clean env-docs $(shell find docs -type f) mkdocs.yml
 docs-linkcheck: site
 	lychee --offline --no-progress "site/**/*.html"
 
-# Check documentation for broken internal links using mkdocs --strict.
+# Check documentation for broken internal links using properdocs --strict.
 # Does not require lychee; fails if any warnings beyond the pre-existing
 # README.md/index.md conflict are found.
 docs-linkcheck-strict: env-docs
-	@OUTPUT=$$(poetry run mkdocs build --clean --strict 2>&1); \
+	@OUTPUT=$$(poetry run properdocs build --clean --strict 2>&1); \
 	echo "$$OUTPUT"; \
   BROKEN=$$(echo "$$OUTPUT" | grep "WARNING -" | grep -v "README.md" | grep -v "griffe:"); \
 	if [ -n "$$BROKEN" ]; then \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ pytest-asyncio = "^0.21.0"
 pytest-xdist = "^3.6"
 
 [tool.poetry.group.docs.dependencies]
-mkdocs = ">=1.6"
+properdocs = ">=1.6"
 mkdocstrings-python = "^1.10"
 mkdocstrings = ">=0.26.1"
 griffe = ">=1.13,<2.0"


### PR DESCRIPTION
## Description

Replaces `mkdocs` with `properdocs` in the docs dependency group and all Makefile doc targets. Closes #2436.

**Background:** MkDocs is now unmaintained. [ProperDocs](https://github.com/orgs/ProperDocs/discussions/33) is the community-maintained fork by oprypin (MkDocs' previous maintainer). It is an exact drop-in replacement with the same configuration format and plugin ecosystem, plus critical bug fixes.

**Changes:**

- `pyproject.toml`: replaced `mkdocs = ">=1.6"` with `properdocs = ">=1.6"` in `[tool.poetry.group.docs.dependencies]`
- `Makefile`: replaced all `poetry run mkdocs` CLI calls with `poetry run properdocs` in `docs`, `docs-serve`, `docs-serve-debug`, `docs-serve-dirty`, `docs-upload`, and `docs-linkcheck-strict` targets

**What stays the same:**
- `mkdocs.yml` config file — ProperDocs uses the same filename and format
- All `mkdocs-*` plugins (`mkdocs-material`, `mkdocs-jupyter`, `mkdocs-gen-files`, etc.) — fully compatible with ProperDocs
- `mkdocstrings`, `mkdocstrings-python` — unchanged

## Other details good to know for developers

The `docs-linkcheck` target uses `lychee` directly (not the mkdocs CLI) so it is unaffected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)