### PR TITLE
feat: add violin plot option and threshold line to metric histograms

### DIFF
--- a/docs/component_guides/evaluation/agentic_evaluations.md
+++ b/docs/component_guides/evaluation/agentic_evaluations.md
@@ -1,0 +1,310 @@
+# Agentic Evaluations
+
+TruLens provides seven feedback templates specifically designed for evaluating agentic
+systems. These templates assess different aspects of an agent's plan and execution,
+giving you fine-grained insight into where your agent succeeds or struggles.
+
+All agentic evaluators are available in `trulens.feedback.templates.agent` and operate
+on the agent's trace — the full record of thinking, planning, and actions taken.
+
+## Installation
+
+```bash
+pip install trulens trulens-providers-openai
+```
+
+## Quick start
+
+```python
+from trulens.core import TruSession
+from trulens.apps.langchain import TruChain
+from trulens.providers.openai import OpenAI
+from trulens.feedback.templates.agent import (
+    LogicalConsistency,
+    ExecutionEfficiency,
+    PlanAdherence,
+    PlanQuality,
+    ToolSelection,
+    ToolCalling,
+    ToolQuality,
+)
+from trulens.core.feedback import Feedback
+from trulens.core.schema.select import Select
+
+session = TruSession()
+provider = OpenAI()
+
+# Build feedback functions from agentic templates
+f_logical_consistency = (
+    Feedback(provider.run_template(LogicalConsistency), name="Logical Consistency")
+    .on(Select.RecordCalls.agent.trace)
+)
+```
+
+## Evaluators
+
+### LogicalConsistency
+
+**What it measures:** Whether every action, claim, and transition in the agent's trace is
+explicitly justified by prior context. Flags hallucinations, unsupported assertions, and
+logical leaps.
+
+**Score range:** 0–3 (Likert scale, higher is better)
+
+**Use when:** You need to verify that your agent's reasoning is grounded and coherent —
+especially important for high-stakes domains like finance, legal, or medical.
+
+**Score interpretation:**
+
+| Score | Meaning |
+|-------|---------|
+| 3 | Every step is traceable to prior context; corrections are explicitly acknowledged |
+| 1–2 | Occasional unsupported statements or implicit corrections |
+| 0 | Frequent fabrications, contradictions, or unacknowledged errors |
+
+```python
+from trulens.feedback.templates.agent import LogicalConsistency
+
+f_logical_consistency = Feedback(
+    provider.run_template(LogicalConsistency),
+    name="Logical Consistency",
+)
+```
+
+---
+
+### ExecutionEfficiency
+
+**What it measures:** Whether the agent executed its plan without unnecessary repetition,
+backtracking, or wasted computation. Penalizes redundant tool calls, preventable retries,
+and poorly ordered steps.
+
+**Score range:** 0–3
+
+**Use when:** You want to reduce latency and cost by identifying agents that loop or
+retry unnecessarily.
+
+**Score interpretation:**
+
+| Score | Meaning |
+|-------|---------|
+| 3 | All actions executed exactly once in optimal order |
+| 1–2 | Some redundant steps or non-ideal ordering |
+| 0 | Highly inefficient; dominated by loops or repeated failures |
+
+```python
+from trulens.feedback.templates.agent import ExecutionEfficiency
+
+f_execution_efficiency = Feedback(
+    provider.run_template(ExecutionEfficiency),
+    name="Execution Efficiency",
+)
+```
+
+---
+
+### PlanAdherence
+
+**What it measures:** Whether the agent's execution followed its plan step-by-step.
+Penalizes skipped steps, unauthorized reordering, and undocumented deviations.
+
+**Score range:** 0–3
+
+**Use when:** You need the agent to follow a structured workflow exactly — e.g., a
+multi-step research or data-processing pipeline.
+
+**Score interpretation:**
+
+| Score | Meaning |
+|-------|---------|
+| 3 | Every planned step executed and completed; deviations explicitly justified |
+| 1–2 | Most steps followed; minor deviations with plausible explanations |
+| 0 | Plan largely ignored; many steps skipped or replaced without justification |
+
+```python
+from trulens.feedback.templates.agent import PlanAdherence
+
+f_plan_adherence = Feedback(
+    provider.run_template(PlanAdherence),
+    name="Plan Adherence",
+)
+```
+
+---
+
+### PlanQuality
+
+**What it measures:** The intrinsic quality of the agent's plan — before execution.
+Evaluates whether the plan correctly uses available tools, addresses the user's query,
+and is structured logically. Does **not** evaluate whether the plan was followed.
+
+**Score range:** 0–3
+
+**Use when:** You want to evaluate the agent's planning capability separately from its
+execution. Useful for debugging planning vs. execution failures.
+
+**Score interpretation:**
+
+| Score | Meaning |
+|-------|---------|
+| 3 | Well-structured plan; all steps necessary, justified, and feasible with available tools |
+| 1–2 | Generally feasible; some steps lack justification or are partially implied |
+| 0 | Plan fails to address the query or relies on non-existent tools |
+
+```python
+from trulens.feedback.templates.agent import PlanQuality
+
+f_plan_quality = Feedback(
+    provider.run_template(PlanQuality),
+    name="Plan Quality",
+)
+```
+
+---
+
+### ToolSelection
+
+**What it measures:** Whether the agent chose the *right* tools for each subtask given
+the available tool descriptions. Focuses purely on selection suitability — not how the
+tool was called or how efficiently it was used.
+
+**Score range:** 0–3
+
+**Use when:** You want to detect agents that consistently pick suboptimal or irrelevant
+tools, or ignore mandated tools.
+
+**Score interpretation:**
+
+| Score | Meaning |
+|-------|---------|
+| 3 | Consistently selects the most suitable tool for each subtask |
+| 1–2 | Generally appropriate; occasional missed opportunities or weak justification |
+| 0 | Frequently selects ill-suited tools or ignores superior/mandated options |
+
+```python
+from trulens.feedback.templates.agent import ToolSelection
+
+f_tool_selection = Feedback(
+    provider.run_template(ToolSelection),
+    name="Tool Selection",
+)
+```
+
+---
+
+### ToolCalling
+
+**What it measures:** The quality of tool invocations — argument validity, semantic
+appropriateness, precondition satisfaction, and how well the agent interprets tool
+outputs. Does **not** judge which tool was chosen (see `ToolSelection`) or external
+tool reliability (see `ToolQuality`).
+
+**Score range:** 0–3
+
+**Use when:** You want to find agents that pass invalid arguments, misread tool outputs,
+or fail to handle tool errors gracefully.
+
+**Score interpretation:**
+
+| Score | Meaning |
+|-------|---------|
+| 3 | Syntactically valid, semantically appropriate calls; outputs correctly interpreted |
+| 1–2 | Minor argument issues or shallow output use |
+| 0 | Invalid/missing arguments, repeated schema violations, outputs ignored or fabricated |
+
+```python
+from trulens.feedback.templates.agent import ToolCalling
+
+f_tool_calling = Feedback(
+    provider.run_template(ToolCalling),
+    name="Tool Calling",
+)
+```
+
+---
+
+### ToolQuality
+
+**What it measures:** The reliability and output quality of the *tools themselves* as
+observed in the trace — external errors (5xx, 429, 401), timeouts, flakiness, and
+domain-specific output quality (e.g., search relevance). Independent of agent behavior.
+
+**Score range:** 0–3
+
+**Use when:** You want to separate tool-side failures from agent-side failures. Useful
+for infrastructure monitoring and vendor evaluation.
+
+**Score interpretation:**
+
+| Score | Meaning |
+|-------|---------|
+| 3 | Tools respond reliably with relevant, complete outputs |
+| 1–2 | Occasional external errors or weak outputs |
+| 0 | Frequent errors, timeouts, rate limits, or persistently poor output quality |
+
+```python
+from trulens.feedback.templates.agent import ToolQuality
+
+f_tool_quality = Feedback(
+    provider.run_template(ToolQuality),
+    name="Tool Quality",
+)
+```
+
+---
+
+## Using all seven evaluators together
+
+```python
+from trulens.core import TruSession
+from trulens.providers.openai import OpenAI
+from trulens.core.feedback import Feedback
+from trulens.feedback.templates.agent import (
+    LogicalConsistency,
+    ExecutionEfficiency,
+    PlanAdherence,
+    PlanQuality,
+    ToolSelection,
+    ToolCalling,
+    ToolQuality,
+)
+
+session = TruSession()
+provider = OpenAI()
+
+feedbacks = [
+    Feedback(provider.run_template(LogicalConsistency), name="Logical Consistency"),
+    Feedback(provider.run_template(ExecutionEfficiency), name="Execution Efficiency"),
+    Feedback(provider.run_template(PlanAdherence), name="Plan Adherence"),
+    Feedback(provider.run_template(PlanQuality), name="Plan Quality"),
+    Feedback(provider.run_template(ToolSelection), name="Tool Selection"),
+    Feedback(provider.run_template(ToolCalling), name="Tool Calling"),
+    Feedback(provider.run_template(ToolQuality), name="Tool Quality"),
+]
+```
+
+## Evaluator scope boundaries
+
+The seven evaluators are designed to be **orthogonal** — each measures a distinct
+aspect of agent behavior with minimal overlap:
+
+| Evaluator | Scope |
+|-----------|-------|
+| LogicalConsistency | Reasoning coherence across the full trace |
+| ExecutionEfficiency | Workflow sequencing and resource use |
+| PlanAdherence | Execution fidelity to the stated plan |
+| PlanQuality | Intrinsic plan quality (strategy, not outcome) |
+| ToolSelection | Choice of tool per subtask |
+| ToolCalling | Argument formation and output interpretation |
+| ToolQuality | External tool/service reliability |
+
+This separation lets you diagnose failures precisely: a low `PlanAdherence` score with
+a high `PlanQuality` score means the agent planned well but failed to follow through.
+A low `ToolCalling` score with a high `ToolSelection` score means the right tools were
+chosen but invoked incorrectly.
+
+## Related
+
+- [Custom Feedback Functions](./feedback_implementations/custom_feedback_functions.ipynb)
+- [Feedback Selectors](./feedback_selectors/index.md)
+- [Agentic Evaluation Cookbook](../../../examples/cookbooks/agentic_evaluations.ipynb)

--- a/src/dashboard/trulens/dashboard/tabs/Leaderboard.py
+++ b/src/dashboard/trulens/dashboard/tabs/Leaderboard.py
@@ -21,6 +21,9 @@ from trulens.dashboard.utils.streamlit_compat import st_columns
 from trulens.dashboard.ux import components as dashboard_components
 from trulens.dashboard.ux import styles as dashboard_styles
 
+SCORE_PASS_THRESHOLD = 0.7
+SCORE_FAIL_THRESHOLD = 0.3
+
 APP_COLS = ["app_version", "app_id", "app_name"]
 APP_AGG_COLS = [
     "Records",
@@ -784,7 +787,15 @@ def _render_plot_tab(
             continue
 
         higher_is_better = feedback_directions.get(feedback_col_name, True)
-        pass_threshold = 0.7 if higher_is_better else 0.3
+        pass_threshold = (
+            SCORE_PASS_THRESHOLD if higher_is_better else SCORE_FAIL_THRESHOLD
+        )
+
+        if chart_type == "Violin" and _df.nunique() <= 1:
+            st.info(
+                f"Not enough variation in scores for '{feedback_col_name}' to render a violin plot."
+            )
+            continue
 
         if chart_type == "Histogram":
             mean_score = float(_df.mean())
@@ -810,13 +821,17 @@ def _render_plot_tab(
                 col=col_num,
             )
         else:
+            mean_score = float(_df.mean())
+            violin_color = dashboard_styles.CATEGORY.of_score(
+                mean_score, higher_is_better=higher_is_better
+            ).color
             plot = go.Violin(
                 y=_df,
                 box_visible=True,
                 meanline_visible=True,
                 name="",
-                fillcolor="lightblue",
-                line_color="steelblue",
+                fillcolor=violin_color,
+                line_color=violin_color,
                 points="all",
                 jitter=0.3,
                 pointpos=0,

--- a/src/dashboard/trulens/dashboard/tabs/Leaderboard.py
+++ b/src/dashboard/trulens/dashboard/tabs/Leaderboard.py
@@ -750,12 +750,27 @@ def _render_list_tab(
 
 
 @streamlit_compat.st_fragment
-def _render_plot_tab(df: pd.DataFrame, feedback_col_names: List[str]):
+def _render_plot_tab(
+    df: pd.DataFrame,
+    feedback_col_names: List[str],
+    feedback_directions: Optional[Dict[str, bool]] = None,
+):
     if len(feedback_col_names) == 0:
         st.warning("No metrics found.")
         return
     if dashboard_constants.HIDE_RECORD_COL_NAME in df.columns:
         df = df[~df[dashboard_constants.HIDE_RECORD_COL_NAME]]
+
+    if feedback_directions is None:
+        feedback_directions = {}
+
+    chart_type = st.radio(
+        "Chart type",
+        options=["Histogram", "Violin"],
+        horizontal=True,
+        key=f"{dashboard_constants.LEADERBOARD_PAGE_NAME}.plot_chart_type",
+    )
+
     cols = 4
     rows = len(feedback_col_names) // cols + 1
     fig = make_subplots(rows=rows, cols=cols, subplot_titles=feedback_col_names)
@@ -765,19 +780,60 @@ def _render_plot_tab(df: pd.DataFrame, feedback_col_names: List[str]):
         col_num = i % cols + 1
         _df = df[feedback_col_name].dropna()
 
-        plot = go.Histogram(
-            x=_df,
-            xbins={
-                "size": 0.1,
-            },
-            texttemplate="%{y}",
-            name="",  # Stops trace {i} from showing up in popup annotation.
-        )
-        fig.add_trace(
-            plot,
-            row=row_num,
-            col=col_num,
-        )
+        if _df.empty:
+            continue
+
+        higher_is_better = feedback_directions.get(feedback_col_name, True)
+        pass_threshold = 0.7 if higher_is_better else 0.3
+
+        if chart_type == "Histogram":
+            mean_score = float(_df.mean())
+            bar_color = dashboard_styles.CATEGORY.of_score(
+                mean_score, higher_is_better=higher_is_better
+            ).color
+            plot = go.Histogram(
+                x=_df,
+                xbins={"size": 0.1},
+                texttemplate="%{y}",
+                name="",
+                marker_color=bar_color,
+            )
+            fig.add_trace(plot, row=row_num, col=col_num)
+
+            # Pass/fail threshold line
+            fig.add_vline(
+                x=pass_threshold,
+                line_dash="dash",
+                line_color="gray",
+                line_width=1,
+                row=row_num,
+                col=col_num,
+            )
+        else:
+            plot = go.Violin(
+                y=_df,
+                box_visible=True,
+                meanline_visible=True,
+                name="",
+                fillcolor="lightblue",
+                line_color="steelblue",
+                points="all",
+                jitter=0.3,
+                pointpos=0,
+                marker={"size": 4, "opacity": 0.5},
+            )
+            fig.add_trace(plot, row=row_num, col=col_num)
+
+            # Pass/fail threshold line
+            fig.add_hline(
+                y=pass_threshold,
+                line_dash="dash",
+                line_color="gray",
+                line_width=1,
+                row=row_num,
+                col=col_num,
+            )
+
         if i == 0:
             xaxis = fig["layout"]["xaxis"]
             yaxis = fig["layout"]["yaxis"]
@@ -785,9 +841,13 @@ def _render_plot_tab(df: pd.DataFrame, feedback_col_names: List[str]):
             xaxis = fig["layout"][f"xaxis{i + 1}"]
             yaxis = fig["layout"][f"yaxis{i + 1}"]
 
-        xaxis["title"] = "Score"
-        if col_num == 1:
-            yaxis["title"] = "# Records"
+        if chart_type == "Histogram":
+            xaxis["title"] = "Score"
+            if col_num == 1:
+                yaxis["title"] = "# Records"
+        else:
+            yaxis["title"] = "Score"
+            yaxis["range"] = [0, 1]
 
     fig.update_layout(
         height=300 * rows,
@@ -798,11 +858,14 @@ def _render_plot_tab(df: pd.DataFrame, feedback_col_names: List[str]):
         bargap=0.05,
     )
     fig.update_yaxes(fixedrange=True, showgrid=False)
-    # Histogram bins are [start_inclusive, end_exclusive), so extend the range
-    # by the step to the right.
-    fig.update_xaxes(
-        fixedrange=True, showgrid=False, autorangeoptions={"include": [0, 1]}
-    )
+    if chart_type == "Histogram":
+        fig.update_xaxes(
+            fixedrange=True,
+            showgrid=False,
+            autorangeoptions={"include": [0, 1]},
+        )
+    else:
+        fig.update_xaxes(fixedrange=True, showgrid=False, showticklabels=False)
     st.plotly_chart(fig, width="stretch")
 
 
@@ -882,7 +945,11 @@ def render_leaderboard(app_name: str):
             )
         )
         if not records_df.empty:
-            _render_plot_tab(records_df, list(plot_feedback_cols))
+            _render_plot_tab(
+                records_df,
+                list(plot_feedback_cols),
+                feedback_directions=feedback_directions,
+            )
         else:
             st.info("No individual records available for histograms.")
     with list_tab:


### PR DESCRIPTION
## Description

Enhances the "Metric Histograms" tab on the Leaderboard page with violin plots and score threshold lines. Closes #2419.

**Changes to `src/dashboard/trulens/dashboard/tabs/Leaderboard.py`:**

- **Histogram/Violin toggle** — a `st.radio` selector lets users switch between `Histogram` and `Violin` chart types
- **Histogram improvements**:
  - Bars colored by mean score category (pass = green, warning = yellow, fail = red), using existing `CATEGORY.of_score()` and `Category.color`
  - Dashed vertical threshold line at 0.7 (higher-is-better metrics) or 0.3 (lower-is-better metrics)
- **Violin plot** (`go.Violin`):
  - Shows box plot, mean line, and individual data points (jittered)
  - Dashed horizontal threshold line at the same pass/fail threshold
  - Y-axis fixed to [0, 1] for score-range consistency
- `feedback_directions` passed from `render_leaderboard` down to `_render_plot_tab` so threshold direction is accurate per metric

## Other details good to know for developers

The existing "Metric Histograms" tab already used `go.Histogram` and `plotly` — this PR builds on that foundation. `go.Violin` is part of the same `plotly.graph_objects` import already present.

## Type of change

- [x] New feature (non-breaking change which adds functionality)