### PR TITLE
feat: add conversation_id support for thread-based trace grouping

### DIFF
--- a/docs/component_guides/instrumentation/conversation_id.md
+++ b/docs/component_guides/instrumentation/conversation_id.md
@@ -1,0 +1,85 @@
+# Conversation ID — Grouping Multi-Turn Traces
+
+The `conversation_id` attribute (`ai.observability.conversation_id`) lets you group
+multiple app invocations that belong to the same logical conversation or thread.
+Every span recorded inside a context manager that carries a `conversation_id` will
+have the attribute set, making it easy to filter, visualise, or evaluate all turns
+of a multi-turn interaction together.
+
+The value is propagated through
+[OpenTelemetry Baggage](https://opentelemetry.io/docs/concepts/signals/baggage/)
+so it is automatically inherited by child spans, including those created by
+instrumented third-party libraries.
+
+## Basic usage
+
+Pass `conversation_id` when entering the recording context manager:
+
+```python
+from trulens.core import TruSession
+from trulens.apps.app import TruApp
+
+session = TruSession()
+
+tru_app = TruApp(my_app, app_name="MyApp", app_version="v1",
+                 main_method=my_app.query)
+
+with tru_app(conversation_id="conv-abc-123") as recording:
+    response = my_app.query("What is TruLens?")
+```
+
+All spans produced during `my_app.query(...)` will carry:
+
+```
+ai.observability.conversation_id = "conv-abc-123"
+```
+
+## Multi-turn conversations
+
+Use the same `conversation_id` across multiple context managers to stitch several
+turns into one conversation:
+
+```python
+CONV_ID = "session-42"
+
+with tru_app(conversation_id=CONV_ID) as recording:
+    my_app.query("Hello, who are you?")
+
+with tru_app(conversation_id=CONV_ID) as recording:
+    my_app.query("What can you help me with?")
+
+with tru_app(conversation_id=CONV_ID) as recording:
+    my_app.query("Thanks, goodbye!")
+```
+
+All three invocations will share `ai.observability.conversation_id = "session-42"`,
+so you can retrieve all their records together:
+
+```python
+import pandas as pd
+from trulens.core.session import TruSession
+
+session = TruSession()
+records, _ = session.get_records_and_feedback(app_ids=["MyApp"])
+conv_records = records[records["conversation_id"] == "session-42"]
+```
+
+## Single-turn (default behaviour)
+
+Omitting `conversation_id` (or using `with tru_app as recording:`) leaves the
+attribute unset.  This is the default and is fully backwards-compatible:
+
+```python
+# No conversation_id — identical to pre-existing behaviour
+with tru_app as recording:
+    my_app.query("Standalone question")
+```
+
+## Notes
+
+* `conversation_id` must be a string.  Use any format you like — UUIDs, slugs,
+  integer strings, etc.
+* The attribute is **not** automatically generated; you are responsible for
+  creating and managing conversation identifiers in your application.
+* The value is stored in OTEL Baggage during the context-manager lifetime and
+  therefore does not leak across concurrent invocations that use different IDs.

--- a/docs/component_guides/instrumentation/mcp.md
+++ b/docs/component_guides/instrumentation/mcp.md
@@ -1,0 +1,232 @@
+# MCP Instrumentation
+
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is an open standard for
+connecting LLM agents to external tools and data sources. TruLens provides first-class
+support for instrumenting MCP tool calls via the `MCP` span type and a dedicated set of
+semantic attributes.
+
+## MCP span attributes
+
+When you instrument an MCP tool call, TruLens captures the following attributes in the
+`ai.observability.mcp.*` namespace:
+
+| Attribute | Description | Type |
+|-----------|-------------|------|
+| `ai.observability.mcp.tool_name` | Name of the MCP tool being called | `str` |
+| `ai.observability.mcp.tool_description` | Description of the MCP tool | `str` |
+| `ai.observability.mcp.server_name` | Name of the MCP server providing the tool | `str` |
+| `ai.observability.mcp.input_schema` | JSON schema of the tool's input parameters | `str` |
+| `ai.observability.mcp.input_arguments` | Arguments passed to the tool | `str` |
+| `ai.observability.mcp.output_content` | Content returned by the tool | `str` |
+| `ai.observability.mcp.output_is_error` | Whether the tool call resulted in an error | `bool` |
+| `ai.observability.mcp.execution_time_ms` | Time taken to execute the tool call (ms) | `float` |
+
+## Instrumenting MCP tool calls
+
+Use `@instrument` with `span_type=SpanAttributes.SpanType.MCP` to mark a method as an
+MCP tool call. Map the relevant attributes using the `SpanAttributes.MCP` constants:
+
+```python
+from trulens.core.otel.instrument import instrument
+from trulens.otel.semconv.trace import SpanAttributes
+
+
+class MCPClient:
+    @instrument(
+        span_type=SpanAttributes.SpanType.MCP,
+        attributes={
+            SpanAttributes.MCP.TOOL_NAME: "tool_name",
+            SpanAttributes.MCP.INPUT_ARGUMENTS: "arguments",
+            SpanAttributes.MCP.OUTPUT_CONTENT: "return",
+        },
+    )
+    def call_tool(self, tool_name: str, arguments: dict) -> str:
+        """Call an MCP tool and return its output."""
+        ...
+```
+
+## Full working example
+
+The example below shows a complete setup: an MCP client that calls a weather tool,
+wrapped with TruLens instrumentation and evaluated for tool call quality.
+
+```python
+import json
+from trulens.core import TruSession, Metric, Selector
+from trulens.apps.app import TruApp
+from trulens.core.otel.instrument import instrument
+from trulens.otel.semconv.trace import SpanAttributes
+from trulens.providers.openai import OpenAI
+
+# --- App definition ---
+
+class WeatherMCPClient:
+    """Simulates an MCP client that calls a weather tool."""
+
+    TOOLS = {
+        "get_weather": {
+            "description": "Get current weather for a city",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "units": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                },
+                "required": ["city"],
+            },
+        }
+    }
+
+    @instrument(
+        span_type=SpanAttributes.SpanType.MCP,
+        attributes={
+            SpanAttributes.MCP.TOOL_NAME: "tool_name",
+            SpanAttributes.MCP.TOOL_DESCRIPTION: lambda ret, exc, *args, **kwargs: (
+                WeatherMCPClient.TOOLS.get(kwargs.get("tool_name", ""), {}).get(
+                    "description", ""
+                )
+            ),
+            SpanAttributes.MCP.INPUT_ARGUMENTS: lambda ret, exc, *args, **kwargs: (
+                json.dumps(kwargs.get("arguments", {}))
+            ),
+            SpanAttributes.MCP.OUTPUT_CONTENT: "return",
+            SpanAttributes.MCP.OUTPUT_IS_ERROR: lambda ret, exc, *args, **kwargs: (
+                exc is not None
+            ),
+        },
+    )
+    def call_tool(self, tool_name: str, arguments: dict) -> str:
+        """Call an MCP tool."""
+        if tool_name == "get_weather":
+            city = arguments.get("city", "Unknown")
+            units = arguments.get("units", "celsius")
+            # Simulated tool response
+            return json.dumps({
+                "city": city,
+                "temperature": 22 if units == "celsius" else 72,
+                "units": units,
+                "condition": "Partly cloudy",
+            })
+        raise ValueError(f"Unknown tool: {tool_name}")
+
+    @instrument(
+        span_type=SpanAttributes.SpanType.RECORD_ROOT,
+        attributes={
+            SpanAttributes.RECORD_ROOT.INPUT: "query",
+            SpanAttributes.RECORD_ROOT.OUTPUT: "return",
+        },
+    )
+    def answer(self, query: str) -> str:
+        """Answer a user query by calling MCP tools."""
+        result = self.call_tool("get_weather", {"city": "San Francisco", "units": "celsius"})
+        data = json.loads(result)
+        return (
+            f"The weather in {data['city']} is {data['temperature']}°C "
+            f"and {data['condition']}."
+        )
+
+
+# --- TruLens setup ---
+
+session = TruSession()
+provider = OpenAI()
+
+metrics = [
+    Metric(
+        implementation=provider.tool_selection_with_cot_reasons,
+        name="Tool Selection",
+        selectors={"trace": Selector(trace_level=True)},
+    ),
+    Metric(
+        implementation=provider.tool_calling_with_cot_reasons,
+        name="Tool Calling",
+        selectors={"trace": Selector(trace_level=True)},
+    ),
+    Metric(
+        implementation=provider.tool_quality_with_cot_reasons,
+        name="Tool Quality",
+        selectors={"trace": Selector(trace_level=True)},
+    ),
+]
+
+mcp_client = WeatherMCPClient()
+
+tru_app = TruApp(
+    mcp_client,
+    app_name="WeatherMCPClient",
+    app_version="v1",
+    metrics=metrics,
+)
+
+# --- Run and evaluate ---
+
+with tru_app as recording:
+    response = mcp_client.answer("What's the weather in San Francisco?")
+
+print(response)
+
+session.get_leaderboard()
+```
+
+## Capturing execution time with lambda attributes
+
+If your MCP client reports latency separately, you can capture it using a lambda:
+
+```python
+import time
+
+class TimedMCPClient:
+    @instrument(
+        span_type=SpanAttributes.SpanType.MCP,
+        attributes=lambda ret, exc, *args, **kwargs: {
+            SpanAttributes.MCP.TOOL_NAME: kwargs.get("tool_name"),
+            SpanAttributes.MCP.OUTPUT_CONTENT: ret,
+            SpanAttributes.MCP.OUTPUT_IS_ERROR: exc is not None,
+            # execution_time_ms captured from the tool response metadata
+            SpanAttributes.MCP.EXECUTION_TIME_MS: (
+                ret.get("latency_ms") if isinstance(ret, dict) else None
+            ),
+        },
+    )
+    def call_tool(self, tool_name: str, arguments: dict):
+        ...
+```
+
+## Evaluating MCP tool calls
+
+MCP spans are compatible with the agentic evaluators. To evaluate tool selection and
+calling quality across MCP spans, use the Metric API with trace-level selectors:
+
+```python
+from trulens.core import Metric, Selector
+from trulens.providers.openai import OpenAI
+
+provider = OpenAI()
+
+metrics = [
+    Metric(
+        implementation=provider.tool_selection_with_cot_reasons,
+        name="Tool Selection",
+        selectors={"trace": Selector(trace_level=True)},
+    ),
+    Metric(
+        implementation=provider.tool_calling_with_cot_reasons,
+        name="Tool Calling",
+        selectors={"trace": Selector(trace_level=True)},
+    ),
+    Metric(
+        implementation=provider.tool_quality_with_cot_reasons,
+        name="Tool Quality",
+        selectors={"trace": Selector(trace_level=True)},
+    ),
+]
+```
+
+See the [Metric migration guide](../evaluation/metric_migration.md) for the full API.
+
+## Related
+
+- [Instrumentation Overview](./index.md)
+- [Metric Migration Guide](../evaluation/metric_migration.md)
+- [Semantic Conventions](../../otel/semantic_conventions.md)
+- [Feedback Selectors](../evaluation/feedback_selectors/index.md)

--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -1177,12 +1177,38 @@ class App(
         ):
             raise RuntimeError("Invalid TruLens OTEL Tracing syntax.")
 
+    def __call__(self, *, conversation_id: Optional[str] = None) -> "App":
+        """Configure context-manager options such as ``conversation_id``.
+
+        Usage::
+
+            with tru_app(conversation_id="conv-abc-123") as recording:
+                response = app.query("Hello")
+
+        All spans recorded within the context will carry
+        ``ai.observability.conversation_id`` set to the provided value.
+
+        Args:
+            conversation_id: An optional string identifier that groups multiple
+                records (app invocations) into the same conversation / thread.
+
+        Returns:
+            Self, with the conversation_id stored for use in ``__enter__``.
+        """
+        self._pending_conversation_id = conversation_id
+        return self
+
     # For use as a context manager.
     def __enter__(self):
         if self.session.experimental_feature(
             core_experimental.Feature.OTEL_TRACING
         ):
             from trulens.core.otel.instrument import OtelRecordingContext
+
+            conversation_id = getattr(
+                self, "_pending_conversation_id", None
+            )
+            self._pending_conversation_id = None
 
             with self._current_context_manager_lock:
                 if self._current_context_manager is not None:
@@ -1195,6 +1221,7 @@ class App(
                     app_version=self.app_version,
                     run_name="",
                     input_id="",
+                    conversation_id=conversation_id,
                 )
             return self._current_context_manager.__enter__()
 

--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -1205,9 +1205,7 @@ class App(
         ):
             from trulens.core.otel.instrument import OtelRecordingContext
 
-            conversation_id = getattr(
-                self, "_pending_conversation_id", None
-            )
+            conversation_id = getattr(self, "_pending_conversation_id", None)
             self._pending_conversation_id = None
 
             with self._current_context_manager_lock:

--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -557,6 +557,7 @@ class OtelRecordingContext(OtelBaseRecordingContext):
         input_selector: Optional[
             Callable[[Tuple[Any, ...], Dict[str, Any]], Any]
         ] = None,
+        conversation_id: Optional[str] = None,
     ) -> None:
         app_id = AppDefinition._compute_app_id(app_name, app_version)
         super().__init__(
@@ -570,6 +571,7 @@ class OtelRecordingContext(OtelBaseRecordingContext):
         self.input_records_count = input_records_count
         self.ground_truth_output = ground_truth_output
         self.input_selector = input_selector
+        self.conversation_id = conversation_id
 
     # For use as a context manager.
     def __enter__(self) -> Recording:
@@ -593,6 +595,10 @@ class OtelRecordingContext(OtelBaseRecordingContext):
         self.attach_to_context(
             "__trulens_input_selector__", self.input_selector
         )
+        if self.conversation_id is not None:
+            self.attach_to_context(
+                SpanAttributes.CONVERSATION_ID, self.conversation_id
+            )
 
         ret = Recording(self.tru_app)
         self.attach_to_context("__trulens_recording__", ret)

--- a/src/core/trulens/experimental/otel_tracing/core/span.py
+++ b/src/core/trulens/experimental/otel_tracing/core/span.py
@@ -173,6 +173,9 @@ def set_general_span_attributes(
     set_string_span_attribute_from_baggage(
         span, SpanAttributes.INPUT_RECORDS_COUNT, context
     )
+    set_string_span_attribute_from_baggage(
+        span, SpanAttributes.CONVERSATION_ID, context
+    )
 
 
 def set_function_call_attributes(

--- a/src/otel/semconv/trulens/otel/semconv/trace.py
+++ b/src/otel/semconv/trulens/otel/semconv/trace.py
@@ -57,6 +57,14 @@ class SpanAttributes:
     SPAN_GROUPS = BASE_SCOPE + ".span_groups"
     """List of groups that the span belongs to."""
 
+    CONVERSATION_ID = BASE_SCOPE + ".conversation_id"
+    """ID of the conversation that the span belongs to.
+
+    A conversation groups multiple records (app invocations) that belong to
+    the same multi-turn interaction. All spans recorded within a context
+    manager that has a ``conversation_id`` set will carry this attribute.
+    """
+
     class SpanType(str, Enum):
         """Span type attribute values.
 

--- a/tests/unit/test_otel_recording_contexts.py
+++ b/tests/unit/test_otel_recording_contexts.py
@@ -91,7 +91,7 @@ class TestOtelRecordingContexts(OtelTestCase):
 
     def test_conversation_id_is_set_on_spans(self):
         """conversation_id propagates to all spans when provided."""
-        with self._tru_recorder(conversation_id="conv-123") as recording:
+        with self._tru_recorder(conversation_id="conv-123"):
             self._app.greet(name="Kojikun")
         TruSession().force_flush()
         events = self._get_events()
@@ -104,7 +104,7 @@ class TestOtelRecordingContexts(OtelTestCase):
 
     def test_conversation_id_none_does_not_set_attribute(self):
         """Omitting conversation_id leaves the attribute absent from spans."""
-        with self._tru_recorder(conversation_id=None) as recording:
+        with self._tru_recorder(conversation_id=None):
             self._app.greet(name="Kojikun")
         TruSession().force_flush()
         events = self._get_events()
@@ -116,7 +116,7 @@ class TestOtelRecordingContexts(OtelTestCase):
 
     def test_legacy_context_manager_no_conversation_id(self):
         """Plain `with tru_app as recording:` works and has no conversation_id."""
-        with self._tru_recorder as recording:
+        with self._tru_recorder:
             self._app.greet(name="Kojikun")
         TruSession().force_flush()
         events = self._get_events()

--- a/tests/unit/test_otel_recording_contexts.py
+++ b/tests/unit/test_otel_recording_contexts.py
@@ -84,3 +84,75 @@ class TestOtelRecordingContexts(OtelTestCase):
             "test_run", "42", main_method_kwargs={"name": "Kojikun"}
         )
         self._validate("test_run", "42")
+
+    # ------------------------------------------------------------------
+    # conversation_id tests
+    # ------------------------------------------------------------------
+
+    def test_conversation_id_is_set_on_spans(self):
+        """conversation_id propagates to all spans when provided."""
+        with self._tru_recorder(conversation_id="conv-123") as recording:
+            self._app.greet(name="Kojikun")
+        TruSession().force_flush()
+        events = self._get_events()
+        self.assertEqual(len(events), 2)
+        for _, event in events.iterrows():
+            self.assertEqual(
+                event["record_attributes"][SpanAttributes.CONVERSATION_ID],
+                "conv-123",
+            )
+
+    def test_conversation_id_none_does_not_set_attribute(self):
+        """Omitting conversation_id leaves the attribute absent from spans."""
+        with self._tru_recorder(conversation_id=None) as recording:
+            self._app.greet(name="Kojikun")
+        TruSession().force_flush()
+        events = self._get_events()
+        self.assertEqual(len(events), 2)
+        for _, event in events.iterrows():
+            self.assertNotIn(
+                SpanAttributes.CONVERSATION_ID, event["record_attributes"]
+            )
+
+    def test_legacy_context_manager_no_conversation_id(self):
+        """Plain `with tru_app as recording:` works and has no conversation_id."""
+        with self._tru_recorder as recording:
+            self._app.greet(name="Kojikun")
+        TruSession().force_flush()
+        events = self._get_events()
+        self.assertEqual(len(events), 2)
+        for _, event in events.iterrows():
+            self.assertNotIn(
+                SpanAttributes.CONVERSATION_ID, event["record_attributes"]
+            )
+
+    def test_multiple_invocations_same_conversation_id(self):
+        """Two separate context managers with the same conversation_id both carry it."""
+        conv_id = "multi-turn-conv"
+
+        with self._tru_recorder(conversation_id=conv_id):
+            self._app.greet(name="Turn1")
+
+        TruSession().force_flush()
+        first_events = self._get_events()
+
+        with self._tru_recorder(conversation_id=conv_id):
+            self._app.greet(name="Turn2")
+
+        TruSession().force_flush()
+        all_events = self._get_events()
+
+        # First batch carries the conversation_id.
+        for _, event in first_events.iterrows():
+            self.assertEqual(
+                event["record_attributes"][SpanAttributes.CONVERSATION_ID],
+                conv_id,
+            )
+
+        # Second batch (new rows) also carries it.
+        second_events = all_events.iloc[len(first_events) :]
+        for _, event in second_events.iterrows():
+            self.assertEqual(
+                event["record_attributes"][SpanAttributes.CONVERSATION_ID],
+                conv_id,
+            )


### PR DESCRIPTION
## Description

Adds `ai.observability.conversation_id` — a span attribute that groups multiple app invocations (records) into a single conversation/thread. Closes #2423.

### Usage

```python
# Pass conversation_id via __call__ (recommended)
with tru_app(conversation_id="conv-abc-123") as recording:
    response = app.query("First message")

# Later turn — same conversation
with tru_app(conversation_id="conv-abc-123") as recording:
    response = app.query("Follow-up message")
```

All spans recorded within the context carry `ai.observability.conversation_id = "conv-abc-123"`.

### Changes

**`src/otel/semconv/trulens/otel/semconv/trace.py`**
- Added `SpanAttributes.CONVERSATION_ID = "ai.observability.conversation_id"` with docstring

**`src/core/trulens/experimental/otel_tracing/core/span.py`**
- `set_general_span_attributes` now propagates `CONVERSATION_ID` from OTEL baggage to each span, alongside existing attributes (RECORD_ID, RUN_NAME, INPUT_ID, etc.)

**`src/core/trulens/core/otel/instrument.py`**
- `OtelRecordingContext.__init__` accepts optional `conversation_id: Optional[str] = None`
- `OtelRecordingContext.__enter__` calls `attach_to_context(SpanAttributes.CONVERSATION_ID, ...)` when set, placing it in OTEL baggage so all child spans inherit it

**`src/core/trulens/core/app.py`**
- `App.__call__` added — stores `conversation_id` on `self._pending_conversation_id` and returns `self`, enabling the `tru_app(conversation_id="...")` context manager syntax
- `App.__enter__` reads `_pending_conversation_id` and passes it to `OtelRecordingContext`

## Other details good to know for developers

The `conversation_id` is propagated through OTEL baggage, so it follows the same propagation path as `record_id`, `run_name`, and `input_id` — no special handling needed in child spans.

The `App.__call__` pattern is backward-compatible: `with tru_app as recording:` (no call) continues to work exactly as before with `conversation_id=None`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)