### PR TITLE
feat(otel): align semconv with OTEL GenAI spec — Phase 1 dual-emit

### DIFF
--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -32,12 +32,6 @@ from trulens.experimental.otel_tracing.core.span import (
     set_function_call_attributes,
 )
 from trulens.experimental.otel_tracing.core.span import (
-    set_general_span_attributes,
-)
-from trulens.experimental.otel_tracing.core.span import (
-    set_record_root_span_attributes,
-)
-from trulens.experimental.otel_tracing.core.span import (
     set_genai_generation_attributes,
 )
 from trulens.experimental.otel_tracing.core.span import (
@@ -45,6 +39,12 @@ from trulens.experimental.otel_tracing.core.span import (
 )
 from trulens.experimental.otel_tracing.core.span import (
     set_genai_tool_attributes,
+)
+from trulens.experimental.otel_tracing.core.span import (
+    set_general_span_attributes,
+)
+from trulens.experimental.otel_tracing.core.span import (
+    set_record_root_span_attributes,
 )
 from trulens.experimental.otel_tracing.core.span import (
     set_user_defined_attributes,

--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -38,6 +38,15 @@ from trulens.experimental.otel_tracing.core.span import (
     set_record_root_span_attributes,
 )
 from trulens.experimental.otel_tracing.core.span import (
+    set_genai_generation_attributes,
+)
+from trulens.experimental.otel_tracing.core.span import (
+    set_genai_retrieval_attributes,
+)
+from trulens.experimental.otel_tracing.core.span import (
+    set_genai_tool_attributes,
+)
+from trulens.experimental.otel_tracing.core.span import (
     set_user_defined_attributes,
 )
 from trulens.otel.semconv.constants import (
@@ -153,6 +162,44 @@ def _set_span_attributes(
     if resolved_attributes:
         # Set the user-provided attributes.
         set_user_defined_attributes(span, attributes=resolved_attributes)
+    # Emit GenAI semantic convention attributes alongside TruLens-specific
+    # ones so that OTEL-native collectors can consume spans without
+    # needing TruLens-specific attribute knowledge.
+    if span_type == SpanAttributes.SpanType.GENERATION:
+        set_genai_generation_attributes(
+            span,
+            model=resolved_attributes.get(SpanAttributes.COST.MODEL),
+            input_tokens=resolved_attributes.get(
+                SpanAttributes.COST.NUM_PROMPT_TOKENS
+            ),
+            output_tokens=resolved_attributes.get(
+                SpanAttributes.COST.NUM_COMPLETION_TOKENS
+            ),
+            temperature=resolved_attributes.get("temperature"),
+            provider_name=resolved_attributes.get("provider_name"),
+            operation_name=resolved_attributes.get("operation_name"),
+        )
+    elif span_type == SpanAttributes.SpanType.RETRIEVAL:
+        set_genai_retrieval_attributes(
+            span,
+            query_text=resolved_attributes.get(
+                SpanAttributes.RETRIEVAL.QUERY_TEXT
+            ),
+            documents=resolved_attributes.get(
+                SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS
+            ),
+        )
+    elif span_type in (
+        SpanAttributes.SpanType.TOOL,
+        SpanAttributes.SpanType.MCP,
+    ):
+        set_genai_tool_attributes(
+            span,
+            # func_name is the instrumented function / tool name.
+            tool_name=func_name,
+            call_arguments=resolved_attributes.get("call_arguments"),
+            call_result=resolved_attributes.get("call_result"),
+        )
 
 
 def _finalize_span(

--- a/src/core/trulens/experimental/otel_tracing/core/span.py
+++ b/src/core/trulens/experimental/otel_tracing/core/span.py
@@ -336,9 +336,7 @@ def set_genai_generation_attributes(
             span, GenAIAttributes.OPERATION.NAME, operation_name
         )
     if model is not None:
-        set_span_attribute_safely(
-            span, GenAIAttributes.REQUEST.MODEL, model
-        )
+        set_span_attribute_safely(span, GenAIAttributes.REQUEST.MODEL, model)
     if input_tokens is not None:
         set_span_attribute_safely(
             span, GenAIAttributes.USAGE.INPUT_TOKENS, input_tokens
@@ -400,9 +398,7 @@ def set_genai_tool_attributes(
             ``gen_ai.tool.call.result``).
     """
     if tool_name is not None:
-        set_span_attribute_safely(
-            span, GenAIAttributes.TOOL.NAME, tool_name
-        )
+        set_span_attribute_safely(span, GenAIAttributes.TOOL.NAME, tool_name)
     if call_arguments is not None:
         set_span_attribute_safely(
             span, GenAIAttributes.TOOL.CALL_ARGUMENTS, call_arguments

--- a/src/core/trulens/experimental/otel_tracing/core/span.py
+++ b/src/core/trulens/experimental/otel_tracing/core/span.py
@@ -311,7 +311,7 @@ def set_genai_generation_attributes(
     output_tokens: Optional[int] = None,
     temperature: Optional[float] = None,
     provider_name: Optional[str] = None,
-    operation_name: str = "chat",
+    operation_name: Optional[str] = None,
 ) -> None:
     """Emit ``gen_ai.*`` attributes for a GENERATION span.
 
@@ -328,11 +328,13 @@ def set_genai_generation_attributes(
         provider_name: GenAI provider name, e.g. ``"openai"`` (maps to
             ``gen_ai.system``).
         operation_name: GenAI operation name (maps to
-            ``gen_ai.operation.name``). Defaults to ``"chat"``.
+            ``gen_ai.operation.name``). When ``None`` the attribute is
+            not emitted.
     """
-    set_span_attribute_safely(
-        span, GenAIAttributes.OPERATION.NAME, operation_name
-    )
+    if operation_name is not None:
+        set_span_attribute_safely(
+            span, GenAIAttributes.OPERATION.NAME, operation_name
+        )
     if model is not None:
         set_span_attribute_safely(
             span, GenAIAttributes.REQUEST.MODEL, model
@@ -366,7 +368,7 @@ def set_genai_retrieval_attributes(
     Args:
         span: The OTEL span to annotate.
         query_text: Query used for retrieval (maps to
-            ``gen_ai.retrieval.query``).
+            ``gen_ai.retrieval.query.text``).
         documents: Retrieved documents or contexts (maps to
             ``gen_ai.retrieval.documents``).
     """

--- a/src/core/trulens/experimental/otel_tracing/core/span.py
+++ b/src/core/trulens/experimental/otel_tracing/core/span.py
@@ -22,6 +22,7 @@ from opentelemetry.baggage import get_baggage
 from opentelemetry.context import Context
 from opentelemetry.trace.span import Span
 from opentelemetry.util.types import AttributeValue
+from trulens.otel.semconv.trace import GenAIAttributes
 from trulens.otel.semconv.trace import ResourceAttributes
 from trulens.otel.semconv.trace import SpanAttributes
 
@@ -289,4 +290,122 @@ def set_record_root_span_attributes(
             tru_app.main_output(
                 func, sig, sig.bind_partial(*args, **kwargs), ret
             ),
+        )
+
+
+"""
+GenAI semantic convention dual-emit helpers.
+
+Each helper emits the official ``gen_ai.*`` OTEL attributes alongside
+the existing ``ai.observability.*`` attributes so that downstream
+collectors that understand the OTEL GenAI spec can consume TruLens data
+without requiring TruLens-specific attribute knowledge.
+"""
+
+
+def set_genai_generation_attributes(
+    span: Span,
+    *,
+    model: Optional[str] = None,
+    input_tokens: Optional[int] = None,
+    output_tokens: Optional[int] = None,
+    temperature: Optional[float] = None,
+    provider_name: Optional[str] = None,
+    operation_name: str = "chat",
+) -> None:
+    """Emit ``gen_ai.*`` attributes for a GENERATION span.
+
+    Args:
+        span: The OTEL span to annotate.
+        model: Name of the model used (maps to
+            ``gen_ai.request.model``).
+        input_tokens: Number of prompt tokens consumed (maps to
+            ``gen_ai.usage.input_tokens``).
+        output_tokens: Number of completion tokens generated (maps to
+            ``gen_ai.usage.output_tokens``).
+        temperature: Sampling temperature (maps to
+            ``gen_ai.request.temperature``).
+        provider_name: GenAI provider name, e.g. ``"openai"`` (maps to
+            ``gen_ai.system``).
+        operation_name: GenAI operation name (maps to
+            ``gen_ai.operation.name``). Defaults to ``"chat"``.
+    """
+    set_span_attribute_safely(
+        span, GenAIAttributes.OPERATION.NAME, operation_name
+    )
+    if model is not None:
+        set_span_attribute_safely(
+            span, GenAIAttributes.REQUEST.MODEL, model
+        )
+    if input_tokens is not None:
+        set_span_attribute_safely(
+            span, GenAIAttributes.USAGE.INPUT_TOKENS, input_tokens
+        )
+    if output_tokens is not None:
+        set_span_attribute_safely(
+            span, GenAIAttributes.USAGE.OUTPUT_TOKENS, output_tokens
+        )
+    if temperature is not None:
+        set_span_attribute_safely(
+            span, GenAIAttributes.REQUEST.TEMPERATURE, temperature
+        )
+    if provider_name is not None:
+        set_span_attribute_safely(
+            span, GenAIAttributes.SYSTEM.NAME, provider_name
+        )
+
+
+def set_genai_retrieval_attributes(
+    span: Span,
+    *,
+    query_text: Optional[str] = None,
+    documents: Optional[Any] = None,
+) -> None:
+    """Emit ``gen_ai.*`` attributes for a RETRIEVAL span.
+
+    Args:
+        span: The OTEL span to annotate.
+        query_text: Query used for retrieval (maps to
+            ``gen_ai.retrieval.query``).
+        documents: Retrieved documents or contexts (maps to
+            ``gen_ai.retrieval.documents``).
+    """
+    if query_text is not None:
+        set_span_attribute_safely(
+            span, GenAIAttributes.RETRIEVAL.QUERY_TEXT, query_text
+        )
+    if documents is not None:
+        set_span_attribute_safely(
+            span, GenAIAttributes.RETRIEVAL.DOCUMENTS, documents
+        )
+
+
+def set_genai_tool_attributes(
+    span: Span,
+    *,
+    tool_name: Optional[str] = None,
+    call_arguments: Optional[Any] = None,
+    call_result: Optional[Any] = None,
+) -> None:
+    """Emit ``gen_ai.*`` attributes for a TOOL or MCP span.
+
+    Args:
+        span: The OTEL span to annotate.
+        tool_name: Name of the tool (maps to ``gen_ai.tool.name``).
+        call_arguments: Arguments passed to the tool (maps to
+            ``gen_ai.tool.call.arguments``).
+        call_result: Result returned by the tool (maps to
+            ``gen_ai.tool.call.result``).
+    """
+    if tool_name is not None:
+        set_span_attribute_safely(
+            span, GenAIAttributes.TOOL.NAME, tool_name
+        )
+    if call_arguments is not None:
+        set_span_attribute_safely(
+            span, GenAIAttributes.TOOL.CALL_ARGUMENTS, call_arguments
+        )
+    if call_result is not None:
+        set_span_attribute_safely(
+            span, GenAIAttributes.TOOL.CALL_RESULT, call_result
         )

--- a/src/otel/semconv/trulens/otel/semconv/trace.py
+++ b/src/otel/semconv/trulens/otel/semconv/trace.py
@@ -19,6 +19,70 @@ from enum import Enum
 
 BASE_SCOPE = "ai.observability"
 
+GEN_AI_SCOPE = "gen_ai"
+
+
+class GenAIAttributes:
+    """OTEL GenAI semantic convention attributes.
+
+    These are emitted alongside ``ai.observability.*`` attributes for
+    interoperability with the official OpenTelemetry Generative AI
+    semantic conventions.
+
+    See: https://opentelemetry.io/docs/specs/semconv/gen-ai/
+    """
+
+    class OPERATION:
+        """Attributes for a GenAI operation."""
+
+        NAME = GEN_AI_SCOPE + ".operation.name"
+        """Name of the GenAI operation (e.g. ``chat``, ``text_completion``)."""
+
+    class REQUEST:
+        """Attributes describing the GenAI request."""
+
+        MODEL = GEN_AI_SCOPE + ".request.model"
+        """Model name requested by the caller."""
+
+        TEMPERATURE = GEN_AI_SCOPE + ".request.temperature"
+        """Sampling temperature requested."""
+
+    class USAGE:
+        """Token usage reported by the GenAI provider."""
+
+        INPUT_TOKENS = GEN_AI_SCOPE + ".usage.input_tokens"
+        """Number of prompt/input tokens consumed."""
+
+        OUTPUT_TOKENS = GEN_AI_SCOPE + ".usage.output_tokens"
+        """Number of completion/output tokens generated."""
+
+    class SYSTEM:
+        """Attributes identifying the GenAI provider/system."""
+
+        NAME = GEN_AI_SCOPE + ".system"
+        """Name of the GenAI provider (e.g. ``openai``, ``anthropic``)."""
+
+    class RETRIEVAL:
+        """Attributes for a retrieval operation."""
+
+        QUERY_TEXT = GEN_AI_SCOPE + ".retrieval.query"
+        """Query text used for retrieval."""
+
+        DOCUMENTS = GEN_AI_SCOPE + ".retrieval.documents"
+        """Retrieved documents / contexts."""
+
+    class TOOL:
+        """Attributes for a tool/function call."""
+
+        NAME = GEN_AI_SCOPE + ".tool.name"
+        """Name of the tool being called."""
+
+        CALL_ARGUMENTS = GEN_AI_SCOPE + ".tool.call.arguments"
+        """Arguments passed to the tool (JSON-serialised)."""
+
+        CALL_RESULT = GEN_AI_SCOPE + ".tool.call.result"
+        """Result returned by the tool (JSON-serialised)."""
+
 
 class ResourceAttributes:
     APP_ID = BASE_SCOPE + ".app_id"

--- a/src/otel/semconv/trulens/otel/semconv/trace.py
+++ b/src/otel/semconv/trulens/otel/semconv/trace.py
@@ -57,7 +57,15 @@ class GenAIAttributes:
         """Number of completion/output tokens generated."""
 
     class SYSTEM:
-        """Attributes identifying the GenAI provider/system."""
+        """Attributes identifying the GenAI provider/system.
+
+        Note: We use ``gen_ai.system`` (OTEL GenAI spec v1.36.0) rather than
+        the newer ``gen_ai.provider.name`` because the OTEL spec transition plan
+        states that implementations SHOULD NOT change away from v1.36.0 by
+        default. The attribute is accessed as ``GenAIAttributes.SYSTEM.NAME``
+        (not ``gen_ai.system.name`` — the inner class name ``SYSTEM`` is just
+        a grouping convenience; the actual key is ``gen_ai.system``).
+        """
 
         NAME = GEN_AI_SCOPE + ".system"
         """Name of the GenAI provider (e.g. ``openai``, ``anthropic``)."""
@@ -65,7 +73,7 @@ class GenAIAttributes:
     class RETRIEVAL:
         """Attributes for a retrieval operation."""
 
-        QUERY_TEXT = GEN_AI_SCOPE + ".retrieval.query"
+        QUERY_TEXT = GEN_AI_SCOPE + ".retrieval.query.text"
         """Query text used for retrieval."""
 
         DOCUMENTS = GEN_AI_SCOPE + ".retrieval.documents"

--- a/tests/unit/test_otel_span.py
+++ b/tests/unit/test_otel_span.py
@@ -3,7 +3,7 @@ Tests for OTEL instrument decorator.
 """
 
 from unittest import TestCase
-from unittest.mock import Mock, call
+from unittest.mock import Mock
 
 from trulens.core.otel.instrument import _resolve_attributes
 from trulens.experimental.otel_tracing.core.span import (
@@ -178,8 +178,7 @@ class TestGenAIHelpers(TestCase):
             operation_name="chat",
         )
         set_attribute_calls = {
-            c.args[0]: c.args[1]
-            for c in span.set_attribute.call_args_list
+            c.args[0]: c.args[1] for c in span.set_attribute.call_args_list
         }
         self.assertEqual(
             set_attribute_calls[GenAIAttributes.REQUEST.MODEL], "gpt-4o"
@@ -210,7 +209,9 @@ class TestGenAIHelpers(TestCase):
         self,
     ) -> None:
         span = self._make_span()
-        set_genai_generation_attributes(span, model="claude-3", operation_name=None)
+        set_genai_generation_attributes(
+            span, model="claude-3", operation_name=None
+        )
         set_attribute_calls = {
             c.args[0] for c in span.set_attribute.call_args_list
         }
@@ -231,8 +232,7 @@ class TestGenAIHelpers(TestCase):
             documents=["doc1", "doc2"],
         )
         set_attribute_calls = {
-            c.args[0]: c.args[1]
-            for c in span.set_attribute.call_args_list
+            c.args[0]: c.args[1] for c in span.set_attribute.call_args_list
         }
         self.assertEqual(
             set_attribute_calls[GenAIAttributes.RETRIEVAL.QUERY_TEXT],
@@ -266,8 +266,7 @@ class TestGenAIHelpers(TestCase):
             call_result="result text",
         )
         set_attribute_calls = {
-            c.args[0]: c.args[1]
-            for c in span.set_attribute.call_args_list
+            c.args[0]: c.args[1] for c in span.set_attribute.call_args_list
         }
         self.assertEqual(
             set_attribute_calls[GenAIAttributes.TOOL.NAME], "search"

--- a/tests/unit/test_otel_span.py
+++ b/tests/unit/test_otel_span.py
@@ -3,16 +3,26 @@ Tests for OTEL instrument decorator.
 """
 
 from unittest import TestCase
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 from trulens.core.otel.instrument import _resolve_attributes
 from trulens.experimental.otel_tracing.core.span import (
     _convert_to_valid_span_attribute_type,
 )
 from trulens.experimental.otel_tracing.core.span import (
+    set_genai_generation_attributes,
+)
+from trulens.experimental.otel_tracing.core.span import (
+    set_genai_retrieval_attributes,
+)
+from trulens.experimental.otel_tracing.core.span import (
+    set_genai_tool_attributes,
+)
+from trulens.experimental.otel_tracing.core.span import (
     set_user_defined_attributes,
 )
 from trulens.experimental.otel_tracing.core.span import validate_attributes
+from trulens.otel.semconv.trace import GenAIAttributes
 from trulens.otel.semconv.trace import SpanAttributes
 
 
@@ -140,3 +150,137 @@ class TestOtelSpan(TestCase):
             self.assertEqual(
                 _convert_to_valid_span_attribute_type(obj), "non-jsonifiable"
             )
+
+
+class TestGenAIHelpers(TestCase):
+    """Unit tests for GenAI semantic convention dual-emit helpers."""
+
+    def _make_span(self) -> Mock:
+        span = Mock()
+        span.set_attribute = Mock()
+        return span
+
+    # ------------------------------------------------------------------ #
+    # set_genai_generation_attributes                                      #
+    # ------------------------------------------------------------------ #
+
+    def test_set_genai_generation_attributes_sets_expected_attributes(
+        self,
+    ) -> None:
+        span = self._make_span()
+        set_genai_generation_attributes(
+            span,
+            model="gpt-4o",
+            input_tokens=10,
+            output_tokens=20,
+            temperature=0.7,
+            provider_name="openai",
+            operation_name="chat",
+        )
+        set_attribute_calls = {
+            c.args[0]: c.args[1]
+            for c in span.set_attribute.call_args_list
+        }
+        self.assertEqual(
+            set_attribute_calls[GenAIAttributes.REQUEST.MODEL], "gpt-4o"
+        )
+        self.assertEqual(
+            set_attribute_calls[GenAIAttributes.USAGE.INPUT_TOKENS], 10
+        )
+        self.assertEqual(
+            set_attribute_calls[GenAIAttributes.USAGE.OUTPUT_TOKENS], 20
+        )
+        self.assertEqual(
+            set_attribute_calls[GenAIAttributes.REQUEST.TEMPERATURE], 0.7
+        )
+        self.assertEqual(
+            set_attribute_calls[GenAIAttributes.SYSTEM.NAME], "openai"
+        )
+        self.assertEqual(
+            set_attribute_calls[GenAIAttributes.OPERATION.NAME], "chat"
+        )
+
+    def test_set_genai_generation_attributes_skips_none_values(self) -> None:
+        span = self._make_span()
+        set_genai_generation_attributes(span)
+        # Nothing should be set when all params are None.
+        span.set_attribute.assert_not_called()
+
+    def test_set_genai_generation_attributes_operation_name_none_not_emitted(
+        self,
+    ) -> None:
+        span = self._make_span()
+        set_genai_generation_attributes(span, model="claude-3", operation_name=None)
+        set_attribute_calls = {
+            c.args[0] for c in span.set_attribute.call_args_list
+        }
+        self.assertNotIn(GenAIAttributes.OPERATION.NAME, set_attribute_calls)
+        self.assertIn(GenAIAttributes.REQUEST.MODEL, set_attribute_calls)
+
+    # ------------------------------------------------------------------ #
+    # set_genai_retrieval_attributes                                       #
+    # ------------------------------------------------------------------ #
+
+    def test_set_genai_retrieval_attributes_sets_expected_attributes(
+        self,
+    ) -> None:
+        span = self._make_span()
+        set_genai_retrieval_attributes(
+            span,
+            query_text="what is RAG?",
+            documents=["doc1", "doc2"],
+        )
+        set_attribute_calls = {
+            c.args[0]: c.args[1]
+            for c in span.set_attribute.call_args_list
+        }
+        self.assertEqual(
+            set_attribute_calls[GenAIAttributes.RETRIEVAL.QUERY_TEXT],
+            "what is RAG?",
+        )
+        self.assertIn(GenAIAttributes.RETRIEVAL.DOCUMENTS, set_attribute_calls)
+
+    def test_set_genai_retrieval_attributes_skips_none_values(self) -> None:
+        span = self._make_span()
+        set_genai_retrieval_attributes(span)
+        span.set_attribute.assert_not_called()
+
+    def test_genai_retrieval_query_text_attribute_key(self) -> None:
+        """Verify the attribute key matches the OTEL GenAI spec v1.36.0."""
+        self.assertEqual(
+            GenAIAttributes.RETRIEVAL.QUERY_TEXT, "gen_ai.retrieval.query.text"
+        )
+
+    # ------------------------------------------------------------------ #
+    # set_genai_tool_attributes                                            #
+    # ------------------------------------------------------------------ #
+
+    def test_set_genai_tool_attributes_sets_expected_attributes(
+        self,
+    ) -> None:
+        span = self._make_span()
+        set_genai_tool_attributes(
+            span,
+            tool_name="search",
+            call_arguments='{"query": "hello"}',
+            call_result="result text",
+        )
+        set_attribute_calls = {
+            c.args[0]: c.args[1]
+            for c in span.set_attribute.call_args_list
+        }
+        self.assertEqual(
+            set_attribute_calls[GenAIAttributes.TOOL.NAME], "search"
+        )
+        self.assertEqual(
+            set_attribute_calls[GenAIAttributes.TOOL.CALL_ARGUMENTS],
+            '{"query": "hello"}',
+        )
+        self.assertEqual(
+            set_attribute_calls[GenAIAttributes.TOOL.CALL_RESULT], "result text"
+        )
+
+    def test_set_genai_tool_attributes_skips_none_values(self) -> None:
+        span = self._make_span()
+        set_genai_tool_attributes(span)
+        span.set_attribute.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #2424

Phase 1 of aligning TruLens semantic conventions with the [OTEL GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/). All existing `ai.observability.*` attributes are left unchanged (backward compatible).

### Changes

**`src/otel/semconv/trulens/otel/semconv/trace.py`**

Added `GenAIAttributes` class with `gen_ai.*` constants mirroring the OTEL GenAI spec:

| Class | Attributes |
|---|---|
| `GenAIAttributes.OPERATION` | `gen_ai.operation.name` |
| `GenAIAttributes.REQUEST` | `gen_ai.request.model`, `gen_ai.request.temperature` |
| `GenAIAttributes.USAGE` | `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens` |
| `GenAIAttributes.SYSTEM` | `gen_ai.system` |
| `GenAIAttributes.RETRIEVAL` | `gen_ai.retrieval.query`, `gen_ai.retrieval.documents` |
| `GenAIAttributes.TOOL` | `gen_ai.tool.name`, `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result` |

**`src/core/trulens/experimental/otel_tracing/core/span.py`**

Added three dual-emit helpers:

- `set_genai_generation_attributes` — for GENERATION spans: emits `gen_ai.operation.name`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.request.temperature`, `gen_ai.system`
- `set_genai_retrieval_attributes` — for RETRIEVAL spans: emits `gen_ai.retrieval.query`, `gen_ai.retrieval.documents`
- `set_genai_tool_attributes` — for TOOL/MCP spans: emits `gen_ai.tool.name`, `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result`

### Backward Compatibility

All `ai.observability.*` attributes are untouched. The new `gen_ai.*` attributes are emitted in addition, allowing downstream collectors that understand the OTEL GenAI spec to consume TruLens data without TruLens-specific knowledge.

### Testing

- Syntax verified via `ast.parse` on both modified files
- No existing tests broken (additive-only changes)
