### PR TITLE
Clean up dummy app TruLens imports

### DIFF
--- a/examples/dev/dummy_app/dummy_app_example.ipynb
+++ b/examples/dev/dummy_app/dummy_app_example.ipynb
@@ -20,21 +20,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pathlib import Path\n",
-    "import sys\n",
-    "\n",
-    "repo_path = Path().cwd().parent.parent.parent.resolve()\n",
-    "\n",
-    "# If using trulens from the repository, add the parent directory to the path:\n",
-    "sys.path.append(str(repo_path))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "from trulens.apps.app import TruApp\n",
     "from trulens.core import TruSession\n",
     "\n",
@@ -119,7 +104,7 @@
     "# Start the dasshboard.\n",
     "from trulens.dashboard import run_dashboard\n",
     "\n",
-    "run_dashboard(_dev=repo_path, force=True)"
+    "run_dashboard(force=True)"
    ]
   },
   {
@@ -158,7 +143,7 @@
     "- Nested use of custom app inside a custom app component. This is controlled by\n",
     "  the `DummyAgent` class `use_app` flag.\n",
     "\n",
-    "- Use of trulens_eval to record the invocation of the above nested model. This\n",
+    "- Use of trulens.core to record the invocation of the above nested model. This\n",
     "  is controlled by the `DummyAgent` class `use_recorder` flag.\n",
     "\n"
    ]

--- a/examples/dev/dummy_app/filter_apps.ipynb
+++ b/examples/dev/dummy_app/filter_apps.ipynb
@@ -13,21 +13,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pathlib import Path\n",
-    "import sys\n",
-    "\n",
-    "repo_path = Path().cwd().parent.parent.parent.resolve()\n",
-    "\n",
-    "# If using trulens from the repository, add the parent directory to the path:\n",
-    "sys.path.append(str(repo_path))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "from trulens.apps.app import TruApp\n",
     "from trulens.core import TruSession\n",
     "\n",

--- a/examples/dev/dummy_app/tool.py
+++ b/examples/dev/dummy_app/tool.py
@@ -97,9 +97,7 @@ class DummyStackTool(DummyTool):
             else:
                 fmod = fmod.__name__
             ffunc = frame.f_code.co_name
-            if not fmod.startswith("examples.") or fmod.startswith(
-                "trulens_eval"
-            ):
+            if not fmod.startswith("examples.") or fmod.startswith("trulens."):
                 continue
 
             ret += f"""


### PR DESCRIPTION
## Summary
- remove notebook sys.path/repo_path hacks from dummy app examples
- run the dashboard using the active TruLens environment instead of _dev=repo_path
- replace the remaining trulens_eval reference in the dummy app examples

Closes #2472

## Validation
- jq empty examples/dev/dummy_app/dummy_app_example.ipynb examples/dev/dummy_app/filter_apps.ipynb
- python3 -m compileall -q examples/dev/dummy_app
- rg -n "trulens_eval|sys\.path|repo_path" examples/dev/dummy_app (no matches)
- uv run --with "ruff>=0.5" ruff format --check examples/dev/dummy_app/tool.py examples/dev/dummy_app/dummy_app_example.ipynb examples/dev/dummy_app/filter_apps.ipynb
- uv run --with "ruff>=0.5" ruff check --select F401,F821 examples/dev/dummy_app/tool.py examples/dev/dummy_app/dummy_app_example.ipynb examples/dev/dummy_app/filter_apps.ipynb

Note: I could not run the documented Poetry commands locally because poetry is not installed in this environment.