### PR TITLE
update default models for bedrock, cortex, and litellm providers

### DIFF
--- a/src/feedback/trulens/feedback/groundtruth.py
+++ b/src/feedback/trulens/feedback/groundtruth.py
@@ -591,7 +591,7 @@ class GroundTruthAgreement(
             ]
 
             bedrock = Bedrock(
-                model_id="amazon.titan-text-express-v1", region_name="us-east-1"
+                model_id="amazon.nova-lite-v1:0", region_name="us-east-1"
             )
             ground_truth_collection = GroundTruthAgreement(golden_set, provider=bedrock)
 

--- a/src/providers/bedrock/trulens/providers/bedrock/provider.py
+++ b/src/providers/bedrock/trulens/providers/bedrock/provider.py
@@ -14,7 +14,7 @@ class Bedrock(llm_provider.LLMProvider):
 
     Args:
         model_id: The specific model id. Defaults to
-            "amazon.titan-text-express-v1".
+            "amazon.nova-lite-v1:0".
 
         *args: args passed to BedrockEndpoint and subsequently to boto3 client
             constructor.
@@ -23,7 +23,7 @@ class Bedrock(llm_provider.LLMProvider):
             client constructor.
     """
 
-    DEFAULT_MODEL_ID: ClassVar[str] = "amazon.titan-text-express-v1"
+    DEFAULT_MODEL_ID: ClassVar[str] = "amazon.nova-lite-v1:0"
 
     # LLMProvider requirement which we do not use:
     model_engine: str = "Bedrock"
@@ -36,7 +36,6 @@ class Bedrock(llm_provider.LLMProvider):
         *args: Any,
         model_id: Optional[str] = None,
         **kwargs: Any,
-        # self, *args, model_id: str = "amazon.titan-text-express-v1", **kwargs
     ):
         if model_id is None:
             model_id = self.DEFAULT_MODEL_ID

--- a/src/providers/cortex/trulens/providers/cortex/provider.py
+++ b/src/providers/cortex/trulens/providers/cortex/provider.py
@@ -24,14 +24,14 @@ class Cortex(
     # https://docs.snowflake.com/en/user-guide/snowflake-cortex/llm-functions#availability
 
     DEFAULT_SNOWPARK_SESSION: Optional[Session] = None
-    DEFAULT_MODEL_ENGINE: ClassVar[str] = "llama3.1-8b"
+    DEFAULT_MODEL_ENGINE: ClassVar[str] = "llama3.3-70b"
 
     model_engine: str
     endpoint: cortex_endpoint.CortexEndpoint
     snowpark_session: Session
     retry_timeout: Optional[float]
 
-    """Snowflake's Cortex COMPLETE endpoint. Defaults to `llama3.1-8b`.
+    """Snowflake's Cortex COMPLETE endpoint. Defaults to `llama3.3-70b`.
 
     Reference: https://docs.snowflake.com/en/sql-reference/functions/complete-snowflake-cortex
 

--- a/src/providers/litellm/trulens/providers/litellm/provider.py
+++ b/src/providers/litellm/trulens/providers/litellm/provider.py
@@ -101,10 +101,10 @@ class LiteLLM(llm_provider.LLMProvider):
             forwarded to ``completion_kwargs``.
     """
 
-    DEFAULT_MODEL_ENGINE: ClassVar[str] = "gpt-3.5-turbo"
+    DEFAULT_MODEL_ENGINE: ClassVar[str] = "gpt-4o-mini"
 
     model_engine: str
-    """The LiteLLM completion model. Defaults to `gpt-3.5-turbo`."""
+    """The LiteLLM completion model. Defaults to `gpt-4o-mini`."""
 
     completion_args: Dict[str, str] = pydantic.Field(default_factory=dict)
     """Additional arguments to pass to the `litellm.completion` as needed for chosen api."""


### PR DESCRIPTION
Closes #2500
Closes #2499
Closes #2498

The default models for three providers were pointing to older/deprecated options. Updated each to a better modern equivalent:

- **Cortex**: `llama3.1-8b` → `llama3.3-70b` — better quality/cost balance for eval tasks, confirmed available in Snowflake Cortex docs
- **Bedrock**: `amazon.titan-text-express-v1` → `amazon.nova-lite-v1:0` — Titan Express is legacy; Nova Lite is cheaper and performs better on evaluation workloads
- **LiteLLM**: `gpt-3.5-turbo` → `gpt-4o-mini` — gpt-4o-mini supersedes 3.5-turbo at lower cost

Also updated matching docstrings and a hardcoded example in `groundtruth.py` to stay consistent with the new defaults. Removed a stale commented-out function signature in the Bedrock provider.