### PR TITLE
test: add feedback template validation coverage

### DIFF
--- a/examples/cookbooks/custom_programmatic_feedback.ipynb
+++ b/examples/cookbooks/custom_programmatic_feedback.ipynb
@@ -13,10 +13,10 @@
     "\n",
     "This notebook shows four non-LLM feedback functions:\n",
     "\n",
-    "1. **JSON schema check** \u2014 verify the response is valid JSON matching a schema\n",
-    "2. **Regex match** \u2014 check that the response matches an expected pattern\n",
-    "3. **Response length** \u2014 score based on response length being within a target range\n",
-    "4. **PII regex scan** \u2014 detect personally identifiable information in the response\n",
+    "1. **JSON schema check** — verify the response is valid JSON matching a schema\n",
+    "2. **Regex match** — check that the response matches an expected pattern\n",
+    "3. **Response length** — score based on response length being within a target range\n",
+    "4. **PII regex scan** — detect personally identifiable information in the response\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/truera/trulens/blob/main/examples/cookbooks/custom_programmatic_feedback.ipynb)"
    ]
@@ -49,9 +49,10 @@
     "import json\n",
     "import os\n",
     "import re\n",
+    "\n",
     "from openai import OpenAI\n",
-    "from trulens.core import TruSession\n",
     "from trulens.apps.custom import TruCustomApp\n",
+    "from trulens.core import TruSession\n",
     "from trulens.core.otel.instrument import instrument\n",
     "from trulens.otel.semconv.trace import SpanAttributes\n",
     "\n",
@@ -69,7 +70,7 @@
    "source": [
     "## Define a simple app\n",
     "\n",
-    "We build a minimal app that returns structured JSON responses \u2014 a good candidate\n",
+    "We build a minimal app that returns structured JSON responses — a good candidate\n",
     "for programmatic evaluation."
    ]
   },
@@ -147,7 +148,9 @@
     "validator = SchemaValidator(schema=REQUIRED_JSON_SCHEMA)\n",
     "\n",
     "# Quick sanity checks\n",
-    "score, meta = validator.validate_json('{\"answer\": \"yes\", \"confidence\": 0.9, \"sources\": [\"wiki\"]}')\n",
+    "score, meta = validator.validate_json(\n",
+    "    '{\"answer\": \"yes\", \"confidence\": 0.9, \"sources\": [\"wiki\"]}'\n",
+    ")\n",
     "assert score == 1.0, meta\n",
     "score, meta = validator.validate_json('{\"answer\": \"yes\"}')\n",
     "assert score == 0.0, meta  # missing fields\n",
@@ -164,7 +167,7 @@
     "## Feedback function 2: Regex match\n",
     "\n",
     "Checks that the response (or a parsed field) matches a specific pattern.\n",
-    "Useful for format compliance \u2014 e.g., dates, codes, citation styles."
+    "Useful for format compliance — e.g., dates, codes, citation styles."
    ]
   },
   {
@@ -194,8 +197,16 @@
     "    return 1.0 if pattern.search(str(answer)) else 0.0\n",
     "\n",
     "\n",
-    "assert answer_not_empty('{\"answer\": \"This is a complete answer.\", \"confidence\": 0.8, \"sources\": []}') == 1.0\n",
-    "assert answer_not_empty('{\"answer\": \"short\", \"confidence\": 0.8, \"sources\": []}') == 0.0\n",
+    "assert (\n",
+    "    answer_not_empty(\n",
+    "        '{\"answer\": \"This is a complete answer.\", \"confidence\": 0.8, \"sources\": []}'\n",
+    "    )\n",
+    "    == 1.0\n",
+    ")\n",
+    "assert (\n",
+    "    answer_not_empty('{\"answer\": \"short\", \"confidence\": 0.8, \"sources\": []}')\n",
+    "    == 0.0\n",
+    ")\n",
     "print(\"answer_not_empty: OK\")"
    ]
   },
@@ -249,8 +260,8 @@
     "    return max(0.0, 1.0 - overage / tolerance)\n",
     "\n",
     "\n",
-    "assert response_length_score(\"x\" * 100) == 1.0   # within range\n",
-    "assert response_length_score(\"x\" * 25) == 0.5    # too short\n",
+    "assert response_length_score(\"x\" * 100) == 1.0  # within range\n",
+    "assert response_length_score(\"x\" * 25) == 0.5  # too short\n",
     "assert response_length_score(\"x\" * 1000) == 0.0  # way too long\n",
     "print(\"response_length_score: OK\")"
    ]
@@ -306,7 +317,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from trulens.core import Metric, Selector\n",
+    "from trulens.core import Metric\n",
+    "from trulens.core import Selector\n",
     "\n",
     "f_json_schema = Metric(\n",
     "    implementation=validator.validate_json,\n",
@@ -397,7 +409,16 @@
    "outputs": [],
    "source": [
     "records, feedback_results = session.get_records_and_feedback()\n",
-    "records[[\"input\", \"output\", \"JSON Schema Check\", \"Answer Not Empty\", \"Response Length\", \"No PII\"]]"
+    "records[\n",
+    "    [\n",
+    "        \"input\",\n",
+    "        \"output\",\n",
+    "        \"JSON Schema Check\",\n",
+    "        \"Answer Not Empty\",\n",
+    "        \"Response Length\",\n",
+    "        \"No PII\",\n",
+    "    ]\n",
+    "]"
    ]
   },
   {
@@ -431,10 +452,10 @@
     "\n",
     "Non-LLM feedback functions are:\n",
     "\n",
-    "- **Free** \u2014 no LLM calls, no API cost\n",
-    "- **Instant** \u2014 run in microseconds\n",
-    "- **Deterministic** \u2014 same input always produces the same score\n",
-    "- **Composable** \u2014 mix with LLM-based feedback functions in the same `TruApp`\n",
+    "- **Free** — no LLM calls, no API cost\n",
+    "- **Instant** — run in microseconds\n",
+    "- **Deterministic** — same input always produces the same score\n",
+    "- **Composable** — mix with LLM-based feedback functions in the same `TruApp`\n",
     "\n",
     "Use them for format compliance, safety checks, and any evaluation where\n",
     "correctness can be determined without a language model."
@@ -448,8 +469,7 @@
    "name": "python3"
   },
   "language_info": {
-   "name": "python",
-   "version": "3.11.0"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/src/feedback/trulens/feedback/templates/base.py
+++ b/src/feedback/trulens/feedback/templates/base.py
@@ -37,8 +37,7 @@ class FeedbackTemplate(pydantic.BaseModel):
     LLM evaluation prompts.
     """
 
-    def __init__(self, examples):
-        self.examples = examples
+    examples: Optional[List[Tuple[Dict[str, str], int]]] = None
 
     @classmethod
     def help(cls) -> None:

--- a/tests/unit/test_feedback_templates_validation.py
+++ b/tests/unit/test_feedback_templates_validation.py
@@ -1,0 +1,134 @@
+"""Validation tests for exported feedback template definitions."""
+
+from collections.abc import Iterable
+from string import Formatter
+import unittest
+
+from trulens.feedback import templates
+from trulens.feedback.templates import base as templates_base
+
+_PROMPT_ATTRIBUTES = ("system_prompt", "user_prompt", "prompt")
+_ALLOWED_PROMPT_FIELDS = {
+    "context",
+    "hypothesis",
+    "key_point",
+    "max_score",
+    "min_score",
+    "premise",
+    "prompt",
+    "question",
+    "response",
+    "source",
+    "statement",
+    "statements",
+    "submission",
+    "summary",
+    "text",
+    "trace",
+}
+
+
+def _exported_prompt_template_classes() -> Iterable[
+    type[templates_base.FeedbackTemplate]
+]:
+    """Yield exported template classes that define a system prompt."""
+    for symbol in templates.__all__:
+        value = getattr(templates, symbol)
+        if (
+            isinstance(value, type)
+            and issubclass(value, templates_base.FeedbackTemplate)
+            and value is not templates_base.FeedbackTemplate
+            and hasattr(value, "system_prompt")
+        ):
+            yield value
+
+
+class TestFeedbackTemplateValidation(unittest.TestCase):
+    """Validate prompt template definitions exported by the package."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.template_classes = tuple(_exported_prompt_template_classes())
+
+    def test_finds_expected_template_classes(self) -> None:
+        template_names = {
+            template.__name__ for template in self.template_classes
+        }
+
+        self.assertIn("Groundedness", template_names)
+        self.assertIn("ContextRelevance", template_names)
+        self.assertIn("Stereotypes", template_names)
+        self.assertIn("Helpfulness", template_names)
+        self.assertIn("LogicalConsistency", template_names)
+
+    def test_template_classes_are_instantiable_pydantic_models(self) -> None:
+        for template in self.template_classes:
+            with self.subTest(template=template.__name__):
+                instance = template()
+
+                self.assertIsInstance(instance, templates_base.FeedbackTemplate)
+
+    def test_system_prompts_are_non_empty_strings(self) -> None:
+        for template in self.template_classes:
+            with self.subTest(template=template.__name__):
+                system_prompt = template.system_prompt
+
+                self.assertIsInstance(system_prompt, str)
+                self.assertGreater(len(system_prompt.strip()), 0)
+
+    def test_user_prompts_are_non_empty_when_declared(self) -> None:
+        for template in self.template_classes:
+            if not hasattr(template, "user_prompt"):
+                continue
+
+            with self.subTest(template=template.__name__):
+                user_prompt = template.user_prompt
+
+                self.assertIsInstance(user_prompt, str)
+                self.assertGreater(len(user_prompt.strip()), 0)
+
+    def test_criteria_mixins_define_criteria(self) -> None:
+        for template in self.template_classes:
+            if not issubclass(
+                template, templates_base.CriteriaOutputSpaceMixin
+            ):
+                continue
+
+            with self.subTest(template=template.__name__):
+                criteria = template.criteria
+
+                self.assertIsInstance(criteria, str)
+                self.assertGreater(len(criteria.strip()), 0)
+
+    def test_output_spaces_are_valid_variants(self) -> None:
+        valid_output_spaces = set(templates_base.OutputSpace.__members__)
+
+        for template in self.template_classes:
+            if not hasattr(template, "output_space"):
+                continue
+
+            with self.subTest(template=template.__name__):
+                self.assertIn(template.output_space, valid_output_spaces)
+
+    def test_prompts_only_contain_expected_runtime_fields(self) -> None:
+        for template in self.template_classes:
+            for prompt_attribute in _PROMPT_ATTRIBUTES:
+                prompt = getattr(template, prompt_attribute, None)
+                if not isinstance(prompt, str):
+                    continue
+
+                with self.subTest(
+                    template=template.__name__,
+                    prompt_attribute=prompt_attribute,
+                ):
+                    fields = {
+                        field_name
+                        for _, field_name, _, _ in Formatter().parse(prompt)
+                        if field_name is not None
+                    }
+
+                    self.assertLessEqual(fields, _ALLOWED_PROMPT_FIELDS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_feedback_templates_validation.py
+++ b/tests/unit/test_feedback_templates_validation.py
@@ -1,30 +1,29 @@
 """Validation tests for exported feedback template definitions."""
 
+import ast
 from collections.abc import Iterable
+import inspect
 from string import Formatter
 import unittest
 
+from trulens.feedback import llm_provider
 from trulens.feedback import templates
 from trulens.feedback.templates import base as templates_base
 
 _PROMPT_ATTRIBUTES = ("system_prompt", "user_prompt", "prompt")
-_ALLOWED_PROMPT_FIELDS = {
-    "context",
-    "hypothesis",
-    "key_point",
-    "max_score",
-    "min_score",
-    "premise",
-    "prompt",
-    "question",
-    "response",
-    "source",
-    "statement",
-    "statements",
-    "submission",
-    "summary",
-    "text",
-    "trace",
+_IGNORED_SIGNATURE_PARAMETERS = {
+    "self",
+    "args",
+    "kwargs",
+    "criteria",
+    "additional_instructions",
+    "custom_instructions",
+    "examples",
+    "groundedness_configs",
+    "min_score_val",
+    "max_score_val",
+    "temperature",
+    "enable_trace_compression",
 }
 
 
@@ -43,12 +42,63 @@ def _exported_prompt_template_classes() -> (
             yield value
 
 
+def _provider_signature_fields() -> set[str]:
+    """Return prompt input names from feedback method signatures."""
+    fields = set()
+
+    for _, member in inspect.getmembers(
+        llm_provider.LLMProvider, predicate=callable
+    ):
+        try:
+            signature = inspect.signature(member)
+        except (TypeError, ValueError):
+            continue
+
+        for parameter in signature.parameters.values():
+            if (
+                parameter.name not in _IGNORED_SIGNATURE_PARAMETERS
+                and parameter.kind
+                in {
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    inspect.Parameter.KEYWORD_ONLY,
+                }
+            ):
+                fields.add(parameter.name)
+
+    return fields
+
+
+def _provider_format_keyword_fields() -> set[str]:
+    """Return prompt field names used when provider methods format templates."""
+    fields = set()
+    provider_tree = ast.parse(inspect.getsource(llm_provider.LLMProvider))
+
+    for node in ast.walk(provider_tree):
+        if not isinstance(node, ast.Call):
+            continue
+
+        if isinstance(node.func, ast.Attribute) and node.func.attr == "format":
+            fields.update(
+                keyword.arg
+                for keyword in node.keywords
+                if keyword.arg is not None
+            )
+
+    return fields
+
+
+def _allowed_prompt_fields() -> set[str]:
+    """Build allowed template fields from the provider implementation."""
+    return _provider_signature_fields() | _provider_format_keyword_fields()
+
+
 class TestFeedbackTemplateValidation(unittest.TestCase):
     """Validate prompt template definitions exported by the package."""
 
     @classmethod
     def setUpClass(cls) -> None:
         cls.template_classes = tuple(_exported_prompt_template_classes())
+        cls.allowed_prompt_fields = _allowed_prompt_fields()
 
     def test_finds_expected_template_classes(self) -> None:
         template_names = {
@@ -127,7 +177,7 @@ class TestFeedbackTemplateValidation(unittest.TestCase):
                         if field_name is not None
                     }
 
-                    self.assertLessEqual(fields, _ALLOWED_PROMPT_FIELDS)
+                    self.assertLessEqual(fields, self.allowed_prompt_fields)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_feedback_templates_validation.py
+++ b/tests/unit/test_feedback_templates_validation.py
@@ -28,9 +28,9 @@ _ALLOWED_PROMPT_FIELDS = {
 }
 
 
-def _exported_prompt_template_classes() -> Iterable[
-    type[templates_base.FeedbackTemplate]
-]:
+def _exported_prompt_template_classes() -> (
+    Iterable[type[templates_base.FeedbackTemplate]]
+):
     """Yield exported template classes that define a system prompt."""
     for symbol in templates.__all__:
         value = getattr(templates, symbol)


### PR DESCRIPTION
## Summary

- Add unit tests for exported feedback prompt template definitions.
- Make `FeedbackTemplate` expose `examples` as an optional Pydantic field so exported prompt classes can instantiate cleanly.

## Why

The existing export test checks that template symbols are re-exported. This adds coverage for prompt-bearing templates themselves: non-empty prompts, valid output spaces, criteria for `CriteriaOutputSpaceMixin` classes, expected runtime format fields, and Pydantic instantiation.

## Testing

- `TEST_OPTIONAL=true uv run pytest tests/unit/test_feedback_templates_validation.py -q`
- `uv run pytest tests/unit/test_feedback_templates_exports.py tests/unit/test_feedback_templates_validation.py -q`
- `uvx ruff check --select I,E303 tests/unit/test_feedback_templates_validation.py`
- `uvx ruff format tests/unit/test_feedback_templates_validation.py --check`

## Notes

Related to #2471. I used `uv` locally because `poetry` was not installed in my environment.