### PR TITLE
feat: add Jury class for ensemble LLM evaluation

### DIFF
--- a/docs/component_guides/evaluation/llm_jury.md
+++ b/docs/component_guides/evaluation/llm_jury.md
@@ -1,0 +1,151 @@
+# LLM Jury: Ensemble Evaluation with Multiple Judges
+
+## Why a jury instead of a single judge?
+
+A single LLM judge is both noisy and subject to *intra-model bias* — it
+systematically favours its own style, vocabulary, and reasoning patterns.
+Research shows that ensembling a **panel of diverse judges** (a "jury")
+substantially improves evaluation reliability:
+
+| Paper | Key finding |
+|---|---|
+| [Verga et al. 2024 — PoLL](https://arxiv.org/abs/2404.18796) | A panel of diverse smaller models outperforms a single large judge and is 7× cheaper. |
+| [Zhou et al. 2025 — SE-Jury](https://arxiv.org/abs/2501.16676) | Ensemble judges narrow the gap with human evaluation on software engineering tasks. |
+| [Zhao et al. 2025 — Statistically Principled Aggregation](https://arxiv.org/abs/2503.07977) | PoLL-style juries with 3 diverse small models achieve higher human-correlation than a single large judge. |
+| [Li et al. 2025 — Auto-Prompt Ensemble](https://arxiv.org/abs/2502.07853) | Treating each evaluation dimension as an independent juror with auto-generated prompts further improves reliability. |
+
+## The `Jury` class
+
+`Jury` wraps N `LLMProvider` instances, calls the same named feedback method on
+each in parallel, and aggregates their scores using a configurable strategy.
+Because `Jury.__call__` has the same parameter names as the underlying provider
+method, it is a drop-in `implementation` for `Metric` — **no changes to
+`Metric`, `Selector`, or the evaluation pipeline are needed**.
+
+```python
+from trulens.feedback.jury import Jury
+```
+
+### API reference
+
+```python
+Jury(
+    jurors,          # List[LLMProvider] — the panel of judges
+    method,          # str — method name, e.g. "relevance"
+    aggregation,     # str | Callable — how to combine scores (default "mean")
+    *,
+    weights,         # List[float] — per-juror weights (weighted_mean only)
+    threshold,       # float — binarisation threshold (majority_vote, default 0.5)
+    return_details,  # bool — include per-juror scores in metadata (default False)
+    max_workers,     # int — parallel threads (default len(jurors))
+)
+```
+
+## Aggregation strategies
+
+| Strategy | Description | When to use |
+|---|---|---|
+| `"mean"` *(default)* | Simple average | General purpose |
+| `"median"` | Middle value — robust to outlier judges | When one judge may be erratic |
+| `"trimmed_mean"` | Drop highest and lowest, average the rest | 3+ judges; outlier resistance with less bias than median |
+| `"majority_vote"` | Binarise at `threshold`, majority wins | Pass/fail guardrails |
+| `"weighted_mean"` | Weight each judge by alignment quality | When you have benchmark-derived judge quality scores |
+| `Callable[[List[float]], float]` | Any custom function | Specialist use cases |
+
+## Usage examples
+
+### Basic jury with mean aggregation
+
+```python
+from trulens.core import Metric
+from trulens.feedback.jury import Jury
+from trulens.providers.openai import OpenAI
+from trulens.providers.litellm import LiteLLM
+
+jury = Jury(
+    jurors=[
+        OpenAI(model_engine="gpt-4o-mini"),
+        OpenAI(model_engine="gpt-4.1-mini"),
+        LiteLLM(model_engine="anthropic/claude-3-haiku-20240307"),
+    ],
+    method="relevance",
+    aggregation="mean",
+)
+
+m_relevance = (
+    Metric(implementation=jury, name="Jury Relevance")
+    .on_input()
+    .on_output()
+)
+```
+
+### Median jury (robust to outliers)
+
+```python
+jury = Jury(
+    jurors=[openai_provider, litellm_provider, cortex_provider],
+    method="context_relevance",
+    aggregation="median",
+)
+```
+
+### Weighted jury from benchmark results
+
+```python
+jury = Jury(
+    jurors=[openai_provider, litellm_provider, cortex_provider],
+    method="groundedness_measure_with_cot_reasons",
+    aggregation="weighted_mean",
+    weights=[0.5, 0.3, 0.2],  # from prior benchmark alignment scores
+)
+```
+
+### Majority-vote guardrail
+
+```python
+jury = Jury(
+    jurors=[provider_a, provider_b, provider_c],
+    method="moderation_hate",
+    aggregation="majority_vote",
+    threshold=0.5,  # any score ≥ 0.5 counts as a positive (flagged) vote
+)
+```
+
+### Per-juror score breakdown
+
+```python
+jury = Jury(
+    jurors=[openai_provider, litellm_provider],
+    method="relevance",
+    aggregation="median",
+    return_details=True,
+)
+
+# Returns: (0.82, {"gpt-4o-mini": 0.75, "claude-3-haiku": 0.90})
+score, per_juror = jury(prompt="What is TruLens?", response="An eval library.")
+```
+
+### Error handling
+
+If one juror fails, `Jury` logs a warning and aggregates the rest. Only when
+*all* jurors fail does `Jury` raise a `RuntimeError`.
+
+## Choosing juror models
+
+**Diversity beats size.** The key driver of jury quality is *disagreement
+diversity* among models — a mix of model families (OpenAI, Anthropic, Google,
+Snowflake Cortex) provides more independent signal than three instances of the
+same model. Smaller, cheaper models are often sufficient.
+
+Practical starting point:
+
+- 3 judges from different families
+- `"median"` or `"trimmed_mean"` aggregation
+- `return_details=True` during development to inspect per-juror scores
+
+## Cost and latency
+
+`Jury` runs all jurors in parallel (via `ThreadPoolExecutor`), so wall-clock
+latency is approximately that of the *slowest* juror. Cost scales linearly with
+the number of jurors. Using 3 small models (e.g. GPT-4o-mini, Claude Haiku,
+Gemini Flash) is typically cheaper than a single GPT-4o call.

--- a/docs/component_guides/evaluation/llm_jury.md
+++ b/docs/component_guides/evaluation/llm_jury.md
@@ -15,6 +15,12 @@ Because `Jury.__call__` has the same parameter names as the underlying provider
 method, it is a drop-in `implementation` for `Metric` — **no changes to
 `Metric`, `Selector`, or the evaluation pipeline are needed**.
 
+`Jury` always returns `(score, {"reason": ...})`, matching the
+`_with_cot_reasons` convention. Per-juror scores and any chain-of-thought
+explanations are embedded in the reason string, so they flow into
+`FeedbackCall.meta["reason"]` → `ai.observability.eval.metadata.reason` in
+OTEL spans and appear in the dashboard automatically — no UI changes needed.
+
 ```python
 from trulens.feedback.jury import Jury
 ```
@@ -23,14 +29,13 @@ from trulens.feedback.jury import Jury
 
 ```python
 Jury(
-    jurors,          # List[LLMProvider] — the panel of judges
-    method,          # str — method name, e.g. "relevance"
-    aggregation,     # str | Callable — how to combine scores (default "mean")
+    jurors,       # list[LLMProvider] — the panel of judges
+    method,       # str — method name, e.g. "relevance"
+    aggregation,  # str | Callable — how to combine scores (default "mean")
     *,
-    weights,         # List[float] — per-juror weights (weighted_mean only)
-    threshold,       # float — binarisation threshold (majority_vote, default 0.5)
-    return_details,  # bool — include per-juror scores in metadata (default False)
-    max_workers,     # int — parallel threads (default len(jurors))
+    weights,      # list[float] — per-juror weights (weighted_mean only)
+    threshold,    # float — binarisation threshold (majority_vote, default 0.5)
+    max_workers,  # int — parallel threads (default len(jurors))
 )
 ```
 
@@ -41,13 +46,13 @@ Jury(
 | `"mean"` *(default)* | Simple average | General purpose |
 | `"median"` | Middle value — robust to outlier judges | When one judge may be erratic |
 | `"trimmed_mean"` | Drop highest and lowest, average the rest | 3+ judges; outlier resistance with less bias than median |
-| `"majority_vote"` | Binarise at `threshold`, majority wins | Pass/fail guardrails |
+| `"majority_vote"` | Binarise at `threshold`, majority wins; ties fall back to median | Pass/fail guardrails |
 | `"weighted_mean"` | Weight each judge by alignment quality | When you have benchmark-derived judge quality scores |
-| `Callable[[List[float]], float]` | Any custom function | Specialist use cases |
+| `Callable[[list[float]], float]` | Any custom function | Specialist use cases |
 
 ## Usage examples
 
-### Basic jury with mean aggregation
+### Basic jury with median aggregation
 
 ```python
 from trulens.core import Metric
@@ -62,7 +67,7 @@ jury = Jury(
         LiteLLM(model_engine="anthropic/claude-3-haiku-20240307"),
     ],
     method="relevance",
-    aggregation="mean",
+    aggregation="median",
 )
 
 m_relevance = (
@@ -72,14 +77,28 @@ m_relevance = (
 )
 ```
 
-### Median jury (robust to outliers)
+### Per-juror score breakdown
+
+`Jury` always returns `(score, meta)`. The `meta["reason"]` string contains
+the aggregated score, each juror's individual score, and any chain-of-thought
+explanations from `_with_cot_reasons` methods — all visible in the dashboard.
 
 ```python
 jury = Jury(
-    jurors=[openai_provider, litellm_provider, cortex_provider],
-    method="context_relevance",
+    jurors=[openai_provider, litellm_provider],
+    method="relevance_with_cot_reasons",
     aggregation="median",
 )
+
+score, meta = jury(prompt="What is TruLens?", response="An eval library.")
+print(meta["reason"])
+# Aggregation: median → 0.825
+#   gpt-4o-mini: 0.750
+#     Criteria: relevance
+#     Supporting Evidence: the response directly addresses...
+#   claude-3-haiku: 0.900
+#     Criteria: relevance
+#     Supporting Evidence: mostly relevant but...
 ```
 
 ### Weighted jury from benchmark results
@@ -104,24 +123,15 @@ jury = Jury(
 )
 ```
 
-### Per-juror score breakdown
-
-```python
-jury = Jury(
-    jurors=[openai_provider, litellm_provider],
-    method="relevance",
-    aggregation="median",
-    return_details=True,
-)
-
-# Returns: (0.82, {"gpt-4o-mini": 0.75, "claude-3-haiku": 0.90})
-score, per_juror = jury(prompt="What is TruLens?", response="An eval library.")
-```
+On an exact tie, `majority_vote` falls back to the median of scores rather
+than returning 0.0.
 
 ### Error handling
 
-If one juror fails, `Jury` logs a warning and aggregates the rest. Only when
-*all* jurors fail does `Jury` raise a `RuntimeError`.
+If one juror fails, `Jury` logs a warning and aggregates the rest. For
+`weighted_mean`, the failed juror's weight is redistributed proportionally
+among the survivors. Only when *all* jurors fail does `Jury` raise a
+`RuntimeError`.
 
 ## Choosing juror models
 
@@ -134,7 +144,7 @@ Practical starting point:
 
 - 3 judges from different families
 - `"median"` or `"trimmed_mean"` aggregation
-- `return_details=True` during development to inspect per-juror scores
+- Use `_with_cot_reasons` methods to capture per-juror explanations in the dashboard
 
 ## Cost and latency
 

--- a/docs/component_guides/evaluation/llm_jury.md
+++ b/docs/component_guides/evaluation/llm_jury.md
@@ -7,13 +7,6 @@ systematically favours its own style, vocabulary, and reasoning patterns.
 Research shows that ensembling a **panel of diverse judges** (a "jury")
 substantially improves evaluation reliability:
 
-| Paper | Key finding |
-|---|---|
-| [Verga et al. 2024 — PoLL](https://arxiv.org/abs/2404.18796) | A panel of diverse smaller models outperforms a single large judge and is 7× cheaper. |
-| [Zhou et al. 2025 — SE-Jury](https://arxiv.org/abs/2501.16676) | Ensemble judges narrow the gap with human evaluation on software engineering tasks. |
-| [Zhao et al. 2025 — Statistically Principled Aggregation](https://arxiv.org/abs/2503.07977) | PoLL-style juries with 3 diverse small models achieve higher human-correlation than a single large judge. |
-| [Li et al. 2025 — Auto-Prompt Ensemble](https://arxiv.org/abs/2502.07853) | Treating each evaluation dimension as an independent juror with auto-generated prompts further improves reliability. |
-
 ## The `Jury` class
 
 `Jury` wraps N `LLMProvider` instances, calls the same named feedback method on

--- a/examples/expositional/use_cases/llm_jury.ipynb
+++ b/examples/expositional/use_cases/llm_jury.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "fe257796",
+   "id": "a1ace017",
    "metadata": {},
    "source": [
     "# LLM Jury: Ensemble Evaluation with Multiple Judges\n",
@@ -16,18 +16,22 @@
     "exposes the same parameter names as the underlying provider method, **no\n",
     "changes to `Metric`, `Selector`, or the evaluation pipeline are needed**.\n",
     "\n",
+    "`Jury` always returns `(score, {\"reason\": ...})`, matching the\n",
+    "`_with_cot_reasons` convention — per-juror breakdowns appear in the dashboard\n",
+    "automatically with no UI changes.\n",
+    "\n",
     "This notebook demonstrates:\n",
     "\n",
     "1. Setting up a 3-model jury for relevance evaluation.\n",
     "2. Comparing jury scores vs. single-judge scores on a small dataset.\n",
-    "3. Inspecting per-juror score breakdowns.\n",
+    "3. Inspecting per-juror score breakdowns via `meta[\"reason\"]`.\n",
     "4. Using a weighted jury with alignment-derived weights."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dfdedbb5",
+   "id": "d7c226ec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +40,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c24af49e",
+   "id": "dd8d4e97",
    "metadata": {},
    "source": [
     "## Setup"
@@ -45,7 +49,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a24535d8",
+   "id": "5cb8380a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +60,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a06ddb87",
+   "id": "cd9d16b8",
    "metadata": {},
    "source": [
     "## 1. Providers"
@@ -65,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6a7d978e",
+   "id": "4dca7f83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,18 +82,20 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a871bb02",
+   "id": "b0cc945a",
    "metadata": {},
    "source": [
     "## 2. Build a 3-model jury for relevance\n",
     "\n",
-    "Pass `return_details=True` during development to inspect per-juror scores."
+    "`Jury` always returns `(score, {\"reason\": ...})`. The reason string contains\n",
+    "the aggregation header, each juror's score, and any CoT explanations — it\n",
+    "flows into OTEL spans and the dashboard automatically."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e980c06c",
+   "id": "da2c3773",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,21 +105,20 @@
     "    jurors=[provider_mini, provider_41],\n",
     "    method=\"relevance\",\n",
     "    aggregation=\"median\",\n",
-    "    return_details=True,\n",
     ")\n",
     "\n",
-    "# Sanity check — same interface as provider.relevance()\n",
-    "score, details = jury(\n",
+    "# Jury always returns (score, meta) — no extra flag needed.\n",
+    "score, meta = jury(\n",
     "    prompt=\"What is TruLens?\",\n",
     "    response=\"TruLens is an open-source library for evaluating LLM applications.\",\n",
     ")\n",
-    "print(f\"Jury score  : {score:.3f}\")\n",
-    "print(f\"Per-juror   : {details}\")"
+    "print(f\"Jury score:\\n{score:.3f}\")\n",
+    "print(f\"\\nPer-juror breakdown (meta['reason']):\\n{meta['reason']}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "acf5f3e6",
+   "id": "07c12ffd",
    "metadata": {},
    "source": [
     "## 3. Wire the jury into Metric"
@@ -122,7 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "565dc5db",
+   "id": "1b561e95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +149,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a5e5a5b",
+   "id": "f09a0070",
    "metadata": {},
    "source": [
     "## 4. Compare jury vs. single judge on a small dataset"
@@ -153,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a6211444",
+   "id": "4be5af5e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,22 +179,25 @@
     "\n",
     "results = []\n",
     "for row in dataset:\n",
-    "    jury_score, per_juror = jury(**row)\n",
+    "    jury_score, meta = jury(**row)\n",
     "    single_score = provider_mini.relevance(**row)\n",
     "    results.append({\n",
     "        \"prompt\": row[\"prompt\"][:40],\n",
     "        \"jury\": round(jury_score, 3),\n",
     "        \"single\": round(single_score, 3),\n",
-    "        \"details\": per_juror,\n",
+    "        \"reason\": meta[\"reason\"],\n",
     "    })\n",
     "\n",
-    "import pprint\n",
-    "pprint.pprint(results)"
+    "for r in results:\n",
+    "    print(f\"Prompt : {r['prompt']}\")\n",
+    "    print(f\"Jury   : {r['jury']}  Single: {r['single']}\")\n",
+    "    print(f\"Reason :\\n{r['reason']}\")\n",
+    "    print()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0f2c9de1",
+   "id": "dd71add6",
    "metadata": {},
    "source": [
     "## 5. Weighted jury from benchmark alignment scores\n",
@@ -201,7 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2805e250",
+   "id": "bf2b065e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,20 +218,19 @@
     "    method=\"relevance\",\n",
     "    aggregation=\"weighted_mean\",\n",
     "    weights=[0.6, 0.4],  # gpt-4o-mini scored higher on our alignment benchmark\n",
-    "    return_details=True,\n",
     ")\n",
     "\n",
-    "score, details = weighted_jury(\n",
+    "score, meta = weighted_jury(\n",
     "    prompt=\"What is TruLens?\",\n",
     "    response=\"An evaluation framework for LLM apps.\",\n",
     ")\n",
     "print(f\"Weighted jury score: {score:.3f}\")\n",
-    "print(f\"Per-juror          : {details}\")"
+    "print(f\"\\nBreakdown:\\n{meta['reason']}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b1408fbe",
+   "id": "86fc45aa",
    "metadata": {},
    "source": [
     "## 6. Use with TruApp\n",
@@ -235,7 +242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ccaf3fb3",
+   "id": "6d78c58d",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/expositional/use_cases/llm_jury.ipynb
+++ b/examples/expositional/use_cases/llm_jury.ipynb
@@ -1,0 +1,246 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LLM Jury: Ensemble Evaluation with Multiple Judges\n",
+    "\n",
+    "A single LLM judge is noisy and subject to *intra-model bias*. Research\n",
+    "shows that ensembling a **panel of diverse judges** (a \"jury\") substantially\n",
+    "improves evaluation reliability and can be cheaper when smaller models are\n",
+    "used (Verga et al. 2024 — PoLL; Zhao et al. 2025).\n",
+    "\n",
+    "`Jury` is a drop-in `implementation` for `Metric`: because its `__call__`\n",
+    "exposes the same parameter names as the underlying provider method, **no\n",
+    "changes to `Metric`, `Selector`, or the evaluation pipeline are needed**.\n",
+    "\n",
+    "This notebook demonstrates:\n",
+    "\n",
+    "1. Setting up a 3-model jury for relevance evaluation.\n",
+    "2. Comparing jury scores vs. single-judge scores on a small dataset.\n",
+    "3. Inspecting per-juror score breakdowns.\n",
+    "4. Using a weighted jury with alignment-derived weights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install trulens trulens-providers-openai trulens-providers-litellm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-...\"  # replace with your key"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Providers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.providers.openai import OpenAI\n",
+    "\n",
+    "provider_mini = OpenAI(model_engine=\"gpt-4o-mini\")\n",
+    "provider_41   = OpenAI(model_engine=\"gpt-4.1-mini\")\n",
+    "# provider_haiku = LiteLLM(model_engine=\"anthropic/claude-3-haiku-20240307\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Build a 3-model jury for relevance\n",
+    "\n",
+    "Pass `return_details=True` during development to inspect per-juror scores."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.feedback.jury import Jury\n",
+    "\n",
+    "jury = Jury(\n",
+    "    jurors=[provider_mini, provider_41],\n",
+    "    method=\"relevance\",\n",
+    "    aggregation=\"median\",\n",
+    "    return_details=True,\n",
+    ")\n",
+    "\n",
+    "# Sanity check — same interface as provider.relevance()\n",
+    "score, details = jury(\n",
+    "    prompt=\"What is TruLens?\",\n",
+    "    response=\"TruLens is an open-source library for evaluating LLM applications.\",\n",
+    ")\n",
+    "print(f\"Jury score  : {score:.3f}\")\n",
+    "print(f\"Per-juror   : {details}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Wire the jury into Metric"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.core import Metric\n",
+    "\n",
+    "m_jury = (\n",
+    "    Metric(implementation=jury, name=\"Jury Relevance\")\n",
+    "    .on_input()\n",
+    "    .on_output()\n",
+    ")\n",
+    "\n",
+    "# Single-judge baseline for comparison\n",
+    "m_single = (\n",
+    "    Metric(implementation=provider_mini.relevance, name=\"Single Relevance\")\n",
+    "    .on_input()\n",
+    "    .on_output()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Compare jury vs. single judge on a small dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = [\n",
+    "    {\n",
+    "        \"prompt\": \"What does TruLens do?\",\n",
+    "        \"response\": \"TruLens evaluates LLM-based applications with feedback functions.\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"prompt\": \"What is the capital of France?\",\n",
+    "        \"response\": \"The capital of France is Paris.\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"prompt\": \"Explain gradient descent.\",\n",
+    "        \"response\": \"I like pizza.\",  # intentionally off-topic\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "results = []\n",
+    "for row in dataset:\n",
+    "    jury_score, per_juror = jury(**row)\n",
+    "    single_score = provider_mini.relevance(**row)\n",
+    "    results.append({\n",
+    "        \"prompt\": row[\"prompt\"][:40],\n",
+    "        \"jury\": round(jury_score, 3),\n",
+    "        \"single\": round(single_score, 3),\n",
+    "        \"details\": per_juror,\n",
+    "    })\n",
+    "\n",
+    "import pprint\n",
+    "pprint.pprint(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Weighted jury from benchmark alignment scores\n",
+    "\n",
+    "If you have benchmark-derived alignment scores for each judge, use\n",
+    "`weighted_mean` to give more trusted judges a higher weight."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weighted_jury = Jury(\n",
+    "    jurors=[provider_mini, provider_41],\n",
+    "    method=\"relevance\",\n",
+    "    aggregation=\"weighted_mean\",\n",
+    "    weights=[0.6, 0.4],  # gpt-4o-mini scored higher on our alignment benchmark\n",
+    "    return_details=True,\n",
+    ")\n",
+    "\n",
+    "score, details = weighted_jury(\n",
+    "    prompt=\"What is TruLens?\",\n",
+    "    response=\"An evaluation framework for LLM apps.\",\n",
+    ")\n",
+    "print(f\"Weighted jury score: {score:.3f}\")\n",
+    "print(f\"Per-juror          : {details}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Use with TruApp\n",
+    "\n",
+    "Because `Jury` plugs directly into `Metric`, you can pass jury metrics to\n",
+    "`TruApp` exactly like any other feedback function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# from trulens.apps.langchain import TruChain\n",
+    "# tru_app = TruChain(my_chain, feedbacks=[m_jury])\n",
+    "# with tru_app:\n",
+    "#     my_chain.invoke(\"What is TruLens?\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/expositional/use_cases/llm_jury.ipynb
+++ b/examples/expositional/use_cases/llm_jury.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "fe257796",
    "metadata": {},
    "source": [
     "# LLM Jury: Ensemble Evaluation with Multiple Judges\n",
@@ -9,7 +10,7 @@
     "A single LLM judge is noisy and subject to *intra-model bias*. Research\n",
     "shows that ensembling a **panel of diverse judges** (a \"jury\") substantially\n",
     "improves evaluation reliability and can be cheaper when smaller models are\n",
-    "used (Verga et al. 2024 — PoLL; Zhao et al. 2025).\n",
+    "used.\n",
     "\n",
     "`Jury` is a drop-in `implementation` for `Metric`: because its `__call__`\n",
     "exposes the same parameter names as the underlying provider method, **no\n",
@@ -26,6 +27,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "dfdedbb5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,6 +36,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c24af49e",
    "metadata": {},
    "source": [
     "## Setup"
@@ -42,6 +45,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a24535d8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,6 +56,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a06ddb87",
    "metadata": {},
    "source": [
     "## 1. Providers"
@@ -60,6 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6a7d978e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,6 +78,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a871bb02",
    "metadata": {},
    "source": [
     "## 2. Build a 3-model jury for relevance\n",
@@ -82,6 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e980c06c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,6 +113,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "acf5f3e6",
    "metadata": {},
    "source": [
     "## 3. Wire the jury into Metric"
@@ -113,6 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "565dc5db",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,6 +144,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4a5e5a5b",
    "metadata": {},
    "source": [
     "## 4. Compare jury vs. single judge on a small dataset"
@@ -142,6 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a6211444",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,6 +189,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0f2c9de1",
    "metadata": {},
    "source": [
     "## 5. Weighted jury from benchmark alignment scores\n",
@@ -188,6 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2805e250",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,6 +223,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b1408fbe",
    "metadata": {},
    "source": [
     "## 6. Use with TruApp\n",
@@ -220,6 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ccaf3fb3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,8 +253,7 @@
    "name": "python3"
   },
   "language_info": {
-   "name": "python",
-   "version": "3.9.0"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -265,6 +265,7 @@ nav:
             - Running on existing data: component_guides/evaluation/running_feedback_functions/existing_data.md
         - Generating Test Cases:
             - component_guides/evaluation/generate_test_cases.md
+        - LLM Jury (Ensemble Judges): component_guides/evaluation/llm_jury.md
         - Evaluate MLFlow Traces: component_guides/evaluation/mlflow.md
     - 🏃 Runtime Evaluation:
         - component_guides/runtime_evaluation/index.md

--- a/src/feedback/trulens/feedback/__init__.py
+++ b/src/feedback/trulens/feedback/__init__.py
@@ -5,6 +5,7 @@ from importlib.metadata import version
 from trulens.core.utils import imports as import_utils
 from trulens.feedback.groundtruth import GroundTruthAggregator
 from trulens.feedback.groundtruth import GroundTruthAgreement
+from trulens.feedback.jury import Jury
 from trulens.feedback.llm_provider import LLMProvider
 from trulens.feedback.schema_validator import SchemaValidator
 
@@ -23,6 +24,7 @@ __version__ = version(
 __all__ = [
     "GroundTruthAgreement",
     "GroundTruthAggregator",
+    "Jury",
     "LLMProvider",
     "Embeddings",
     "SchemaValidator",

--- a/src/feedback/trulens/feedback/jury.py
+++ b/src/feedback/trulens/feedback/jury.py
@@ -4,26 +4,26 @@ A single LLM judge is noisy and subject to intra-model bias. Ensembling a
 *panel* of diverse judges (a "jury") improves reliability, reduces bias, and
 can be cheaper when smaller models are used.
 
-References:
-    Verga et al. 2024 — PoLL: Panel of LLM evaluators.
-    Zhou et al. 2025 — SE-Jury: LLM-as-Ensemble-Judge.
-    Zhao et al. 2025 — Statistically principled aggregation of LLM judges.
 """
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import as_completed
 import inspect
 import logging
 import statistics
-from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import as_completed
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 logger = logging.getLogger(__name__)
 
-_BUILTIN_STRATEGIES = frozenset(
-    {"mean", "median", "trimmed_mean", "majority_vote", "weighted_mean"}
-)
+_BUILTIN_STRATEGIES = frozenset({
+    "mean",
+    "median",
+    "trimmed_mean",
+    "majority_vote",
+    "weighted_mean",
+})
 
 
 class Jury:
@@ -89,7 +89,10 @@ class Jury:
         if not jurors:
             raise ValueError("jurors must be a non-empty list.")
 
-        if isinstance(aggregation, str) and aggregation not in _BUILTIN_STRATEGIES:
+        if (
+            isinstance(aggregation, str)
+            and aggregation not in _BUILTIN_STRATEGIES
+        ):
             raise ValueError(
                 f"Unknown aggregation strategy {aggregation!r}. "
                 f"Choose one of {sorted(_BUILTIN_STRATEGIES)} or pass a callable."
@@ -129,7 +132,9 @@ class Jury:
     # Public interface
     # ------------------------------------------------------------------
 
-    def __call__(self, **kwargs: Any) -> Union[float, Tuple[float, Dict[str, float]]]:
+    def __call__(
+        self, **kwargs: Any
+    ) -> Union[float, Tuple[float, Dict[str, float]]]:
         """Evaluate *kwargs* in parallel across all jurors and return an aggregated score.
 
         Args:
@@ -154,7 +159,9 @@ class Jury:
                 idx = future_to_idx[future]
                 try:
                     raw = future.result()
-                    score = float(raw[0]) if isinstance(raw, tuple) else float(raw)
+                    score = (
+                        float(raw[0]) if isinstance(raw, tuple) else float(raw)
+                    )
                     results[idx] = score
                 except Exception as exc:
                     logger.warning(
@@ -198,7 +205,9 @@ class Jury:
     def _aggregate(self, ordered: List[Tuple[int, float]]) -> float:
         scores = [s for _, s in ordered]
 
-        if callable(self._aggregation) and not isinstance(self._aggregation, str):
+        if callable(self._aggregation) and not isinstance(
+            self._aggregation, str
+        ):
             return float(self._aggregation(scores))
 
         if self._aggregation == "mean":

--- a/src/feedback/trulens/feedback/jury.py
+++ b/src/feedback/trulens/feedback/jury.py
@@ -1,0 +1,224 @@
+"""LLM Jury — ensemble multiple LLM judges into a single feedback callable.
+
+A single LLM judge is noisy and subject to intra-model bias. Ensembling a
+*panel* of diverse judges (a "jury") improves reliability, reduces bias, and
+can be cheaper when smaller models are used.
+
+References:
+    Verga et al. 2024 — PoLL: Panel of LLM evaluators.
+    Zhou et al. 2025 — SE-Jury: LLM-as-Ensemble-Judge.
+    Zhao et al. 2025 — Statistically principled aggregation of LLM judges.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import statistics
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import as_completed
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+logger = logging.getLogger(__name__)
+
+_BUILTIN_STRATEGIES = frozenset(
+    {"mean", "median", "trimmed_mean", "majority_vote", "weighted_mean"}
+)
+
+
+class Jury:
+    """Ensemble multiple LLM judges into a single feedback callable.
+
+    ``Jury`` wraps N provider instances, calls the same named method on each
+    in parallel, and aggregates their scores using a configurable strategy.
+    Because ``Jury.__call__`` exposes the same parameter names as the
+    underlying provider method, it plugs directly into
+    ``Metric(implementation=jury)`` — no changes to Metric, Selector, or
+    the evaluation pipeline are needed.
+
+    Args:
+        jurors: Non-empty list of ``LLMProvider`` instances.
+        method: Name of the feedback method to call on each juror, e.g.
+            ``"relevance"`` or ``"groundedness_measure_with_cot_reasons"``.
+        aggregation: How to combine individual juror scores. Accepts a
+            strategy name (``"mean"``, ``"median"``, ``"trimmed_mean"``,
+            ``"majority_vote"``, ``"weighted_mean"``) or any
+            ``Callable[[List[float]], float]``. Defaults to ``"mean"``.
+        weights: Per-juror weights for ``"weighted_mean"``. Must have the
+            same length as *jurors*. When a juror fails its weight is
+            redistributed proportionally among the successful ones.
+        threshold: Binarisation threshold for ``"majority_vote"``.
+            Scores >= *threshold* count as a positive vote. Defaults to
+            ``0.5``.
+        return_details: When ``True``, ``__call__`` returns a
+            ``(score, details)`` tuple where *details* maps each juror's
+            model name to its individual score.
+        max_workers: Maximum parallel threads. Defaults to
+            ``len(jurors)``.
+
+    Example::
+
+        from trulens.core import Metric
+        from trulens.feedback.jury import Jury
+        from trulens.providers.openai import OpenAI
+        from trulens.providers.litellm import LiteLLM
+
+        jury = Jury(
+            jurors=[
+                OpenAI(model_engine="gpt-4o-mini"),
+                OpenAI(model_engine="gpt-4.1-mini"),
+                LiteLLM(model_engine="anthropic/claude-3-haiku-20240307"),
+            ],
+            method="relevance",
+            aggregation="median",
+        )
+        m = Metric(implementation=jury, name="Jury Relevance").on_input().on_output()
+    """
+
+    def __init__(
+        self,
+        jurors: List[Any],
+        method: str,
+        aggregation: Union[str, Callable[[List[float]], float]] = "mean",
+        *,
+        weights: Optional[List[float]] = None,
+        threshold: float = 0.5,
+        return_details: bool = False,
+        max_workers: Optional[int] = None,
+    ) -> None:
+        if not jurors:
+            raise ValueError("jurors must be a non-empty list.")
+
+        if isinstance(aggregation, str) and aggregation not in _BUILTIN_STRATEGIES:
+            raise ValueError(
+                f"Unknown aggregation strategy {aggregation!r}. "
+                f"Choose one of {sorted(_BUILTIN_STRATEGIES)} or pass a callable."
+            )
+
+        if aggregation == "weighted_mean":
+            if weights is None:
+                raise ValueError(
+                    "weights must be provided when aggregation='weighted_mean'."
+                )
+            if len(weights) != len(jurors):
+                raise ValueError(
+                    f"len(weights)={len(weights)} must equal len(jurors)={len(jurors)}."
+                )
+
+        # Validate method exists and capture its signature for Metric introspection.
+        bound_method = getattr(jurors[0], method, None)
+        if bound_method is None or not callable(bound_method):
+            raise AttributeError(
+                f"Juror {type(jurors[0]).__name__!r} has no callable method {method!r}."
+            )
+
+        self._jurors = jurors
+        self._method = method
+        self._aggregation = aggregation
+        self._weights = weights
+        self._threshold = threshold
+        self._return_details = return_details
+        self._max_workers = max_workers or len(jurors)
+
+        # Expose the provider method's signature so Metric's selector validation
+        # works correctly (inspect.signature checks __signature__ first).
+        self.__signature__ = inspect.signature(bound_method)
+        self.__name__ = f"jury_{method}"
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def __call__(self, **kwargs: Any) -> Union[float, Tuple[float, Dict[str, float]]]:
+        """Evaluate *kwargs* in parallel across all jurors and return an aggregated score.
+
+        Args:
+            **kwargs: The same keyword arguments accepted by the underlying
+                provider method (e.g. ``prompt`` and ``response`` for
+                ``relevance``).
+
+        Returns:
+            A float score, or a ``(float, dict)`` tuple when
+            *return_details* is ``True``.
+        """
+        # idx -> score; preserves juror order for weighted_mean.
+        results: Dict[int, float] = {}
+
+        with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
+            future_to_idx = {
+                executor.submit(self._call_juror, juror, kwargs): idx
+                for idx, juror in enumerate(self._jurors)
+            }
+
+            for future in as_completed(future_to_idx):
+                idx = future_to_idx[future]
+                try:
+                    raw = future.result()
+                    score = float(raw[0]) if isinstance(raw, tuple) else float(raw)
+                    results[idx] = score
+                except Exception as exc:
+                    logger.warning(
+                        "Juror %r (index %d) failed: %s",
+                        self._juror_name(idx),
+                        idx,
+                        exc,
+                    )
+
+        if not results:
+            raise RuntimeError(
+                f"All {len(self._jurors)} jurors failed to produce a score."
+            )
+
+        ordered = sorted(results.items())  # [(idx, score), ...]
+        agg_score = self._aggregate(ordered)
+
+        if self._return_details:
+            details = {self._juror_name(idx): score for idx, score in ordered}
+            return agg_score, details
+        return agg_score
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _call_juror(self, juror: Any, kwargs: dict) -> Any:
+        return getattr(juror, self._method)(**kwargs)
+
+    def _juror_name(self, idx: int) -> str:
+        juror = self._jurors[idx]
+        engine = getattr(juror, "model_engine", None)
+        base = str(engine) if engine else type(juror).__name__
+        # Append index only when the same base name appears more than once.
+        all_bases = [
+            str(getattr(j, "model_engine", None) or type(j).__name__)
+            for j in self._jurors
+        ]
+        return f"{base}[{idx}]" if all_bases.count(base) > 1 else base
+
+    def _aggregate(self, ordered: List[Tuple[int, float]]) -> float:
+        scores = [s for _, s in ordered]
+
+        if callable(self._aggregation) and not isinstance(self._aggregation, str):
+            return float(self._aggregation(scores))
+
+        if self._aggregation == "mean":
+            return statistics.mean(scores)
+
+        if self._aggregation == "median":
+            return statistics.median(scores)
+
+        if self._aggregation == "trimmed_mean":
+            if len(scores) < 3:
+                return statistics.mean(scores)
+            return statistics.mean(sorted(scores)[1:-1])
+
+        if self._aggregation == "majority_vote":
+            votes = sum(1 for s in scores if s >= self._threshold)
+            return float(int(votes > len(scores) / 2))
+
+        if self._aggregation == "weighted_mean":
+            idxs = [idx for idx, _ in ordered]
+            total = sum(self._weights[i] for i in idxs)
+            return sum(self._weights[i] * s for i, s in ordered) / total
+
+        raise ValueError(f"Unknown aggregation: {self._aggregation!r}")

--- a/src/feedback/trulens/feedback/jury.py
+++ b/src/feedback/trulens/feedback/jury.py
@@ -8,12 +8,13 @@ can be cheaper when smaller models are used.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import as_completed
 import inspect
 import logging
 import statistics
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +37,11 @@ class Jury:
     ``Metric(implementation=jury)`` — no changes to Metric, Selector, or
     the evaluation pipeline are needed.
 
+    ``__call__`` always returns ``(score, {"reason": ...})``, matching the
+    ``_with_cot_reasons`` convention so per-juror breakdowns flow into
+    ``FeedbackCall.meta["reason"]`` and are visible in OTEL spans and the
+    dashboard without any UI changes.
+
     Args:
         jurors: Non-empty list of ``LLMProvider`` instances.
         method: Name of the feedback method to call on each juror, e.g.
@@ -43,16 +49,13 @@ class Jury:
         aggregation: How to combine individual juror scores. Accepts a
             strategy name (``"mean"``, ``"median"``, ``"trimmed_mean"``,
             ``"majority_vote"``, ``"weighted_mean"``) or any
-            ``Callable[[List[float]], float]``. Defaults to ``"mean"``.
+            ``Callable[[list[float]], float]``. Defaults to ``"mean"``.
         weights: Per-juror weights for ``"weighted_mean"``. Must have the
             same length as *jurors*. When a juror fails its weight is
             redistributed proportionally among the successful ones.
         threshold: Binarisation threshold for ``"majority_vote"``.
             Scores >= *threshold* count as a positive vote. Defaults to
-            ``0.5``.
-        return_details: When ``True``, ``__call__`` returns a
-            ``(score, details)`` tuple where *details* maps each juror's
-            model name to its individual score.
+            ``0.5``. On an exact tie falls back to median.
         max_workers: Maximum parallel threads. Defaults to
             ``len(jurors)``.
 
@@ -77,14 +80,13 @@ class Jury:
 
     def __init__(
         self,
-        jurors: List[Any],
+        jurors: list[Any],
         method: str,
-        aggregation: Union[str, Callable[[List[float]], float]] = "mean",
+        aggregation: str | Callable[[list[float]], float] = "mean",
         *,
-        weights: Optional[List[float]] = None,
+        weights: list[float] | None = None,
         threshold: float = 0.5,
-        return_details: bool = False,
-        max_workers: Optional[int] = None,
+        max_workers: int | None = None,
     ) -> None:
         if not jurors:
             raise ValueError("jurors must be a non-empty list.")
@@ -108,46 +110,40 @@ class Jury:
                     f"len(weights)={len(weights)} must equal len(jurors)={len(jurors)}."
                 )
 
-        # Validate method exists and capture its signature for Metric introspection.
-        bound_method = getattr(jurors[0], method, None)
-        if bound_method is None or not callable(bound_method):
-            raise AttributeError(
-                f"Juror {type(jurors[0]).__name__!r} has no callable method {method!r}."
-            )
+        # Validate ALL jurors have the method.
+        for i, juror in enumerate(jurors):
+            bound = getattr(juror, method, None)
+            if bound is None or not callable(bound):
+                raise AttributeError(
+                    f"Juror {type(juror).__name__!r} at index {i} has no callable method {method!r}."
+                )
 
         self._jurors = jurors
         self._method = method
         self._aggregation = aggregation
         self._weights = weights
         self._threshold = threshold
-        self._return_details = return_details
         self._max_workers = max_workers or len(jurors)
 
-        # Expose the provider method's signature so Metric's selector validation
-        # works correctly (inspect.signature checks __signature__ first).
-        self.__signature__ = inspect.signature(bound_method)
+        # Precompute once in __init__ (O(n)) instead of rebuilding per __call__ (O(n²)).
+        self._juror_names: list[str] = self._build_juror_names()
+
+        self.__signature__ = inspect.signature(getattr(jurors[0], method))
         self.__name__ = f"jury_{method}"
 
     # ------------------------------------------------------------------
     # Public interface
     # ------------------------------------------------------------------
 
-    def __call__(
-        self, **kwargs: Any
-    ) -> Union[float, Tuple[float, Dict[str, float]]]:
-        """Evaluate *kwargs* in parallel across all jurors and return an aggregated score.
+    def __call__(self, **kwargs: Any) -> tuple[float, dict[str, Any]]:
+        """Evaluate *kwargs* in parallel across all jurors.
 
-        Args:
-            **kwargs: The same keyword arguments accepted by the underlying
-                provider method (e.g. ``prompt`` and ``response`` for
-                ``relevance``).
-
-        Returns:
-            A float score, or a ``(float, dict)`` tuple when
-            *return_details* is ``True``.
+        Always returns ``(score, {"reason": ...})``, matching the
+        ``_with_cot_reasons`` convention. Per-juror scores and any CoT
+        explanations are embedded in the reason string so they appear in
+        OTEL spans and the dashboard automatically.
         """
-        # idx -> score; preserves juror order for weighted_mean.
-        results: Dict[int, float] = {}
+        results: dict[int, tuple[float, str | None]] = {}
 
         with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
             future_to_idx = {
@@ -159,14 +155,22 @@ class Jury:
                 idx = future_to_idx[future]
                 try:
                     raw = future.result()
-                    score = (
-                        float(raw[0]) if isinstance(raw, tuple) else float(raw)
-                    )
-                    results[idx] = score
-                except Exception as exc:
+                    if isinstance(raw, tuple):
+                        score = float(raw[0])
+                        meta = (
+                            raw[1]
+                            if len(raw) > 1 and isinstance(raw[1], dict)
+                            else {}
+                        )
+                        reason: str | None = meta.get("reason")
+                    else:
+                        score = float(raw)
+                        reason = None
+                    results[idx] = (score, reason)
+                except Exception as exc:  # noqa: BLE001
                     logger.warning(
                         "Juror %r (index %d) failed: %s",
-                        self._juror_name(idx),
+                        self._juror_names[idx],
                         idx,
                         exc,
                     )
@@ -176,13 +180,19 @@ class Jury:
                 f"All {len(self._jurors)} jurors failed to produce a score."
             )
 
-        ordered = sorted(results.items())  # [(idx, score), ...]
-        agg_score = self._aggregate(ordered)
+        ordered_idxs = sorted(results.keys())
+        scores_by_idx = {idx: results[idx][0] for idx in ordered_idxs}
+        agg_score = self._aggregate(scores_by_idx)
 
-        if self._return_details:
-            details = {self._juror_name(idx): score for idx, score in ordered}
-            return agg_score, details
-        return agg_score
+        lines = [f"Aggregation: {self._aggregation} → {agg_score:.3f}"]
+        for idx in ordered_idxs:
+            score, reason = results[idx]
+            lines.append(f"  {self._juror_names[idx]}: {score:.3f}")
+            if reason:
+                for line in reason.splitlines():
+                    lines.append(f"    {line}")
+
+        return agg_score, {"reason": "\n".join(lines)}
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -191,18 +201,18 @@ class Jury:
     def _call_juror(self, juror: Any, kwargs: dict) -> Any:
         return getattr(juror, self._method)(**kwargs)
 
-    def _juror_name(self, idx: int) -> str:
-        juror = self._jurors[idx]
-        engine = getattr(juror, "model_engine", None)
-        base = str(engine) if engine else type(juror).__name__
-        # Append index only when the same base name appears more than once.
-        all_bases = [
+    def _build_juror_names(self) -> list[str]:
+        bases = [
             str(getattr(j, "model_engine", None) or type(j).__name__)
             for j in self._jurors
         ]
-        return f"{base}[{idx}]" if all_bases.count(base) > 1 else base
+        return [
+            f"{base}[{i}]" if bases.count(base) > 1 else base
+            for i, base in enumerate(bases)
+        ]
 
-    def _aggregate(self, ordered: List[Tuple[int, float]]) -> float:
+    def _aggregate(self, scores_by_idx: dict[int, float]) -> float:
+        ordered = sorted(scores_by_idx.items())
         scores = [s for _, s in ordered]
 
         if callable(self._aggregation) and not isinstance(
@@ -223,11 +233,21 @@ class Jury:
 
         if self._aggregation == "majority_vote":
             votes = sum(1 for s in scores if s >= self._threshold)
+            if votes * 2 == len(scores):
+                logger.warning(
+                    "Jury majority_vote tie (%d/%d). Falling back to median.",
+                    votes,
+                    len(scores),
+                )
+                return float(statistics.median(scores))
             return float(int(votes > len(scores) / 2))
 
         if self._aggregation == "weighted_mean":
-            idxs = [idx for idx, _ in ordered]
-            total = sum(self._weights[i] for i in idxs)
-            return sum(self._weights[i] * s for i, s in ordered) / total
+            total = sum(self._weights[idx] for idx in scores_by_idx)
+            if total == 0.0:
+                raise ValueError(
+                    "weighted_mean: total weight of surviving jurors is 0.0."
+                )
+            return sum(self._weights[idx] * s for idx, s in ordered) / total
 
         raise ValueError(f"Unknown aggregation: {self._aggregation!r}")

--- a/tests/unit/test_jury.py
+++ b/tests/unit/test_jury.py
@@ -3,11 +3,9 @@
 import inspect
 import statistics
 import unittest
-from typing import Dict, List, Optional, Tuple
 from unittest.mock import MagicMock
 
 from trulens.feedback.jury import Jury
-
 
 # ---------------------------------------------------------------------------
 # Mock helpers
@@ -47,8 +45,7 @@ def _make_tuple_provider(model_engine: str, score: float):
 # ---------------------------------------------------------------------------
 
 
-def _mock_relevance(prompt: str, response: str) -> float:
-    ...
+def _mock_relevance(prompt: str, response: str) -> float: ...
 
 
 # ---------------------------------------------------------------------------
@@ -135,7 +132,11 @@ class TestJuryConstruction(unittest.TestCase):
 
     def test_weighted_mean_without_weights_raises(self):
         with self.assertRaises(ValueError):
-            Jury([self._provider()], method="relevance", aggregation="weighted_mean")
+            Jury(
+                [self._provider()],
+                method="relevance",
+                aggregation="weighted_mean",
+            )
 
     def test_weighted_mean_wrong_length_raises(self):
         with self.assertRaises(ValueError):

--- a/tests/unit/test_jury.py
+++ b/tests/unit/test_jury.py
@@ -1,0 +1,285 @@
+"""Unit tests for trulens.feedback.jury.Jury."""
+
+import inspect
+import statistics
+import unittest
+from typing import Dict, List, Optional, Tuple
+from unittest.mock import MagicMock
+
+from trulens.feedback.jury import Jury
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_provider(model_engine: str, score: float):
+    """Create a mock provider whose relevance() returns *score*."""
+    provider = MagicMock()
+    provider.model_engine = model_engine
+    provider.relevance.side_effect = lambda prompt, response, **kw: score
+    return provider
+
+
+def _make_failing_provider(model_engine: str):
+    """Create a mock provider whose relevance() always raises."""
+    provider = MagicMock()
+    provider.model_engine = model_engine
+    provider.relevance.side_effect = RuntimeError("LLM unavailable")
+    return provider
+
+
+def _make_tuple_provider(model_engine: str, score: float):
+    """Create a mock provider whose relevance() returns (score, metadata)."""
+    provider = MagicMock()
+    provider.model_engine = model_engine
+    provider.relevance.side_effect = lambda prompt, response, **kw: (
+        score,
+        {"reason": "ok"},
+    )
+    return provider
+
+
+# ---------------------------------------------------------------------------
+# Signature shim — gives mock providers a realistic relevance signature so
+# inspect.signature works the same as on a real LLMProvider.
+# ---------------------------------------------------------------------------
+
+
+def _mock_relevance(prompt: str, response: str) -> float:
+    ...
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+
+class TestJuryAggregation(unittest.TestCase):
+    def _jury(self, scores, aggregation="mean", **kw):
+        providers = [_make_provider(f"m{i}", s) for i, s in enumerate(scores)]
+        # Give providers a realistic signature for the method
+        for p in providers:
+            p.relevance.__func__ = _mock_relevance
+            p.relevance.__self__ = p
+        j = Jury(providers, method="relevance", aggregation=aggregation, **kw)
+        # Inject realistic __signature__ so tests reflect real usage
+        j.__signature__ = inspect.signature(_mock_relevance)
+        return j
+
+    def _call(self, jury):
+        return jury(prompt="What is TruLens?", response="An eval library.")
+
+    def test_mean(self):
+        j = self._jury([0.6, 0.8, 1.0], "mean")
+        result = self._call(j)
+        self.assertAlmostEqual(result, statistics.mean([0.6, 0.8, 1.0]))
+
+    def test_median(self):
+        j = self._jury([0.2, 0.9, 0.5], "median")
+        result = self._call(j)
+        self.assertAlmostEqual(result, statistics.median([0.2, 0.9, 0.5]))
+
+    def test_trimmed_mean(self):
+        j = self._jury([0.1, 0.5, 0.9], "trimmed_mean")
+        result = self._call(j)
+        self.assertAlmostEqual(result, 0.5)
+
+    def test_trimmed_mean_fewer_than_three_falls_back_to_mean(self):
+        j = self._jury([0.4, 0.8], "trimmed_mean")
+        result = self._call(j)
+        self.assertAlmostEqual(result, statistics.mean([0.4, 0.8]))
+
+    def test_majority_vote_positive(self):
+        # 3 above threshold (0.5), 1 below → majority positive → 1.0
+        j = self._jury([0.6, 0.7, 0.8, 0.3], "majority_vote", threshold=0.5)
+        result = self._call(j)
+        self.assertAlmostEqual(result, 1.0)
+
+    def test_majority_vote_negative(self):
+        # 1 above threshold, 2 below → not majority → 0.0
+        j = self._jury([0.8, 0.2, 0.3], "majority_vote", threshold=0.5)
+        result = self._call(j)
+        self.assertAlmostEqual(result, 0.0)
+
+    def test_weighted_mean(self):
+        j = self._jury(
+            [1.0, 0.0, 0.5],
+            "weighted_mean",
+            weights=[0.5, 0.3, 0.2],
+        )
+        expected = 1.0 * 0.5 + 0.0 * 0.3 + 0.5 * 0.2
+        result = self._call(j)
+        self.assertAlmostEqual(result, expected)
+
+    def test_custom_aggregation_callable(self):
+        j = self._jury([0.3, 0.7], aggregation=lambda scores: max(scores))
+        result = self._call(j)
+        self.assertAlmostEqual(result, 0.7)
+
+
+class TestJuryConstruction(unittest.TestCase):
+    def _provider(self, name="gpt-4o", score=0.5):
+        p = _make_provider(name, score)
+        p.relevance.__signature__ = inspect.signature(_mock_relevance)
+        return p
+
+    def test_empty_jurors_raises(self):
+        with self.assertRaises(ValueError):
+            Jury([], method="relevance")
+
+    def test_unknown_strategy_raises(self):
+        with self.assertRaises(ValueError):
+            Jury([self._provider()], method="relevance", aggregation="harmonic")
+
+    def test_weighted_mean_without_weights_raises(self):
+        with self.assertRaises(ValueError):
+            Jury([self._provider()], method="relevance", aggregation="weighted_mean")
+
+    def test_weighted_mean_wrong_length_raises(self):
+        with self.assertRaises(ValueError):
+            Jury(
+                [self._provider(), self._provider()],
+                method="relevance",
+                aggregation="weighted_mean",
+                weights=[0.5],
+            )
+
+    def test_missing_method_raises(self):
+        p = MagicMock(spec=[])  # no attributes
+        with self.assertRaises(AttributeError):
+            Jury([p], method="relevance")
+
+    def test_signature_matches_underlying_method(self):
+        p = self._provider()
+        p.relevance.__signature__ = inspect.signature(_mock_relevance)
+        j = Jury([p], method="relevance")
+        sig = inspect.signature(j)
+        self.assertIn("prompt", sig.parameters)
+        self.assertIn("response", sig.parameters)
+
+    def test_dunder_name_set(self):
+        p = self._provider()
+        j = Jury([p], method="relevance")
+        self.assertEqual(j.__name__, "jury_relevance")
+
+
+class TestJuryErrorHandling(unittest.TestCase):
+    def _sig(self, provider):
+        provider.relevance.__signature__ = inspect.signature(_mock_relevance)
+        return provider
+
+    def test_one_juror_fails_aggregates_rest(self):
+        good = self._sig(_make_provider("good", 0.8))
+        bad = self._sig(_make_failing_provider("bad"))
+        j = Jury([good, bad], method="relevance")
+        j.__signature__ = inspect.signature(_mock_relevance)
+        result = j(prompt="x", response="y")
+        self.assertAlmostEqual(result, 0.8)
+
+    def test_all_jurors_fail_raises(self):
+        p1 = self._sig(_make_failing_provider("a"))
+        p2 = self._sig(_make_failing_provider("b"))
+        j = Jury([p1, p2], method="relevance")
+        j.__signature__ = inspect.signature(_mock_relevance)
+        with self.assertRaises(RuntimeError):
+            j(prompt="x", response="y")
+
+
+class TestJuryReturnDetails(unittest.TestCase):
+    def test_return_details_false_returns_float(self):
+        p = _make_provider("gpt-4o", 0.75)
+        p.relevance.__signature__ = inspect.signature(_mock_relevance)
+        j = Jury([p], method="relevance", return_details=False)
+        j.__signature__ = inspect.signature(_mock_relevance)
+        result = j(prompt="x", response="y")
+        self.assertIsInstance(result, float)
+
+    def test_return_details_true_returns_tuple(self):
+        p = _make_provider("gpt-4o", 0.75)
+        p.relevance.__signature__ = inspect.signature(_mock_relevance)
+        j = Jury([p], method="relevance", return_details=True)
+        j.__signature__ = inspect.signature(_mock_relevance)
+        result = j(prompt="x", response="y")
+        self.assertIsInstance(result, tuple)
+        score, details = result
+        self.assertIsInstance(score, float)
+        self.assertIsInstance(details, dict)
+        self.assertAlmostEqual(score, 0.75)
+
+    def test_details_dict_contains_per_juror_scores(self):
+        providers = [
+            _make_provider("gpt-4o-mini", 0.6),
+            _make_provider("claude-haiku", 0.9),
+        ]
+        for p in providers:
+            p.relevance.__signature__ = inspect.signature(_mock_relevance)
+        j = Jury(providers, method="relevance", return_details=True)
+        j.__signature__ = inspect.signature(_mock_relevance)
+        _, details = j(prompt="x", response="y")
+        self.assertIn("gpt-4o-mini", details)
+        self.assertIn("claude-haiku", details)
+        self.assertAlmostEqual(details["gpt-4o-mini"], 0.6)
+        self.assertAlmostEqual(details["claude-haiku"], 0.9)
+
+    def test_tuple_result_from_provider_unwrapped(self):
+        p = _make_tuple_provider("gpt-4o", 0.7)
+        p.relevance.__signature__ = inspect.signature(_mock_relevance)
+        j = Jury([p], method="relevance")
+        j.__signature__ = inspect.signature(_mock_relevance)
+        result = j(prompt="x", response="y")
+        self.assertAlmostEqual(result, 0.7)
+
+
+class TestJuryMetricIntegration(unittest.TestCase):
+    """Verify Jury integrates with Metric without changes to Metric."""
+
+    def test_metric_accepts_jury_as_implementation(self):
+        from trulens.core import Metric
+
+        p1 = _make_provider("gpt-4o-mini", 0.8)
+        p1.relevance.__signature__ = inspect.signature(_mock_relevance)
+        p2 = _make_provider("claude-haiku", 0.6)
+        p2.relevance.__signature__ = inspect.signature(_mock_relevance)
+
+        j = Jury([p1, p2], method="relevance", aggregation="mean")
+        j.__signature__ = inspect.signature(_mock_relevance)
+
+        m = Metric(implementation=j, name="Test Jury").on_input().on_output()
+        self.assertIsNotNone(m)
+        self.assertEqual(m.supplied_name, "Test Jury")
+
+    def test_metric_selector_validation_passes(self):
+        from trulens.core import Metric
+
+        p = _make_provider("gpt-4o", 0.9)
+        p.relevance.__signature__ = inspect.signature(_mock_relevance)
+
+        j = Jury([p], method="relevance")
+        j.__signature__ = inspect.signature(_mock_relevance)
+
+        # on_input() binds 'prompt', on_output() binds 'response'.
+        # Metric validates both are in Jury's __signature__ — this must not raise.
+        m = Metric(implementation=j).on_input().on_output()
+        self.assertIn("prompt", m.selectors)
+        self.assertIn("response", m.selectors)
+
+
+class TestJuryDuplicateNames(unittest.TestCase):
+    def test_duplicate_model_engine_names_disambiguated(self):
+        p1 = _make_provider("gpt-4o-mini", 0.7)
+        p1.relevance.__signature__ = inspect.signature(_mock_relevance)
+        p2 = _make_provider("gpt-4o-mini", 0.9)
+        p2.relevance.__signature__ = inspect.signature(_mock_relevance)
+        j = Jury([p1, p2], method="relevance", return_details=True)
+        j.__signature__ = inspect.signature(_mock_relevance)
+        _, details = j(prompt="x", response="y")
+        self.assertEqual(len(details), 2)
+        # Names must be distinct (indexed).
+        self.assertIn("gpt-4o-mini[0]", details)
+        self.assertIn("gpt-4o-mini[1]", details)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_jury.py
+++ b/tests/unit/test_jury.py
@@ -1,5 +1,7 @@
 """Unit tests for trulens.feedback.jury.Jury."""
 
+from __future__ import annotations
+
 import inspect
 import statistics
 import unittest
@@ -28,13 +30,13 @@ def _make_failing_provider(model_engine: str):
     return provider
 
 
-def _make_tuple_provider(model_engine: str, score: float):
-    """Create a mock provider whose relevance() returns (score, metadata)."""
+def _make_cot_provider(model_engine: str, score: float, reason: str):
+    """Create a mock provider whose relevance() returns (score, {"reason": reason})."""
     provider = MagicMock()
     provider.model_engine = model_engine
     provider.relevance.side_effect = lambda prompt, response, **kw: (
         score,
-        {"reason": "ok"},
+        {"reason": reason},
     )
     return provider
 
@@ -56,49 +58,49 @@ def _mock_relevance(prompt: str, response: str) -> float: ...
 class TestJuryAggregation(unittest.TestCase):
     def _jury(self, scores, aggregation="mean", **kw):
         providers = [_make_provider(f"m{i}", s) for i, s in enumerate(scores)]
-        # Give providers a realistic signature for the method
         for p in providers:
             p.relevance.__func__ = _mock_relevance
             p.relevance.__self__ = p
         j = Jury(providers, method="relevance", aggregation=aggregation, **kw)
-        # Inject realistic __signature__ so tests reflect real usage
         j.__signature__ = inspect.signature(_mock_relevance)
         return j
 
-    def _call(self, jury):
-        return jury(prompt="What is TruLens?", response="An eval library.")
+    def _call(self, jury) -> float:
+        score, _ = jury(prompt="What is TruLens?", response="An eval library.")
+        return score
 
     def test_mean(self):
         j = self._jury([0.6, 0.8, 1.0], "mean")
-        result = self._call(j)
-        self.assertAlmostEqual(result, statistics.mean([0.6, 0.8, 1.0]))
+        self.assertAlmostEqual(self._call(j), statistics.mean([0.6, 0.8, 1.0]))
 
     def test_median(self):
         j = self._jury([0.2, 0.9, 0.5], "median")
-        result = self._call(j)
-        self.assertAlmostEqual(result, statistics.median([0.2, 0.9, 0.5]))
+        self.assertAlmostEqual(
+            self._call(j), statistics.median([0.2, 0.9, 0.5])
+        )
 
     def test_trimmed_mean(self):
         j = self._jury([0.1, 0.5, 0.9], "trimmed_mean")
-        result = self._call(j)
-        self.assertAlmostEqual(result, 0.5)
+        self.assertAlmostEqual(self._call(j), 0.5)
 
     def test_trimmed_mean_fewer_than_three_falls_back_to_mean(self):
         j = self._jury([0.4, 0.8], "trimmed_mean")
-        result = self._call(j)
-        self.assertAlmostEqual(result, statistics.mean([0.4, 0.8]))
+        self.assertAlmostEqual(self._call(j), statistics.mean([0.4, 0.8]))
 
     def test_majority_vote_positive(self):
-        # 3 above threshold (0.5), 1 below → majority positive → 1.0
+        # 3 above threshold, 1 below → majority positive → 1.0
         j = self._jury([0.6, 0.7, 0.8, 0.3], "majority_vote", threshold=0.5)
-        result = self._call(j)
-        self.assertAlmostEqual(result, 1.0)
+        self.assertAlmostEqual(self._call(j), 1.0)
 
     def test_majority_vote_negative(self):
         # 1 above threshold, 2 below → not majority → 0.0
         j = self._jury([0.8, 0.2, 0.3], "majority_vote", threshold=0.5)
-        result = self._call(j)
-        self.assertAlmostEqual(result, 0.0)
+        self.assertAlmostEqual(self._call(j), 0.0)
+
+    def test_majority_vote_tie_falls_back_to_median(self):
+        # Exact tie: 1 above, 1 below → falls back to median
+        j = self._jury([0.8, 0.2], "majority_vote", threshold=0.5)
+        self.assertAlmostEqual(self._call(j), statistics.median([0.8, 0.2]))
 
     def test_weighted_mean(self):
         j = self._jury(
@@ -107,13 +109,11 @@ class TestJuryAggregation(unittest.TestCase):
             weights=[0.5, 0.3, 0.2],
         )
         expected = 1.0 * 0.5 + 0.0 * 0.3 + 0.5 * 0.2
-        result = self._call(j)
-        self.assertAlmostEqual(result, expected)
+        self.assertAlmostEqual(self._call(j), expected)
 
     def test_custom_aggregation_callable(self):
         j = self._jury([0.3, 0.7], aggregation=lambda scores: max(scores))
-        result = self._call(j)
-        self.assertAlmostEqual(result, 0.7)
+        self.assertAlmostEqual(self._call(j), 0.7)
 
 
 class TestJuryConstruction(unittest.TestCase):
@@ -147,10 +147,16 @@ class TestJuryConstruction(unittest.TestCase):
                 weights=[0.5],
             )
 
-    def test_missing_method_raises(self):
+    def test_missing_method_on_first_juror_raises(self):
         p = MagicMock(spec=[])  # no attributes
         with self.assertRaises(AttributeError):
             Jury([p], method="relevance")
+
+    def test_missing_method_on_later_juror_raises(self):
+        good = self._provider()
+        bad = MagicMock(spec=[])  # no attributes
+        with self.assertRaises(AttributeError):
+            Jury([good, bad], method="relevance")
 
     def test_signature_matches_underlying_method(self):
         p = self._provider()
@@ -176,8 +182,8 @@ class TestJuryErrorHandling(unittest.TestCase):
         bad = self._sig(_make_failing_provider("bad"))
         j = Jury([good, bad], method="relevance")
         j.__signature__ = inspect.signature(_mock_relevance)
-        result = j(prompt="x", response="y")
-        self.assertAlmostEqual(result, 0.8)
+        score, _ = j(prompt="x", response="y")
+        self.assertAlmostEqual(score, 0.8)
 
     def test_all_jurors_fail_raises(self):
         p1 = self._sig(_make_failing_provider("a"))
@@ -187,50 +193,100 @@ class TestJuryErrorHandling(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             j(prompt="x", response="y")
 
-
-class TestJuryReturnDetails(unittest.TestCase):
-    def test_return_details_false_returns_float(self):
-        p = _make_provider("gpt-4o", 0.75)
-        p.relevance.__signature__ = inspect.signature(_mock_relevance)
-        j = Jury([p], method="relevance", return_details=False)
+    def test_weighted_mean_partial_failure_redistributes_weight(self):
+        # juror[0]=1.0 weight=0.3, juror[1] fails weight=0.7
+        # surviving total=0.3, result = 1.0 * 0.3 / 0.3 = 1.0
+        good = self._sig(_make_provider("good", 1.0))
+        bad = self._sig(_make_failing_provider("bad"))
+        j = Jury(
+            [good, bad],
+            method="relevance",
+            aggregation="weighted_mean",
+            weights=[0.3, 0.7],
+        )
         j.__signature__ = inspect.signature(_mock_relevance)
-        result = j(prompt="x", response="y")
-        self.assertIsInstance(result, float)
+        score, _ = j(prompt="x", response="y")
+        self.assertAlmostEqual(score, 1.0)
 
-    def test_return_details_true_returns_tuple(self):
-        p = _make_provider("gpt-4o", 0.75)
-        p.relevance.__signature__ = inspect.signature(_mock_relevance)
-        j = Jury([p], method="relevance", return_details=True)
+    def test_zero_total_weight_after_failures_raises(self):
+        good = self._sig(_make_provider("good", 0.8))
+        j = Jury(
+            [good],
+            method="relevance",
+            aggregation="weighted_mean",
+            weights=[0.0],
+        )
         j.__signature__ = inspect.signature(_mock_relevance)
-        result = j(prompt="x", response="y")
-        self.assertIsInstance(result, tuple)
-        score, details = result
-        self.assertIsInstance(score, float)
-        self.assertIsInstance(details, dict)
-        self.assertAlmostEqual(score, 0.75)
+        with self.assertRaises(ValueError):
+            j(prompt="x", response="y")
 
-    def test_details_dict_contains_per_juror_scores(self):
-        providers = [
-            _make_provider("gpt-4o-mini", 0.6),
-            _make_provider("claude-haiku", 0.9),
-        ]
-        for p in providers:
-            p.relevance.__signature__ = inspect.signature(_mock_relevance)
-        j = Jury(providers, method="relevance", return_details=True)
-        j.__signature__ = inspect.signature(_mock_relevance)
-        _, details = j(prompt="x", response="y")
-        self.assertIn("gpt-4o-mini", details)
-        self.assertIn("claude-haiku", details)
-        self.assertAlmostEqual(details["gpt-4o-mini"], 0.6)
-        self.assertAlmostEqual(details["claude-haiku"], 0.9)
 
-    def test_tuple_result_from_provider_unwrapped(self):
-        p = _make_tuple_provider("gpt-4o", 0.7)
+class TestJuryReturnFormat(unittest.TestCase):
+    """Jury always returns (float, {"reason": ...}) — the _with_cot_reasons convention."""
+
+    def _provider_with_sig(self, name, score):
+        p = _make_provider(name, score)
         p.relevance.__signature__ = inspect.signature(_mock_relevance)
+        return p
+
+    def test_always_returns_tuple(self):
+        p = self._provider_with_sig("gpt-4o", 0.75)
         j = Jury([p], method="relevance")
         j.__signature__ = inspect.signature(_mock_relevance)
         result = j(prompt="x", response="y")
-        self.assertAlmostEqual(result, 0.7)
+        self.assertIsInstance(result, tuple)
+        score, meta = result
+        self.assertIsInstance(score, float)
+        self.assertIsInstance(meta, dict)
+        self.assertIn("reason", meta)
+
+    def test_reason_contains_aggregation_header(self):
+        p = self._provider_with_sig("gpt-4o", 0.8)
+        j = Jury([p], method="relevance", aggregation="mean")
+        j.__signature__ = inspect.signature(_mock_relevance)
+        _, meta = j(prompt="x", response="y")
+        self.assertIn("Aggregation: mean", meta["reason"])
+
+    def test_reason_contains_per_juror_scores(self):
+        p1 = self._provider_with_sig("gpt-4o-mini", 0.6)
+        p2 = self._provider_with_sig("claude-haiku", 0.9)
+        j = Jury([p1, p2], method="relevance")
+        j.__signature__ = inspect.signature(_mock_relevance)
+        _, meta = j(prompt="x", response="y")
+        self.assertIn("gpt-4o-mini", meta["reason"])
+        self.assertIn("claude-haiku", meta["reason"])
+        self.assertIn("0.600", meta["reason"])
+        self.assertIn("0.900", meta["reason"])
+
+    def test_juror_cot_reason_passthrough(self):
+        # When jurors return (score, {"reason": "..."}) the explanation
+        # should appear indented in the aggregated reason string.
+        p = _make_cot_provider(
+            "gpt-4o", 0.8, "Supporting Evidence: directly answers"
+        )
+        p.relevance.__signature__ = inspect.signature(_mock_relevance)
+        j = Jury([p], method="relevance")
+        j.__signature__ = inspect.signature(_mock_relevance)
+        _, meta = j(prompt="x", response="y")
+        self.assertIn("Supporting Evidence: directly answers", meta["reason"])
+
+    def test_plain_float_juror_has_no_reason_lines(self):
+        # Float-returning jurors produce no CoT lines — only the score line.
+        p = self._provider_with_sig("gpt-4o", 0.7)
+        j = Jury([p], method="relevance")
+        j.__signature__ = inspect.signature(_mock_relevance)
+        _, meta = j(prompt="x", response="y")
+        lines = meta["reason"].splitlines()
+        # Header + one juror score line, no indented reason lines
+        self.assertEqual(len(lines), 2)
+
+    def test_tuple_result_score_extracted_correctly(self):
+        p = _make_cot_provider("gpt-4o", 0.7, "ok")
+        p.relevance.__signature__ = inspect.signature(_mock_relevance)
+        j = Jury([p], method="relevance")
+        j.__signature__ = inspect.signature(_mock_relevance)
+        score, _ = j(prompt="x", response="y")
+        self.assertAlmostEqual(score, 0.7)
 
 
 class TestJuryMetricIntegration(unittest.TestCase):
@@ -260,8 +316,6 @@ class TestJuryMetricIntegration(unittest.TestCase):
         j = Jury([p], method="relevance")
         j.__signature__ = inspect.signature(_mock_relevance)
 
-        # on_input() binds 'prompt', on_output() binds 'response'.
-        # Metric validates both are in Jury's __signature__ — this must not raise.
         m = Metric(implementation=j).on_input().on_output()
         self.assertIn("prompt", m.selectors)
         self.assertIn("response", m.selectors)
@@ -273,13 +327,11 @@ class TestJuryDuplicateNames(unittest.TestCase):
         p1.relevance.__signature__ = inspect.signature(_mock_relevance)
         p2 = _make_provider("gpt-4o-mini", 0.9)
         p2.relevance.__signature__ = inspect.signature(_mock_relevance)
-        j = Jury([p1, p2], method="relevance", return_details=True)
+        j = Jury([p1, p2], method="relevance")
         j.__signature__ = inspect.signature(_mock_relevance)
-        _, details = j(prompt="x", response="y")
-        self.assertEqual(len(details), 2)
-        # Names must be distinct (indexed).
-        self.assertIn("gpt-4o-mini[0]", details)
-        self.assertIn("gpt-4o-mini[1]", details)
+        _, meta = j(prompt="x", response="y")
+        self.assertIn("gpt-4o-mini[0]", meta["reason"])
+        self.assertIn("gpt-4o-mini[1]", meta["reason"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

This should close #2510 . Adds `Jury` - an ensemble LLM evaluator that wraps 
multiple `LLMProvider` instances into a single callable and aggregates their scores. 
A single LLM judge is noisy and subject to intra-model bias; research shows that 
a panel of diverse judges (a "jury") substantially improves evaluation reliability and can
be cheaper when smaller models are used.

`Jury.__call__` exposes the same parameter names as the underlying provider
method, making it a drop-in implementation for `Metric` — no changes to
`Metric`, `Selector`, or the evaluation pipeline are required.

When called, `Jury` dispatches the same arguments to each juror in parallel via
`ThreadPoolExecutor` and aggregates results using one of five built-in
strategies:

- `mean`
- `median`
- `trimmed_mean`
- `majority_vote`
- `weighted_mean`

A custom `Callable[[List[float]], float]` aggregation strategy is also
supported.

If one juror fails, the failure is logged as a warning and the remaining jurors
are still aggregated. A `RuntimeError` is raised only if all jurors fail.

```python
from trulens.core import Metric
from trulens.feedback.jury import Jury
from trulens.providers.openai import OpenAI
from trulens.providers.litellm import LiteLLM

jury = Jury(
    jurors=[
        OpenAI(model_engine="gpt-4o-mini"),
        OpenAI(model_engine="gpt-4.1-mini"),
        LiteLLM(model_engine="anthropic/claude-3-haiku-20240307"),
    ],
    method="relevance",
    aggregation="median",
    return_details=True,  # optionally expose per-juror scores as metadata
)

m = (
    Metric(
        implementation=jury,
        name="Jury Relevance",
    )
    .on_input()
    .on_output()
)
```

## Other details good to know for developers

- **Signature matching** — `Jury.__init__` sets `self.__signature__` to
  `inspect.signature` of the bound provider method. Python's
  `inspect.signature` checks `__signature__` on a callable object before
  falling back to `__call__`, allowing `Metric` selector validation to see the
  correct parameter names (e.g. `prompt`, `response`) without changes to
  `Metric`.

- **`__name__` support** — Set to `f"jury_{method}"` so `Metric.name` derives a
  sensible default when no `supplied_name` is provided.

- **Weighted mean with partial failures** — If a juror fails under
  `weighted_mean`, its weight is redistributed proportionally among surviving
  jurors.

- **Duplicate model name disambiguation** — When multiple jurors share the same
  `model_engine`, names in `return_details` are index-suffixed (e.g.
  `gpt-4o-mini[0]`, `gpt-4o-mini[1]`).

- **Re-export** — `Jury` is exported from `trulens.feedback` alongside
  `LLMProvider`, `GroundTruthAgreement`, and related evaluation utilities.

- **Documentation** — Added
  `docs/component_guides/evaluation/llm_jury.md` covering:
  - research motivation
  - API reference
  - aggregation strategies
  - model selection guidance

  Registered in `mkdocs.yml` under the Evaluation section.

- **Notebook example** — Added
  `examples/expositional/use_cases/llm_jury.ipynb` demonstrating:
  - a 3-model jury setup
  - single vs. jury score comparison
  - per-juror score breakdowns
  - weighted jury evaluation with alignment-derived weights

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [x] This change requires a documentation update