### PR TITLE
Fix Jury positional argument forwarding

### DIFF
--- a/docs/component_guides/evaluation/llm_jury.md
+++ b/docs/component_guides/evaluation/llm_jury.md
@@ -7,6 +7,16 @@ systematically favours its own style, vocabulary, and reasoning patterns.
 Research shows that ensembling a **panel of diverse judges** (a "jury")
 substantially improves evaluation reliability:
 
+- [Replacing Judges with Juries: Evaluating LLM Generations with a Panel of Diverse Models](https://arxiv.org/abs/2404.18796)
+- [SE-Jury: An LLM-as-Ensemble-Judge Metric](https://arxiv.org/abs/2512.01786)
+- [From Many Voices to One: A Statistically Principled Aggregation of LLM Judges](https://openreview.net/forum?id=Ou53DNvjx7)
+- [Auto-Prompt Ensemble for LLM Judge](https://arxiv.org/abs/2510.06538)
+- [Debate, Deliberate, Decide (D3)](https://aclanthology.org/2026.eacl-long.392/)
+
+`Jury` is not tied to one paper's algorithm. It provides the common
+infrastructure for running several LLM judges through the existing Metric API
+and combining their scores.
+
 ## The `Jury` class
 
 `Jury` wraps N `LLMProvider` instances, calls the same named feedback method on
@@ -152,3 +162,9 @@ Practical starting point:
 latency is approximately that of the *slowest* juror. Cost scales linearly with
 the number of jurors. Using 3 small models (e.g. GPT-4o-mini, Claude Haiku,
 Gemini Flash) is typically cheaper than a single GPT-4o call.
+
+## Configuration note
+
+`Jury` stores provider instances, including their model configuration. Build the
+jury in the same environment where those providers and credentials are
+available, especially when using deferred or remote evaluation workflows.

--- a/examples/cookbooks/custom_programmatic_feedback.ipynb
+++ b/examples/cookbooks/custom_programmatic_feedback.ipynb
@@ -13,10 +13,10 @@
     "\n",
     "This notebook shows four non-LLM feedback functions:\n",
     "\n",
-    "1. **JSON schema check** \u2014 verify the response is valid JSON matching a schema\n",
-    "2. **Regex match** \u2014 check that the response matches an expected pattern\n",
-    "3. **Response length** \u2014 score based on response length being within a target range\n",
-    "4. **PII regex scan** \u2014 detect personally identifiable information in the response\n",
+    "1. **JSON schema check** — verify the response is valid JSON matching a schema\n",
+    "2. **Regex match** — check that the response matches an expected pattern\n",
+    "3. **Response length** — score based on response length being within a target range\n",
+    "4. **PII regex scan** — detect personally identifiable information in the response\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/truera/trulens/blob/main/examples/cookbooks/custom_programmatic_feedback.ipynb)"
    ]
@@ -49,9 +49,10 @@
     "import json\n",
     "import os\n",
     "import re\n",
+    "\n",
     "from openai import OpenAI\n",
-    "from trulens.core import TruSession\n",
     "from trulens.apps.custom import TruCustomApp\n",
+    "from trulens.core import TruSession\n",
     "from trulens.core.otel.instrument import instrument\n",
     "from trulens.otel.semconv.trace import SpanAttributes\n",
     "\n",
@@ -69,7 +70,7 @@
    "source": [
     "## Define a simple app\n",
     "\n",
-    "We build a minimal app that returns structured JSON responses \u2014 a good candidate\n",
+    "We build a minimal app that returns structured JSON responses — a good candidate\n",
     "for programmatic evaluation."
    ]
   },
@@ -147,7 +148,9 @@
     "validator = SchemaValidator(schema=REQUIRED_JSON_SCHEMA)\n",
     "\n",
     "# Quick sanity checks\n",
-    "score, meta = validator.validate_json('{\"answer\": \"yes\", \"confidence\": 0.9, \"sources\": [\"wiki\"]}')\n",
+    "score, meta = validator.validate_json(\n",
+    "    '{\"answer\": \"yes\", \"confidence\": 0.9, \"sources\": [\"wiki\"]}'\n",
+    ")\n",
     "assert score == 1.0, meta\n",
     "score, meta = validator.validate_json('{\"answer\": \"yes\"}')\n",
     "assert score == 0.0, meta  # missing fields\n",
@@ -164,7 +167,7 @@
     "## Feedback function 2: Regex match\n",
     "\n",
     "Checks that the response (or a parsed field) matches a specific pattern.\n",
-    "Useful for format compliance \u2014 e.g., dates, codes, citation styles."
+    "Useful for format compliance — e.g., dates, codes, citation styles."
    ]
   },
   {
@@ -194,8 +197,16 @@
     "    return 1.0 if pattern.search(str(answer)) else 0.0\n",
     "\n",
     "\n",
-    "assert answer_not_empty('{\"answer\": \"This is a complete answer.\", \"confidence\": 0.8, \"sources\": []}') == 1.0\n",
-    "assert answer_not_empty('{\"answer\": \"short\", \"confidence\": 0.8, \"sources\": []}') == 0.0\n",
+    "assert (\n",
+    "    answer_not_empty(\n",
+    "        '{\"answer\": \"This is a complete answer.\", \"confidence\": 0.8, \"sources\": []}'\n",
+    "    )\n",
+    "    == 1.0\n",
+    ")\n",
+    "assert (\n",
+    "    answer_not_empty('{\"answer\": \"short\", \"confidence\": 0.8, \"sources\": []}')\n",
+    "    == 0.0\n",
+    ")\n",
     "print(\"answer_not_empty: OK\")"
    ]
   },
@@ -249,8 +260,8 @@
     "    return max(0.0, 1.0 - overage / tolerance)\n",
     "\n",
     "\n",
-    "assert response_length_score(\"x\" * 100) == 1.0   # within range\n",
-    "assert response_length_score(\"x\" * 25) == 0.5    # too short\n",
+    "assert response_length_score(\"x\" * 100) == 1.0  # within range\n",
+    "assert response_length_score(\"x\" * 25) == 0.5  # too short\n",
     "assert response_length_score(\"x\" * 1000) == 0.0  # way too long\n",
     "print(\"response_length_score: OK\")"
    ]
@@ -306,7 +317,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from trulens.core import Metric, Selector\n",
+    "from trulens.core import Metric\n",
+    "from trulens.core import Selector\n",
     "\n",
     "f_json_schema = Metric(\n",
     "    implementation=validator.validate_json,\n",
@@ -397,7 +409,16 @@
    "outputs": [],
    "source": [
     "records, feedback_results = session.get_records_and_feedback()\n",
-    "records[[\"input\", \"output\", \"JSON Schema Check\", \"Answer Not Empty\", \"Response Length\", \"No PII\"]]"
+    "records[\n",
+    "    [\n",
+    "        \"input\",\n",
+    "        \"output\",\n",
+    "        \"JSON Schema Check\",\n",
+    "        \"Answer Not Empty\",\n",
+    "        \"Response Length\",\n",
+    "        \"No PII\",\n",
+    "    ]\n",
+    "]"
    ]
   },
   {
@@ -431,10 +452,10 @@
     "\n",
     "Non-LLM feedback functions are:\n",
     "\n",
-    "- **Free** \u2014 no LLM calls, no API cost\n",
-    "- **Instant** \u2014 run in microseconds\n",
-    "- **Deterministic** \u2014 same input always produces the same score\n",
-    "- **Composable** \u2014 mix with LLM-based feedback functions in the same `TruApp`\n",
+    "- **Free** — no LLM calls, no API cost\n",
+    "- **Instant** — run in microseconds\n",
+    "- **Deterministic** — same input always produces the same score\n",
+    "- **Composable** — mix with LLM-based feedback functions in the same `TruApp`\n",
     "\n",
     "Use them for format compliance, safety checks, and any evaluation where\n",
     "correctness can be determined without a language model."
@@ -448,8 +469,7 @@
    "name": "python3"
   },
   "language_info": {
-   "name": "python",
-   "version": "3.11.0"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/src/feedback/trulens/feedback/jury.py
+++ b/src/feedback/trulens/feedback/jury.py
@@ -135,8 +135,10 @@ class Jury:
     # Public interface
     # ------------------------------------------------------------------
 
-    def __call__(self, **kwargs: Any) -> tuple[float, dict[str, Any]]:
-        """Evaluate *kwargs* in parallel across all jurors.
+    def __call__(
+        self, *args: Any, **kwargs: Any
+    ) -> tuple[float, dict[str, Any]]:
+        """Evaluate the same arguments in parallel across all jurors.
 
         Always returns ``(score, {"reason": ...})``, matching the
         ``_with_cot_reasons`` convention. Per-juror scores and any CoT
@@ -147,7 +149,7 @@ class Jury:
 
         with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
             future_to_idx = {
-                executor.submit(self._call_juror, juror, kwargs): idx
+                executor.submit(self._call_juror, juror, args, kwargs): idx
                 for idx, juror in enumerate(self._jurors)
             }
 
@@ -198,8 +200,10 @@ class Jury:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _call_juror(self, juror: Any, kwargs: dict) -> Any:
-        return getattr(juror, self._method)(**kwargs)
+    def _call_juror(
+        self, juror: Any, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> Any:
+        return getattr(juror, self._method)(*args, **kwargs)
 
     def _build_juror_names(self) -> list[str]:
         bases = [

--- a/src/feedback/trulens/feedback/jury.py
+++ b/src/feedback/trulens/feedback/jury.py
@@ -149,7 +149,9 @@ class Jury:
 
         with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
             future_to_idx = {
-                executor.submit(self._call_juror, juror, args, kwargs): idx
+                executor.submit(
+                    self._call_juror, juror, args, dict(kwargs)
+                ): idx
                 for idx, juror in enumerate(self._jurors)
             }
 

--- a/tests/unit/test_jury.py
+++ b/tests/unit/test_jury.py
@@ -322,6 +322,42 @@ class TestJuryReturnFormat(unittest.TestCase):
             custom_instructions="be strict",
         )
 
+    def test_each_juror_receives_independent_kwargs(self):
+        class MutatingKwargsJury(Jury):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.seen_custom_instructions = []
+
+            def _call_juror(self, juror, args, kwargs):
+                self.seen_custom_instructions.append(
+                    kwargs.get("custom_instructions")
+                )
+                kwargs.pop("custom_instructions", None)
+                return super()._call_juror(juror, args, kwargs)
+
+        p1 = _make_provider("gpt-4o-mini", 0.6)
+        p1.relevance.__signature__ = inspect.signature(
+            _mock_relevance_with_kwargs
+        )
+        p2 = _make_provider("claude-haiku", 0.8)
+        p2.relevance.__signature__ = inspect.signature(
+            _mock_relevance_with_kwargs
+        )
+        j = MutatingKwargsJury(
+            [p1, p2],
+            method="relevance",
+            max_workers=1,
+        )
+        j.__signature__ = inspect.signature(_mock_relevance_with_kwargs)
+
+        score, _ = j("x", "y", custom_instructions="be strict")
+
+        self.assertAlmostEqual(score, 0.7)
+        self.assertEqual(
+            j.seen_custom_instructions,
+            ["be strict", "be strict"],
+        )
+
 
 class TestJuryMetricIntegration(unittest.TestCase):
     """Verify Jury integrates with Metric without changes to Metric."""

--- a/tests/unit/test_jury.py
+++ b/tests/unit/test_jury.py
@@ -50,6 +50,11 @@ def _make_cot_provider(model_engine: str, score: float, reason: str):
 def _mock_relevance(prompt: str, response: str) -> float: ...
 
 
+def _mock_relevance_with_kwargs(
+    prompt: str, response: str, **kwargs
+) -> float: ...
+
+
 # ---------------------------------------------------------------------------
 # Test cases
 # ---------------------------------------------------------------------------
@@ -287,6 +292,35 @@ class TestJuryReturnFormat(unittest.TestCase):
         j.__signature__ = inspect.signature(_mock_relevance)
         score, _ = j(prompt="x", response="y")
         self.assertAlmostEqual(score, 0.7)
+
+    def test_accepts_positional_arguments_matching_provider_signature(self):
+        p = self._provider_with_sig("gpt-4o", 0.75)
+        j = Jury([p], method="relevance")
+        j.__signature__ = inspect.signature(_mock_relevance)
+
+        score, _ = j("What is TruLens?", "An eval library.")
+
+        self.assertAlmostEqual(score, 0.75)
+        p.relevance.assert_called_once_with(
+            "What is TruLens?", "An eval library."
+        )
+
+    def test_preserves_extra_keyword_arguments(self):
+        p = _make_provider("gpt-4o", 0.8)
+        p.relevance.__signature__ = inspect.signature(
+            _mock_relevance_with_kwargs
+        )
+        j = Jury([p], method="relevance")
+        j.__signature__ = inspect.signature(_mock_relevance_with_kwargs)
+
+        score, _ = j("x", "y", custom_instructions="be strict")
+
+        self.assertAlmostEqual(score, 0.8)
+        p.relevance.assert_called_once_with(
+            "x",
+            "y",
+            custom_instructions="be strict",
+        )
 
 
 class TestJuryMetricIntegration(unittest.TestCase):


### PR DESCRIPTION
## Related issue

Related to #2509. A near-duplicate issue, #2510, was closed by #2517 when the first Jury implementation merged. #2509 is still open, so this PR is a focused follow-up rather than a full reimplementation of the original feature request.

## Summary

This PR updates `Jury` so direct calls can pass arguments the same way the wrapped provider method accepts them. Before this change, `Jury` exposed the provider method signature for Metric selector validation, but `Jury.__call__` only accepted keyword arguments internally. That worked for the Metric path, but made direct provider-style usage inconsistent with the advertised signature.

It also adds the LLM jury research references from #2509 to the docs page.

## What changed

- Forward both `*args` and `**kwargs` from `Jury.__call__` to each juror method.
- Copy keyword arguments per juror before dispatch so one juror cannot affect another by mutating its local kwargs.
- Keep the existing Metric keyword-argument path unchanged.
- Add regression tests for direct positional calls.
- Add regression tests for mixed positional and keyword arguments.
- Add regression coverage for independent kwargs across multiple jurors.
- Add the research references requested in the LLM jury docs checklist.
- Add a short docs note about provider instances and credentials.
- Apply notebook formatting produced by CI's all-file pre-commit hook.

## Checklist

- [x] Keeps `Jury` as a drop-in callable for `Metric`.
- [x] Preserves the current parallel juror execution flow.
- [x] Preserves existing aggregation behavior.
- [x] Covers direct positional calls in unit tests.
- [x] Covers mixed positional/keyword calls in unit tests.
- [x] Covers independent kwargs handling across multiple jurors.
- [x] Updates docs without changing the Jury example notebook.
- [x] Avoids new dependencies.

## Why

The `Jury` object sets `__signature__` from the wrapped provider method so callers and Metric validation see the expected parameter names, such as `prompt` and `response`. With the previous implementation, a direct call like this failed even though it matched the provider method shape:

```python
score, meta = jury("What is TruLens?", "An eval library.")
```

After this change, `Jury` forwards those arguments to each juror exactly as received. Metric-based usage still works because keyword arguments are forwarded the same way as before.

The latest update also gives every juror dispatch its own kwargs dict. That avoids accidental cross-juror interference if any dispatch path mutates top-level keyword arguments.

## Testing

- `uvx --with-editable src/core --with-editable src/feedback --from pytest pytest tests/unit/test_jury.py -q`
  - `33 passed`
- `uvx pre-commit run --files src/feedback/trulens/feedback/jury.py tests/unit/test_jury.py docs/component_guides/evaluation/llm_jury.md`
  - passed
- `uvx pre-commit run --all-files --show-diff-on-failure`
  - first run reproduced the Azure pre-commit notebook cleanup
  - second run passed

## Review and CI follow-up

- Addressed Copilot review feedback by copying kwargs per juror dispatch.
- Added a two-juror regression test where the dispatch path mutates kwargs and both jurors still see the expected original argument.
- Addressed the Azure `py311-static` pre-commit failure by committing the notebook cleanup produced by the full pre-commit run.

## Risk

Low. The runtime change broadens argument forwarding from keyword-only forwarding to normal Python call forwarding and isolates top-level keyword arguments per juror. Existing Metric calls continue to pass keyword arguments, and the new tests cover the direct-call and multi-juror kwargs cases.

## Notes

I used `Related to #2509` instead of a closing keyword because the main Jury feature was already merged in #2517 via #2510. This PR is a compatibility/docs follow-up for the still-open #2509 thread.