### PR TITLE
feat(semconv): add __all__ exports

### DIFF
--- a/src/otel/semconv/trulens/otel/semconv/__init__.py
+++ b/src/otel/semconv/trulens/otel/semconv/__init__.py
@@ -1,6 +1,14 @@
 from importlib.metadata import version
 import sys
 
+from trulens.otel.semconv.trace import ResourceAttributes
+from trulens.otel.semconv.trace import SpanAttributes
+
+__all__ = [
+    "ResourceAttributes",
+    "SpanAttributes",
+]
+
 
 def safe_importlib_package_name(package_name: str) -> str:
     """Convert a package name that may have periods in it to one that uses

--- a/src/otel/semconv/trulens/otel/semconv/__init__.py
+++ b/src/otel/semconv/trulens/otel/semconv/__init__.py
@@ -1,10 +1,14 @@
 from importlib.metadata import version
 import sys
 
+# Re-export key symbols so callers don't need to know the internal trace module.
+from trulens.otel.semconv.trace import GenAIAttributes
 from trulens.otel.semconv.trace import ResourceAttributes
 from trulens.otel.semconv.trace import SpanAttributes
 
+# Explicit public API surface for this package.
 __all__ = [
+    "GenAIAttributes",
     "ResourceAttributes",
     "SpanAttributes",
 ]


### PR DESCRIPTION
Closes #2478

## Description

Adds `__all__` exports to `src/otel/semconv/trulens/otel/semconv/__init__.py` so that `ResourceAttributes` and `SpanAttributes` can be imported directly from `trulens.otel.semconv`, consistent with other TruLens packages.

Verified locally:
```python
from trulens.otel.semconv import SpanAttributes, ResourceAttributes  # works
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update