### PR TITLE
Standardize Provider __init__.py Exports

### DIFF
--- a/src/providers/langchain/trulens/providers/langchain/__init__.py
+++ b/src/providers/langchain/trulens/providers/langchain/__init__.py
@@ -10,13 +10,16 @@
 !!! note
     LangChain provider cannot be used in `deferred` mode due to inconsistent serialization capabilities of LangChain apps.
 """
+# WARNING: This file does not follow the no-init aliases import standard.
 
 from importlib.metadata import version
 
-from trulens.core.utils.imports import safe_importlib_package_name
+from trulens.core.utils import imports as import_utils
 from trulens.providers.langchain.provider import Langchain
 
-__version__ = version(safe_importlib_package_name(__package__ or __name__))
+__version__ = version(
+    import_utils.safe_importlib_package_name(__package__ or __name__)
+)
 
 
 __all__ = [

--- a/src/providers/litellm/trulens/providers/litellm/__init__.py
+++ b/src/providers/litellm/trulens/providers/litellm/__init__.py
@@ -29,12 +29,16 @@ warnings.filterwarnings(
 # Suppress python-dotenv logger warnings for malformed .env files
 logging.getLogger("dotenv.main").setLevel(logging.ERROR)
 
+# WARNING: This file does not follow the no-init aliases import standard.
+
 from importlib.metadata import version  # noqa: E402
 
-from trulens.core.utils.imports import safe_importlib_package_name  # noqa: E402
+from trulens.core.utils import imports as import_utils  # noqa: E402
 from trulens.providers.litellm.provider import LiteLLM  # noqa: E402
 
-__version__ = version(safe_importlib_package_name(__package__ or __name__))
+__version__ = version(
+    import_utils.safe_importlib_package_name(__package__ or __name__)
+)
 
 
 __all__ = [


### PR DESCRIPTION
Closes #2476

Audited all 7 provider `__init__.py` files. 5 already followed the 
majority pattern (`import_utils.safe_importlib_package_name` + 
`# WARNING` comment). Standardized the remaining 2:

- `langchain`: updated import style, added `# WARNING` comment
- `litellm`: updated import style, added `# WARNING` comment 
  (warning suppression block preserved)
