### PR TITLE
feat(dashboard): thread-based grouping of records by conversation_id

### DIFF
--- a/src/core/trulens/core/database/base.py
+++ b/src/core/trulens/core/database/base.py
@@ -59,6 +59,7 @@ class BaseAppsExtractor:
     app_cols = ["app_name", "app_version", "app_id", "app_json", "type"]
     rec_cols = [
         "record_id",
+        "conversation_id",
         "input",
         "output",
         "tags",
@@ -606,6 +607,7 @@ class DB(serial_utils.SerialModel, abc.ABC, text_utils.WithIdentString):
                     "app_name": app_name,
                     "app_version": app_version,
                     "app_id": app_id,
+                    "conversation_id": None,  # Initialize to None, filled below
                     "input": "",  # Initialize to empty string, filled below
                     "output": "",  # Initialize to empty string, filled below
                     "tags": "",  # Not present in OTEL, use empty string
@@ -628,6 +630,9 @@ class DB(serial_utils.SerialModel, abc.ABC, text_utils.WithIdentString):
             ):
                 record_events[record_id]["input_id"] = record_attributes.get(
                     SpanAttributes.INPUT_ID, ""
+                )
+                record_events[record_id]["conversation_id"] = (
+                    record_attributes.get(SpanAttributes.CONVERSATION_ID)
                 )
                 record_events[record_id]["input"] = record_attributes.get(
                     SpanAttributes.RECORD_ROOT.INPUT, ""
@@ -834,6 +839,7 @@ class DB(serial_utils.SerialModel, abc.ABC, text_utils.WithIdentString):
                 # TODO(nit): consider using a constant here
                 "type": "SPAN",  # Default type as per orm.py
                 "record_id": record_id,
+                "conversation_id": record_data.get("conversation_id"),
                 "input_id": record_data.get("input_id"),
                 "input": record_data["input"],
                 "output": record_data["output"],

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -2038,7 +2038,7 @@ class AppsExtractor(core_db.BaseAppsExtractor):
                     row[col] = (
                         datetime.fromtimestamp(_rec.ts).isoformat()
                         if col == "ts"
-                        else getattr(_rec, col)
+                        else getattr(_rec, col, None)
                     )
 
                 yield row

--- a/src/dashboard/trulens/dashboard/tabs/Records.py
+++ b/src/dashboard/trulens/dashboard/tabs/Records.py
@@ -42,6 +42,7 @@ def init_page_state():
         page_name=page_name,
         transforms={
             "app_ids": lambda x: x.split(","),
+            "selected_thread": lambda x: x,
         },
     )
 
@@ -175,13 +176,23 @@ def _render_record_metrics(
         )
 
 
-@streamlit_compat.st_fragment
-def _render_trace(
+def _render_record_detail(
     selected_row: pd.Series,
     records_df: pd.DataFrame,
     feedback_col_names: Sequence[str],
     feedback_directions: Dict[str, bool],
+    key_suffix: Optional[str] = None,
 ):
+    """Render the full detail view for a single record.
+
+    This is the canonical record display (input/output, metrics, feedback
+    results, and trace details). It is reused both for standalone records and
+    for each turn within a conversation thread. ``key_suffix`` makes the
+    widget/component keys unique when several records are rendered on the same
+    page (e.g. one per turn in a thread).
+    """
+    suffix = key_suffix if key_suffix is not None else selected_row["record_id"]
+
     # Start the record specific section
     st.divider()
 
@@ -225,6 +236,7 @@ def _render_trace(
             feedback_col_names=feedback_col_names,
             selected_row=selected_row,
             feedback_directions=feedback_directions,
+            key=f"{page_name}.feedback_pills.{suffix}",
         ):
             _render_feedback_call(
                 selected_ff,
@@ -247,13 +259,35 @@ def _render_trace(
                 selected_row["record_id"], selected_row["app_name"]
             )
             if event_spans:
-                record_viewer_otel(spans=event_spans, key=None)
+                record_viewer_otel(
+                    spans=event_spans,
+                    key=f"{page_name}.trace.{suffix}",
+                )
             else:
                 st.warning("No trace data available for this record.")
     else:
         with trace_details:
             st.subheader("Trace Details")
-            record_viewer(record_json, app_json)
+            record_viewer(
+                record_json,
+                app_json,
+                key=f"{page_name}.trace_legacy.{suffix}",
+            )
+
+
+@streamlit_compat.st_fragment
+def _render_trace(
+    selected_row: pd.Series,
+    records_df: pd.DataFrame,
+    feedback_col_names: Sequence[str],
+    feedback_directions: Dict[str, bool],
+):
+    _render_record_detail(
+        selected_row,
+        records_df,
+        feedback_col_names,
+        feedback_directions,
+    )
 
 
 def _preprocess_df(
@@ -631,6 +665,455 @@ def _render_grid_tab(
     _render_trace(selected_record, df, feedback_col_names, feedback_directions)
 
 
+def _has_conversations(df: pd.DataFrame) -> bool:
+    """Return True if any record in the dataframe carries a conversation_id."""
+    if "conversation_id" not in df.columns:
+        return False
+    conv = df["conversation_id"]
+    return bool((conv.notna() & (conv.astype(str).str.len() > 0)).any())
+
+
+def _thread_membership(df: pd.DataFrame) -> pd.Series:
+    """Boolean mask of rows that belong to a conversation/thread."""
+    if "conversation_id" not in df.columns:
+        return pd.Series([False] * len(df), index=df.index)
+    conv = df["conversation_id"]
+    return conv.notna() & (conv.astype(str).str.len() > 0)
+
+
+def _build_thread_summary(
+    df: pd.DataFrame, feedback_col_names: Sequence[str]
+) -> pd.DataFrame:
+    """Collapse the records dataframe into one row per thread.
+
+    Records that share a ``conversation_id`` are grouped into a single thread.
+    Records without a ``conversation_id`` become standalone single-message
+    "threads" keyed by their ``record_id`` so they still appear and open
+    normally.
+    """
+    df = df.copy()
+    is_thread = _thread_membership(df)
+    df["_thread_key"] = df["conversation_id"].where(is_thread, df["record_id"])
+    df["_is_thread"] = is_thread
+
+    rows = []
+    for thread_key, group in df.groupby("_thread_key", dropna=False):
+        group_sorted = group.sort_values("ts")
+        first = group_sorted.iloc[0]
+        last = group_sorted.iloc[-1]
+        is_conv = bool(first["_is_thread"])
+        row: Dict[str, Any] = {
+            "thread_key": thread_key,
+            "is_thread": is_conv,
+            "conversation_id": first["conversation_id"] if is_conv else None,
+            "record_id": None if is_conv else first["record_id"],
+            "app_name": first["app_name"],
+            "app_version": first["app_version"],
+            "app_id": first["app_id"],
+            "num_messages": len(group_sorted),
+            "first_input": first["input"],
+            "last_output": last["output"],
+            "start_ts": first["ts"],
+            "ts": last["ts"],
+            "total_tokens": group_sorted["total_tokens"].sum(),
+            "total_cost": group_sorted["total_cost"].sum(),
+            "cost_currency": first["cost_currency"],
+            "latency": group_sorted["latency"].sum(),
+        }
+        for fcol in feedback_col_names:
+            if fcol in group_sorted.columns:
+                row[fcol] = group_sorted[fcol].mean(skipna=True)
+        rows.append(row)
+
+    thread_df = pd.DataFrame(rows)
+    if not thread_df.empty:
+        thread_df = thread_df.sort_values(by="ts", ascending=False)
+    return thread_df
+
+
+def _build_thread_grid_options(
+    df: pd.DataFrame,
+    feedback_col_names: Sequence[str],
+    feedback_directions: Dict[str, bool],
+):
+    from st_aggrid.grid_options_builder import GridOptionsBuilder
+
+    gb = GridOptionsBuilder.from_dataframe(df, headerHeight=50)
+    gb.configure_default_column(resizable=True, flex=0, suppressSizeToFit=True)
+
+    gb.configure_column("thread_key", hide=True)
+    gb.configure_column("is_thread", hide=True)
+    gb.configure_column("app_name", hide=True)
+    gb.configure_column("app_id", hide=True)
+    gb.configure_column("start_ts", hide=True)
+    gb.configure_column("cost_currency", hide=True)
+    gb.configure_column(
+        "conversation_id",
+        header_name="Conversation ID",
+        pinned="left",
+        flex=2,
+        filter="agSetColumnFilter",
+        checkboxSelection=True,
+    )
+    gb.configure_column(
+        "record_id",
+        header_name="Record ID",
+        pinned="left",
+        flex=2,
+        filter="agSetColumnFilter",
+    )
+    gb.configure_column(
+        "app_version",
+        header_name="App Version",
+        pinned="left",
+        flex=2,
+        filter="agMultiColumnFilter",
+    )
+    gb.configure_column(
+        "num_messages",
+        header_name="Messages (#)",
+        filter="agNumberColumnFilter",
+    )
+    gb.configure_column(
+        "first_input",
+        header_name="First Input",
+        cellStyle={
+            "white-space": "nowrap",
+            "overflow": "hidden",
+            "text-overflow": "ellipsis",
+        },
+        width=300,
+        minWidth=300,
+        maxWidth=300,
+        resizable=False,
+        suppressSizeToFit=True,
+        tooltipField="first_input",
+        filter="agMultiColumnFilter",
+    )
+    gb.configure_column(
+        "last_output",
+        header_name="Last Output",
+        cellStyle={
+            "white-space": "nowrap",
+            "overflow": "hidden",
+            "text-overflow": "ellipsis",
+        },
+        width=300,
+        minWidth=300,
+        maxWidth=300,
+        resizable=False,
+        suppressSizeToFit=True,
+        tooltipField="last_output",
+        filter="agMultiColumnFilter",
+    )
+    gb.configure_column(
+        "total_tokens",
+        header_name="Total Tokens (#)",
+        filter="agNumberColumnFilter",
+    )
+    gb.configure_column(
+        "total_cost", header_name="Total Cost", filter="agNumberColumnFilter"
+    )
+    gb.configure_column(
+        "latency", header_name="Latency (s)", filter="agNumberColumnFilter"
+    )
+    gb.configure_column(
+        "ts",
+        header_name="Last Activity",
+        sort="desc",
+        filter="agDateColumnFilter",
+    )
+
+    for fcol in feedback_col_names:
+        if fcol not in df.columns:
+            continue
+        feedback_direction = (
+            "HIGHER_IS_BETTER"
+            if feedback_directions.get(fcol, default_direction)
+            else "LOWER_IS_BETTER"
+        )
+        gb.configure_column(
+            fcol,
+            header_name=f"{fcol} (avg)",
+            cellClassRules=cell_rules[feedback_direction],
+            hide=False,
+        )
+
+    gb.configure_grid_options(
+        rowHeight=40,
+        suppressContextMenu=True,
+        suppressSizeToFit=True,
+    )
+    gb.configure_selection(selection_mode="single", use_checkbox=True)
+    gb.configure_pagination(enabled=True)
+    gb.configure_side_bar()
+    return gb.build()
+
+
+def _render_thread_grid(
+    df: pd.DataFrame,
+    feedback_col_names: Sequence[str],
+    feedback_directions: Dict[str, bool],
+):
+    if not is_sis_compatibility_enabled():
+        try:
+            import st_aggrid
+            from st_aggrid.shared import ColumnsAutoSizeMode
+            from st_aggrid.shared import DataReturnMode
+
+            event = st_aggrid.AgGrid(
+                df,
+                gridOptions=_build_thread_grid_options(
+                    df=df,
+                    feedback_col_names=feedback_col_names,
+                    feedback_directions=feedback_directions,
+                ),
+                update_on=["selectionChanged"],
+                custom_css={**aggrid_css, **radio_button_css},
+                columns_auto_size_mode=ColumnsAutoSizeMode.NO_AUTOSIZE,
+                fit_columns_on_grid_load=False,
+                reload_data=True,
+                data_return_mode=DataReturnMode.FILTERED,
+                allow_unsafe_jscode=True,
+                key=f"{page_name}.thread_grid",
+            )
+            return pd.DataFrame(event.selected_rows)
+        except ImportError:
+            pass
+
+    column_order = [
+        "conversation_id",
+        "record_id",
+        "app_version",
+        "num_messages",
+        "first_input",
+        "last_output",
+        "total_tokens",
+        "total_cost",
+        "latency",
+        "ts",
+        *[f for f in feedback_col_names if f in df.columns],
+    ]
+    column_order = [col for col in column_order if col in df.columns]
+    event = st.dataframe(
+        df[column_order],
+        column_order=column_order,
+        selection_mode="single-row",
+        on_select="rerun",
+        hide_index=True,
+        width="stretch",
+        key=f"{page_name}.thread_grid_df",
+    )
+    return df.iloc[event.selection["rows"]]
+
+
+def _clear_selected_thread():
+    if f"{page_name}.selected_thread" in st.session_state:
+        del st.session_state[f"{page_name}.selected_thread"]
+    if "selected_thread" in st.query_params:
+        st.query_params.pop("selected_thread")
+
+
+def _render_conversation_timeline(subset: pd.DataFrame):
+    """Render a chat-style message timeline with left-aligned user and
+    right-aligned assistant messages. Each turn is clickable to scroll
+    to its full trace below.
+    """
+    for turn_index, (_, msg) in enumerate(subset.iterrows()):
+        record_id = msg["record_id"]
+        input_text = str(msg["input"])[:200]
+        output_text = str(msg["output"])[:200]
+        ellipsis_in = "..." if len(str(msg["input"])) > 200 else ""
+        ellipsis_out = "..." if len(str(msg["output"])) > 200 else ""
+
+        user_text = _escape_problematic_markdown(input_text) + ellipsis_in
+        asst_text = _escape_problematic_markdown(output_text) + ellipsis_out
+
+        st.html(
+            f'<div style="display:flex;flex-direction:column;gap:6px;margin-bottom:8px;">'
+            f'  <div style="display:flex;align-items:flex-start;">'
+            f'    <div style="background:#2a2a3d;border-radius:12px 12px 12px 2px;padding:8px 12px;max-width:75%;font-size:0.85em;">'
+            f'      <span style="color:#aaa;font-size:0.75em;">User</span><br>{user_text}'
+            f"    </div>"
+            f"  </div>"
+            f'  <div style="display:flex;align-items:flex-start;justify-content:flex-end;">'
+            f'    <div style="background:#1a3a2a;border-radius:12px 12px 2px 12px;padding:8px 12px;max-width:75%;font-size:0.85em;">'
+            f'      <span style="color:#aaa;font-size:0.75em;">Assistant</span><br>{asst_text}'
+            f"    </div>"
+            f'    <a href="#record-{record_id}" style="margin-left:8px;margin-top:8px;text-decoration:none;font-size:0.75em;color:#888;white-space:nowrap;">trace&nbsp;↓</a>'
+            f"  </div>"
+            f"</div>"
+        )
+
+
+def _render_thread(
+    thread_key: str,
+    records_df: pd.DataFrame,
+    feedback_col_names: Sequence[str],
+    feedback_directions: Dict[str, bool],
+):
+    """Render a single thread as a sequence of its messages.
+
+    Each message (turn) is rendered with the exact same detail view used for a
+    standalone record (``_render_record_detail``), so a conversation is just a
+    vertical stack of record detail views in turn order.
+    """
+    is_thread = _thread_membership(records_df)
+    subset = records_df[
+        (is_thread & (records_df["conversation_id"] == thread_key))
+        | (~is_thread & (records_df["record_id"] == thread_key))
+    ]
+    if subset.empty:
+        return
+
+    subset = subset.sort_values(by="ts", ascending=True)
+    first = subset.iloc[0]
+
+    st.divider()
+    st.button(
+        "← Back to threads",
+        on_click=_clear_selected_thread,
+        key=f"{page_name}.back_to_threads",
+    )
+
+    # Standalone (non-conversation) records keep the existing record detail view.
+    if not bool(first["conversation_id"]):
+        _render_trace(
+            first, records_df, feedback_col_names, feedback_directions
+        )
+        return
+
+    st.caption(
+        f"{first['app_name']} / {first['app_version']} / Thread: {thread_key}"
+    )
+    st.markdown(f"#### Thread: {thread_key}")
+    st.caption(f"{len(subset)} message(s) in this conversation")
+
+    # Conversation-level stats
+    cost_currency = first["cost_currency"]
+    total_cost = subset[subset["cost_currency"] == cost_currency][
+        "total_cost"
+    ].sum()
+    total_time = subset["latency"].sum()
+    total_tokens = int(subset["total_tokens"].sum())
+
+    # Left: chat-style timeline. Right: conversation-level stats.
+    timeline_col, stats_col = st.columns(2)
+    with timeline_col:
+        _render_conversation_timeline(subset)
+    with stats_col:
+        stat_top = st.columns(2)
+        stat_bottom = st.columns(2)
+        with stat_top[0].container(height=128, border=True):
+            st.metric(
+                label="Turns (#)",
+                value=len(subset),
+                help="Number of messages (records) in this conversation.",
+            )
+        with stat_top[1].container(height=128, border=True):
+            st.metric(
+                label="Total time (s)",
+                value=f"{total_time:.3g}",
+                help="Sum of per-turn latency across the conversation.",
+            )
+        with stat_bottom[0].container(height=128, border=True):
+            st.metric(
+                label=f"Total cost ({cost_currency})",
+                value=_format_cost(total_cost, cost_currency),
+                help="Sum of app execution cost across all turns (excludes eval cost).",
+            )
+        with stat_bottom[1].container(height=128, border=True):
+            st.metric(
+                label="Total AI tokens (#)",
+                value=f"{total_tokens:,}",
+                help="Sum of tokens generated across all turns.",
+            )
+
+    # Conversation-level average metrics as pills + per-turn drill-down
+    avail_fcols = [
+        f
+        for f in feedback_col_names
+        if f in subset.columns and subset[f].notna().any()
+    ]
+    if avail_fcols:
+        avg_row = pd.Series({
+            fcol: subset[fcol].mean(skipna=True) for fcol in avail_fcols
+        })
+        pills_key = f"{page_name}.thread_avg_pills.{thread_key}"
+        selected_metric = _render_feedback_pills(
+            avail_fcols,
+            feedback_directions,
+            selected_row=avg_row,
+            key=pills_key,
+        )
+        if selected_metric and selected_metric in subset.columns:
+            turn_scores = subset[["record_id", "input", selected_metric]].copy()
+            turn_scores.insert(0, "Turn", range(1, len(turn_scores) + 1))
+            turn_scores["input"] = turn_scores["input"].astype(str).str[:80]
+            turn_scores = turn_scores.rename(
+                columns={
+                    "record_id": "Record ID",
+                    "input": "Input",
+                    selected_metric: f"{selected_metric} (score)",
+                }
+            )
+            st.dataframe(
+                turn_scores.set_index("Turn"),
+                use_container_width=True,
+            )
+
+    for turn_index, (_, msg) in enumerate(subset.iterrows()):
+        record_id = msg["record_id"]
+        st.html(
+            f'<div id="record-{record_id}" style="height:0;margin:0;padding:0;overflow:hidden;"></div>'
+        )
+        _render_record_detail(
+            msg,
+            records_df,
+            feedback_col_names,
+            feedback_directions,
+            key_suffix=f"{thread_key}.{turn_index}.{msg['record_id']}",
+        )
+
+
+def _render_thread_view(
+    df: pd.DataFrame,
+    feedback_col_names: List[str],
+    feedback_directions: Dict[str, bool],
+):
+    """Render the thread-grouped records view with drill-in transcript."""
+    thread_summary = _build_thread_summary(df, feedback_col_names)
+    if thread_summary.empty:
+        st.info("No threads to display.", icon="ℹ️")
+        return
+
+    selected = _render_thread_grid(
+        thread_summary,
+        feedback_col_names=feedback_col_names,
+        feedback_directions=feedback_directions,
+    )
+
+    valid_keys = set(thread_summary["thread_key"].tolist())
+    if selected is not None and not selected.empty:
+        selected_thread = selected.iloc[0]["thread_key"]
+        st.session_state[f"{page_name}.selected_thread"] = selected_thread
+        st.query_params["selected_thread"] = str(selected_thread)
+    else:
+        selected_thread = st.session_state.get(
+            f"{page_name}.selected_thread", None
+        )
+
+    if selected_thread is not None and selected_thread in valid_keys:
+        _render_thread(
+            selected_thread, df, feedback_col_names, feedback_directions
+        )
+    else:
+        st.info(
+            "Click a thread's checkbox to view the conversation.",
+            icon="ℹ️",
+        )
+
+
 def _reset_app_ids():
     if f"{page_name}.app_ids" in st.session_state:
         del st.session_state[f"{page_name}.app_ids"]
@@ -687,7 +1170,7 @@ def render_records(app_name: str):
         key=f"{page_name}.record_search",
         on_change=_handle_record_query_change,
     )
-    versions_df, version_metadata_col_names = render_app_version_filters(
+    versions_df, _ = render_app_version_filters(
         app_name,
         {f"{page_name}.record_search": record_query},
         page_name_keys=[f"{page_name}.record_search"],
@@ -753,11 +1236,10 @@ def render_records(app_name: str):
 
     _, feedback_directions = get_feedback_defs()
 
-    _render_grid_tab(
+    _render_thread_view(
         df,
         feedback_col_names,
         feedback_directions,
-        version_metadata_col_names,
     )
 
 

--- a/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
@@ -238,9 +238,11 @@ def get_records_and_feedback(
     )
 
     records_df["record_metadata"] = records_df["record_json"].apply(
-        lambda x: metadata_utils.flatten_metadata(x["meta"])
-        if isinstance(x["meta"], dict)
-        else {}
+        lambda x: (
+            metadata_utils.flatten_metadata(x["meta"])
+            if isinstance(x["meta"], dict)
+            else {}
+        )
     )
 
     records_df, _ = _factor_out_metadata(records_df, "record_metadata")
@@ -256,6 +258,31 @@ def get_records_and_feedback(
     ]
 
     return records_df, feedback_col_names
+
+
+@st.cache_data(
+    ttl=dashboard_constants.CACHE_TTL,
+    show_spinner="Getting conversation trace data",
+)
+def get_events_for_records(
+    app_name: Optional[str] = None,
+    record_ids: Optional[List[str]] = None,
+):
+    """Fetch all OTEL span events for the given record ids.
+
+    Used to build a combined conversation timeline across the turns
+    (records) that make up a thread.
+    """
+    session = get_session()
+    lms = session.connector.db
+    assert lms
+
+    return lms.get_events(
+        app_name=app_name,
+        app_version=None,
+        record_ids=list(record_ids) if record_ids else None,
+        start_time=None,
+    )
 
 
 @st.cache_data(
@@ -398,9 +425,9 @@ def get_app_versions(app_name: str):
 
     # Flatten metadata
     app_versions_df["metadata"] = app_versions_df["metadata"].apply(
-        lambda x: metadata_utils.flatten_metadata(x)
-        if isinstance(x, dict)
-        else {}
+        lambda x: (
+            metadata_utils.flatten_metadata(x) if isinstance(x, dict) else {}
+        )
     )
 
     # Factor out metadata

--- a/src/dashboard/trulens/dashboard/utils/records_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/records_utils.py
@@ -273,6 +273,7 @@ def _render_feedback_pills(
     feedback_col_names: Sequence[str],
     feedback_directions: Dict[str, bool],
     selected_row: Optional[pd.Series] = None,
+    key: Optional[str] = None,
 ):
     """Render each feedback as pills.
 
@@ -280,6 +281,7 @@ def _render_feedback_pills(
         feedback_col_names (Sequence[str]): The name of the feedback function columns.
         feedback_directions (Dict[str, bool]): A dictionary mapping feedback names to their directions. True if higher is better, False otherwise.
         selected_row (Optional[pd.Series], optional): The selected row (if any). If provided, renders the feedback values. Defaults to None.
+        key (Optional[str], optional): An optional unique key for the widget. Required when rendering multiple pill groups on the same page (e.g. one per message in a thread) to avoid duplicate widget IDs. Defaults to None.
 
     Returns:
         Any: The feedback pills streamlit component.
@@ -300,8 +302,8 @@ def _render_feedback_pills(
             if fcol in selected_row and selected_row[fcol] is not None
         ])
 
-        format_func = (
-            lambda fcol: f"{get_icon(fcol)} {fcol} {selected_row[fcol]:.2f}"
+        format_func = lambda fcol: (
+            f"{get_icon(fcol)} {fcol} {selected_row[fcol]:.2f}"
         )
     else:
         feedback_with_valid_results = feedback_col_names
@@ -317,6 +319,8 @@ def _render_feedback_pills(
     }
     if format_func:
         kwargs["format_func"] = format_func
+    if key is not None:
+        kwargs["key"] = key
 
     if hasattr(st, "pills"):
         # Use native streamlit pills, released in 1.40.0

--- a/tests/unit/static/golden/api.trulens.3.11.yaml
+++ b/tests/unit/static/golden/api.trulens.3.11.yaml
@@ -2170,6 +2170,7 @@ trulens.dashboard.utils.dashboard_utils:
     add_query_param: builtins.function
     get_app_versions: streamlit.runtime.caching.cache_utils.CachedFunc
     get_apps: streamlit.runtime.caching.cache_utils.CachedFunc
+    get_events_for_records: streamlit.runtime.caching.cache_utils.CachedFunc
     get_feedback_defs: streamlit.runtime.caching.cache_utils.CachedFunc
     get_records_and_feedback: streamlit.runtime.caching.cache_utils.CachedFunc
     get_session: streamlit.runtime.caching.cache_utils.CachedFunc


### PR DESCRIPTION
## Summary

Adds a **thread view** to the dashboard **Records** tab that groups records sharing a `conversation_id` into a single conversation. This builds directly on the `conversation_id` span attribute introduced in #2462 (https://github.com/truera/trulens/pull/2462).

- The Records grid surfaces a **Conversation ID** column; rows belonging to a thread are selectable to drill into a conversation view.
- The thread drill-in renders a **chat-style timeline** (left = user, right = assistant) next to **boxed conversation stats** — turns, total time, total cost, total AI tokens — matching the existing record-level metric style.
- Conversation-level feedback averages render as **pills**; clicking a metric pill reveals the **per-turn scores**.
- Each turn links down to its full **per-record trace**.
- Plumbs `conversation_id` through the DB events extractor (`base.py`), adds `get_events_for_records`, and adds a `key` argument to `_render_feedback_pills` so multiple pill groups can coexist on one page.

## Screenshots

### Records grid with thread grouping
![Threads list](https://raw.githubusercontent.com/joshreini1/trulens/pr-assets-thread-grouping/docs/assets/thread-grouping/threads_list.png)

### Conversation drill-in (chat timeline + boxed stats + eval pills)
![Thread overview](https://raw.githubusercontent.com/joshreini1/trulens/pr-assets-thread-grouping/docs/assets/thread-grouping/thread_overview.png)

### Full thread view with per-turn trace drill-down
![Thread detail](https://raw.githubusercontent.com/joshreini1/trulens/pr-assets-thread-grouping/docs/assets/thread-grouping/thread_detail.png)

## Reproducing the screenshotted example

The screenshots above show the `conv-002` thread (a 4-turn pasta-recipe conversation). To produce a thread, pass the same `conversation_id` across multiple recording contexts (see the [conversation_id guide](https://github.com/truera/trulens/blob/main/docs/component_guides/instrumentation/conversation_id.md)):

```python
from trulens.core import TruSession
from trulens.apps.app import TruApp

session = TruSession()
tru_app = TruApp(
    my_app,
    app_name="rag_chatbot",
    app_version="v1.0",
    main_method=my_app.query,
)

# All turns sharing this id are grouped into one thread in the dashboard.
CONV_ID = "conv-002"

turns = [
    "Recommend a pasta recipe.",
    "Make it vegan.",
    "What wine pairs well?",
    "Thanks!",
]

for user_msg in turns:
    with tru_app(conversation_id=CONV_ID) as recording:
        my_app.query(user_msg)
```

Every span emitted inside each context carries `ai.observability.conversation_id = "conv-002"`, so the four records render together as a single conversation. In the dashboard, open **Records**, then click the thread's checkbox in the **Conversation ID** column to open the drill-in view.

## Test plan

- [x] `Records` tab loads with the new **Conversation ID** column
- [x] Selecting a thread opens the chat-style drill-in with boxed stats (turns / time / cost / tokens)
- [x] Conversation-level eval **pills** render; clicking a pill shows per-turn scores
- [x] Each turn's `trace ↓` link scrolls to its full per-record trace
- [x] Records without a `conversation_id` continue to render as standalone records (backwards compatible)

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
