### PR TITLE
Remove polyfill.io from docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -301,11 +301,9 @@ extra_css:
   - stylesheets/extra.css
 
 # https://squidfunk.github.io/mkdocs-material/reference/mathjax/
-# Polyfill provides backcompat for JS. We need to import it before
-# importing MathJax.
+# Load the local MathJax configuration before importing MathJax.
 extra_javascript:
   - javascript/config.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - javascript/tex-mml-chtml-3.0.0.js
   - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
   - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js


### PR DESCRIPTION
## Summary
- remove the polyfill.io script from the MkDocs extra JavaScript list
- update the nearby MathJax comment so it no longer references the removed polyfill

Fixes #2533

## Verification
- `python - <<'PY' ...` parsed `mkdocs.yml` with PyYAML and asserted no `polyfill.io` URL remains in `extra_javascript`
- `rg -n "polyfill\.io|polyfill" mkdocs.yml docs || true` returned no matches
- `git diff --check`
- `.venv-docs/bin/properdocs build --clean --strict` progressed through config and notebook conversion, then stopped because the manual docs venv lacked the existing `pydantic` griffe extension dependency (`ModuleNotFoundError: No module named 'pydantic'`); not related to this JavaScript removal
