### PR TITLE
Add leaderboard output format options

### DIFF
--- a/src/core/trulens/core/session.py
+++ b/src/core/trulens/core/session.py
@@ -849,7 +849,8 @@ class TruSession(
         group_by_metadata_key: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-    ) -> pandas.DataFrame:
+        format: str = "dataframe",
+    ) -> Union[pandas.DataFrame, str, List[Dict[str, Any]]]:
         """Get a leaderboard for the given apps.
 
         Args:
@@ -862,16 +863,33 @@ class TruSession(
 
             offset: Record row offset to select which records to use to aggregate the leaderboard.
 
+            format: Output format for the leaderboard. Supported values are
+                `"dataframe"` for the existing pandas DataFrame behavior,
+                `"dict"` for `DataFrame.to_dict(orient="records")`, and
+                `"json"` for `DataFrame.to_json(orient="records")`.
+
         Returns:
-            Dataframe of apps with their feedback results aggregated.
-            If group_by_metadata_key is provided, the dataframe will be grouped by the specified key.
+            Leaderboard data in the requested format. If `format` is
+            `"dataframe"` and `group_by_metadata_key` is provided, the
+            DataFrame will be grouped by the specified key.
         """
-        return self.connector.get_leaderboard(
+        leaderboard = self.connector.get_leaderboard(
             app_ids=app_ids,
             group_by_metadata_key=group_by_metadata_key,
             limit=limit,
             offset=offset,
         )
+        if format == "dataframe":
+            return leaderboard
+        elif format == "dict":
+            return leaderboard.to_dict(orient="records")
+        elif format == "json":
+            return leaderboard.to_json(orient="records")
+        else:
+            raise ValueError(
+                "Unsupported leaderboard format. Expected one of "
+                "'dataframe', 'dict', or 'json'."
+            )
 
     def add_ground_truth_to_dataset(
         self,

--- a/tests/unit/test_tru_session.py
+++ b/tests/unit/test_tru_session.py
@@ -1,0 +1,72 @@
+import json
+
+import pandas
+import pytest
+from trulens.core import session as core_session
+
+
+class _FakeConnector:
+    def __init__(self, leaderboard: pandas.DataFrame):
+        self.leaderboard = leaderboard
+        self.calls = []
+
+    def get_leaderboard(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.leaderboard
+
+
+@pytest.fixture
+def leaderboard_session():
+    leaderboard = pandas.DataFrame({
+        "app_name": ["app-a", "app-b"],
+        "latency": [0.1, 0.2],
+        "quality": [0.9, 0.8],
+    })
+    connector = _FakeConnector(leaderboard)
+    session = core_session.TruSession.model_construct(connector=connector)
+    return session, connector, leaderboard
+
+
+def test_get_leaderboard_defaults_to_dataframe(leaderboard_session):
+    session, connector, leaderboard = leaderboard_session
+
+    result = session.get_leaderboard(app_ids=["app-a"], limit=1, offset=2)
+
+    assert result is leaderboard
+    assert connector.calls == [
+        {
+            "app_ids": ["app-a"],
+            "group_by_metadata_key": None,
+            "limit": 1,
+            "offset": 2,
+        }
+    ]
+
+
+def test_get_leaderboard_returns_dict_records(leaderboard_session):
+    session, _, _ = leaderboard_session
+
+    result = session.get_leaderboard(format="dict")
+
+    assert result == [
+        {"app_name": "app-a", "latency": 0.1, "quality": 0.9},
+        {"app_name": "app-b", "latency": 0.2, "quality": 0.8},
+    ]
+
+
+def test_get_leaderboard_returns_json_records(leaderboard_session):
+    session, _, _ = leaderboard_session
+
+    result = session.get_leaderboard(format="json")
+
+    assert json.loads(result) == [
+        {"app_name": "app-a", "latency": 0.1, "quality": 0.9},
+        {"app_name": "app-b", "latency": 0.2, "quality": 0.8},
+    ]
+
+
+def test_get_leaderboard_rejects_unknown_format(leaderboard_session):
+    session, _, _ = leaderboard_session
+
+    with pytest.raises(ValueError, match="Unsupported leaderboard format"):
+        session.get_leaderboard(format="yaml")


### PR DESCRIPTION
# Description

`TruSession.get_leaderboard()` currently always returns a pandas DataFrame. This adds an optional `format` parameter so callers can keep that default behavior or ask for JSON-serializable records when using the leaderboard from CI jobs, monitoring scripts, or other programmatic workflows.

Closes #2467.

## Other details good to know for developers

The connector-level `get_leaderboard()` still returns a DataFrame. The conversion happens at the public `TruSession` API boundary, which keeps existing connector/dashboard consumers unchanged:

- `format="dataframe"` keeps the existing behavior
- `format="dict"` returns `DataFrame.to_dict(orient="records")`
- `format="json"` returns `DataFrame.to_json(orient="records")`

Local verification:

- `.venv/bin/python -m pytest -q tests/unit/test_tru_session.py`
- `.venv/bin/python -m ruff format --check tests/unit/test_tru_session.py`
- `.venv/bin/python -m ruff check --isolated --select F src/core/trulens/core/session.py tests/unit/test_tru_session.py`
- `.venv/bin/python -m ruff check --isolated --select F,I tests/unit/test_tru_session.py`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
