### PR TITLE
test: add prompt-template rendering integration test (#2493)

### DIFF
--- a/tests/integration/test_prompt_template_rendering.py
+++ b/tests/integration/test_prompt_template_rendering.py
@@ -62,9 +62,9 @@ _TEMPLATE_CASES = _collect_template_strings()
 
 def test_templates_were_discovered():
     """Guard so the parametrization below can't pass vacuously."""
-    assert len(_TEMPLATE_CASES) > 10, (
-        f"expected to discover many templates, found {len(_TEMPLATE_CASES)}"
-    )
+    assert (
+        len(_TEMPLATE_CASES) > 10
+    ), f"expected to discover many templates, found {len(_TEMPLATE_CASES)}"
 
 
 @pytest.mark.parametrize(
@@ -86,6 +86,6 @@ def test_template_renders_without_unresolved_placeholders(template):
 
     assert rendered.strip(), "template rendered to an empty string"
     leftover = _UNRESOLVED_PLACEHOLDER.findall(rendered)
-    assert not leftover, (
-        f"unresolved placeholders remain after render: {leftover}"
-    )
+    assert (
+        not leftover
+    ), f"unresolved placeholders remain after render: {leftover}"

--- a/tests/integration/test_prompt_template_rendering.py
+++ b/tests/integration/test_prompt_template_rendering.py
@@ -1,0 +1,91 @@
+"""Integration test for prompt-template rendering across all feedback templates.
+
+Addresses truera/trulens#2493.
+
+TruLens ships 20+ feedback template classes (in ``rag.py``, ``safety.py``,
+``quality.py``, ``agent.py``) that expose ``system_prompt`` /
+``system_prompt_template`` / ``user_prompt`` / ``criteria`` / ... strings with
+``{placeholder}`` fields. Providers build the LLM evaluation prompts by
+``str.format``-ing these. Nothing currently verifies that every exported
+template actually renders -- i.e. that its braces are well-formed and that
+supplying its declared fields leaves no unresolved ``{placeholder}`` behind.
+
+This test enumerates every prompt-template string reachable from
+``trulens.feedback.templates.__all__`` and renders each one, which surfaces:
+
+* malformed / unescaped braces (``str.format`` raises), and
+* fields that cannot be satisfied / stray placeholders left in the output.
+"""
+
+import inspect
+import re
+from string import Formatter
+
+import pytest
+from trulens.feedback import templates as fb_templates
+
+# ClassVar string attributes that hold renderable prompt templates.
+_TEMPLATE_STR_ATTRS = (
+    "system_prompt",
+    "system_prompt_template",
+    "user_prompt",
+    "criteria",
+    "criteria_template",
+    "output_space_prompt",
+    "default_cot_prompt",
+    "sentences_splitter_prompt",
+    "prompt",
+)
+
+# Matches a leftover ``{field_name}`` placeholder (not rendered JSON like
+# ``{"score": 2}``, whose first char after ``{`` is not an identifier char).
+_UNRESOLVED_PLACEHOLDER = re.compile(r"\{[A-Za-z_]\w*\}")
+
+
+def _collect_template_strings():
+    """Return ``(id, template_str)`` for every prompt-template ClassVar on
+    every class exported from ``trulens.feedback.templates.__all__``."""
+    cases = []
+    for name in fb_templates.__all__:
+        obj = getattr(fb_templates, name, None)
+        if not inspect.isclass(obj):
+            continue
+        for attr in _TEMPLATE_STR_ATTRS:
+            value = getattr(obj, attr, None)
+            if isinstance(value, str) and value.strip():
+                cases.append((f"{name}.{attr}", value))
+    return cases
+
+
+_TEMPLATE_CASES = _collect_template_strings()
+
+
+def test_templates_were_discovered():
+    """Guard so the parametrization below can't pass vacuously."""
+    assert len(_TEMPLATE_CASES) > 10, (
+        f"expected to discover many templates, found {len(_TEMPLATE_CASES)}"
+    )
+
+
+@pytest.mark.parametrize(
+    "template",
+    [case[1] for case in _TEMPLATE_CASES],
+    ids=[case[0] for case in _TEMPLATE_CASES],
+)
+def test_template_renders_without_unresolved_placeholders(template):
+    """Every exported template renders cleanly once its fields are supplied."""
+    declared_fields = {
+        field_name
+        for _, field_name, _, _ in Formatter().parse(template)
+        if field_name
+    }
+
+    # Supplying every declared field must fully render the template. This also
+    # surfaces malformed/unescaped braces, which raise inside ``str.format``.
+    rendered = template.format(**{f: f"<{f}>" for f in declared_fields})
+
+    assert rendered.strip(), "template rendered to an empty string"
+    leftover = _UNRESOLVED_PLACEHOLDER.findall(rendered)
+    assert not leftover, (
+        f"unresolved placeholders remain after render: {leftover}"
+    )


### PR DESCRIPTION
## Summary

Closes #2493.

TruLens ships 20+ feedback template classes (`rag.py`, `safety.py`,
`quality.py`, `agent.py`) whose `system_prompt` / `system_prompt_template` /
`user_prompt` / `criteria` / ... strings carry `{placeholder}` fields that
providers fill via `str.format`. Nothing currently verifies that every exported
template actually renders — i.e. that its braces are well-formed and that
supplying its declared fields leaves no unresolved `{placeholder}` behind.

This adds `tests/integration/test_prompt_template_rendering.py`, which
enumerates every prompt-template string reachable from
`trulens.feedback.templates.__all__` and renders each one.

## What it covers

- Discovers every prompt-template `ClassVar` string (`system_prompt`,
  `system_prompt_template`, `user_prompt`, `criteria`, `criteria_template`,
  `output_space_prompt`, `default_cot_prompt`, `sentences_splitter_prompt`,
  `prompt`) on every class in `templates.__all__` — **126 template strings**.
- For each, supplies its declared fields and asserts:
  - rendering does not raise (surfaces malformed / unescaped braces), and
  - the result is non-empty with **no unresolved `{placeholder}`** left
    (the regex ignores rendered JSON like `{"score": 2}`).
- A guard test (`test_templates_were_discovered`) ensures the parametrization
  can't pass vacuously.

This is the rendering-correctness counterpart to the pipeline-wiring coverage
tracked in #2494.

## Testing

```bash
pytest tests/integration/test_prompt_template_rendering.py -q
# 127 passed
```

## Notes

Depends only on `trulens-core` + `trulens-feedback`; no network calls.
