### PR TITLE
docs: remove polyfill.io from documentation site config (closes #2533)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -301,7 +301,6 @@ extra_css:
   - stylesheets/extra.css
 
 # https://squidfunk.github.io/mkdocs-material/reference/mathjax/
-# importing MathJax.
 extra_javascript:
   - javascript/config.js
   - javascript/tex-mml-chtml-3.0.0.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -301,11 +301,9 @@ extra_css:
   - stylesheets/extra.css
 
 # https://squidfunk.github.io/mkdocs-material/reference/mathjax/
-# Polyfill provides backcompat for JS. We need to import it before
 # importing MathJax.
 extra_javascript:
   - javascript/config.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - javascript/tex-mml-chtml-3.0.0.js
   - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
   - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js


### PR DESCRIPTION
## Description

Closes #2533.

Removes the external `polyfill.io` reference from `mkdocs.yml` so the documentation site no longer loads that supply-chain-risk domain.

## Notes

- Config-only change.
- No documentation content or runtime package code touched.
- The removed reference was the only `polyfill.io` match in the repository search.