### PR TITLE
docs: add HuggingFace local eval quickstart (closes #2470)

### DIFF
--- a/examples/expositional/models/huggingface/huggingface_local_quickstart.ipynb
+++ b/examples/expositional/models/huggingface/huggingface_local_quickstart.ipynb
@@ -80,9 +80,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Configure local HuggingFace feedback\n",
+        "## Configure local feedback\n",
         "\n",
-        "`HuggingfaceLocal` runs feedback locally. The exact model you choose depends on the feedback function and resources available on your machine.\n"
+        "The instrumentation above works independently of the feedback provider. For local HuggingFace feedback, choose a `HuggingfaceLocal` feedback function that is implemented for the model/task you install locally. If a local endpoint is not implemented for a feedback function, use this instrumentation pattern with a custom `Metric` implementation instead.\n"
       ]
     },
     {
@@ -91,20 +91,15 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "from trulens.providers.huggingface import HuggingfaceLocal\n",
+        "def simple_answer_length_score(response: str) -> float:\n",
+        "    \"\"\"Toy local metric: short, non-empty answers score higher.\"\"\"\n",
+        "    return 1.0 if 1 <= len(response.split()) <= 30 else 0.0\n",
         "\n",
-        "# Choose a small local model appropriate for your feedback task.\n",
-        "# This keeps the example API-only; update the model name for your environment.\n",
-        "provider = HuggingfaceLocal(model_engine=\"distilbert-base-uncased\")\n",
-        "\n",
-        "# Example custom metric hook: use selector wiring with the recorded input/output.\n",
-        "# Replace `provider.language_match` with the local feedback function you want to run.\n",
-        "f_language_match = Metric(\n",
-        "    implementation=provider.language_match,\n",
-        "    name=\"Language Match\",\n",
+        "f_answer_length = Metric(\n",
+        "    implementation=simple_answer_length_score,\n",
+        "    name=\"Answer Length Smoke Test\",\n",
         "    selectors={\n",
-        "        \"text1\": Selector.select_record_input(),\n",
-        "        \"text2\": Selector.select_record_output(),\n",
+        "        \"response\": Selector.select_record_output(),\n",
         "    },\n",
         ")\n"
       ]
@@ -130,7 +125,7 @@
         "    app,\n",
         "    app_name=\"HuggingFace Local Quickstart\",\n",
         "    app_version=\"v1\",\n",
-        "    feedbacks=[f_language_match],\n",
+        "    feedbacks=[f_answer_length],\n",
         ")\n",
         "\n",
         "with tru_app as recording:\n",

--- a/examples/expositional/models/huggingface/huggingface_local_quickstart.ipynb
+++ b/examples/expositional/models/huggingface/huggingface_local_quickstart.ipynb
@@ -1,0 +1,170 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# HuggingFace Local Evaluation Quickstart\n",
+        "\n",
+        "This cookbook shows how to instrument a small local HuggingFace-style pipeline with TruLens OTEL tracing and configure local HuggingFace feedback without external API calls.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Install dependencies\n",
+        "\n",
+        "```bash\n",
+        "pip install trulens trulens-providers-huggingface transformers torch\n",
+        "```\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from trulens.apps.app import TruApp\n",
+        "from trulens.core import Metric, Selector, TruSession\n",
+        "from trulens.core.otel.instrument import instrument\n",
+        "from trulens.otel.semconv.trace import SpanAttributes\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Define a tiny local pipeline\n",
+        "\n",
+        "The example uses a deterministic in-memory pipeline so the instrumentation pattern is easy to see. Replace `generate` with a local `transformers.pipeline` call in a real app.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "class LocalQAPipeline:\n",
+        "    @instrument(\n",
+        "        span_type=SpanAttributes.SpanType.RETRIEVAL,\n",
+        "        attributes={\n",
+        "            SpanAttributes.RETRIEVAL.QUERY_TEXT: \"question\",\n",
+        "            SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS: \"return\",\n",
+        "        },\n",
+        "    )\n",
+        "    def retrieve(self, question: str) -> list[str]:\n",
+        "        return [\n",
+        "            \"TruLens helps evaluate and track LLM application quality with feedback functions.\"\n",
+        "        ]\n",
+        "\n",
+        "    @instrument(span_type=SpanAttributes.SpanType.GENERATION)\n",
+        "    def generate(self, question: str, context: list[str]) -> str:\n",
+        "        return context[0]\n",
+        "\n",
+        "    @instrument(\n",
+        "        span_type=SpanAttributes.SpanType.RECORD_ROOT,\n",
+        "        attributes={\n",
+        "            SpanAttributes.RECORD_ROOT.INPUT: \"question\",\n",
+        "            SpanAttributes.RECORD_ROOT.OUTPUT: \"return\",\n",
+        "        },\n",
+        "    )\n",
+        "    def answer(self, question: str) -> str:\n",
+        "        context = self.retrieve(question)\n",
+        "        return self.generate(question, context)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Configure local HuggingFace feedback\n",
+        "\n",
+        "`HuggingfaceLocal` runs feedback locally. The exact model you choose depends on the feedback function and resources available on your machine.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from trulens.providers.huggingface import HuggingfaceLocal\n",
+        "\n",
+        "# Choose a small local model appropriate for your feedback task.\n",
+        "# This keeps the example API-only; update the model name for your environment.\n",
+        "provider = HuggingfaceLocal(model_engine=\"distilbert-base-uncased\")\n",
+        "\n",
+        "# Example custom metric hook: use selector wiring with the recorded input/output.\n",
+        "# Replace `provider.language_match` with the local feedback function you want to run.\n",
+        "f_language_match = Metric(\n",
+        "    implementation=provider.language_match,\n",
+        "    name=\"Language Match\",\n",
+        "    selectors={\n",
+        "        \"text1\": Selector.select_record_input(),\n",
+        "        \"text2\": Selector.select_record_output(),\n",
+        "    },\n",
+        ")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Record and evaluate\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "session = TruSession()\n",
+        "session.reset_database()\n",
+        "\n",
+        "app = LocalQAPipeline()\n",
+        "tru_app = TruApp(\n",
+        "    app,\n",
+        "    app_name=\"HuggingFace Local Quickstart\",\n",
+        "    app_version=\"v1\",\n",
+        "    feedbacks=[f_language_match],\n",
+        ")\n",
+        "\n",
+        "with tru_app as recording:\n",
+        "    app.answer(\"What is TruLens used for?\")\n",
+        "\n",
+        "recording.retrieve_feedback_results(timeout=300)\n",
+        "session.get_leaderboard()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## View traces and scores\n",
+        "\n",
+        "```python\n",
+        "from trulens.dashboard import run_dashboard\n",
+        "run_dashboard(session)\n",
+        "```\n",
+        "\n",
+        "Use the dashboard to inspect the root span, retrieval span, generation span, and local HuggingFace feedback results.\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Description

Closes #2470.

Adds a HuggingFace local evaluation quickstart notebook showing a small instrumented local pipeline and local HuggingFace feedback setup.

## What changed

- New notebook: `examples/expositional/models/huggingface/huggingface_local_quickstart.ipynb`
- Demonstrates `@instrument()` with RECORD_ROOT, RETRIEVAL, and GENERATION spans.
- Shows `HuggingfaceLocal` feedback setup and dashboard viewing flow.

## Notes

The example avoids external API keys. Users can swap the deterministic generation method for a local `transformers.pipeline` call and choose the local model appropriate for their feedback task.