### PR TITLE
feat: add CrossModelAlignment for comparing judges across models

### DIFF
--- a/docs/component_guides/evaluation/cross_model_alignment.md
+++ b/docs/component_guides/evaluation/cross_model_alignment.md
@@ -1,0 +1,66 @@
+# Cross-Model Alignment
+
+When you switch the model behind a judge (`gpt-4o-mini` to `gpt-4.1-nano`, or one
+provider to another) the scores can shift in ways a single accuracy number hides.
+
+`CrossModelAlignment` runs the same feedback method with several judges over one
+golden set and reports how much they agree: pairwise Spearman correlation, mean
+absolute difference and score-shift bias between every pair, plus each judge's
+agreement with the ground truth, and a plain recommendation of which judges are
+interchangeable and which are outliers.
+
+!!! Initial Setup
+
+    ```bash
+    pip install trulens-benchmark
+    pip install trulens-providers-openai
+    pip install matplotlib  # optional, for report.plot_heatmap()
+    ```
+
+!!! example
+
+    ```python
+    import os
+    from trulens.benchmark.cross_model_alignment import CrossModelAlignment
+    from trulens.providers.openai import OpenAI
+
+    os.environ["OPENAI_API_KEY"] = "<replace-with-your-api-key>"
+
+    alignment = CrossModelAlignment(
+        judges=[
+            {"provider": OpenAI(model_engine="gpt-4o-mini"), "name": "4o-mini"},
+            {"provider": OpenAI(model_engine="gpt-4.1-mini"), "name": "4.1-mini"},
+        ],
+        feedback_method="relevance",
+        golden_set=my_golden_set,
+    )
+    report = alignment.run()
+    report.print_matrix()
+    report.plot_heatmap()  # matplotlib heatmap of pairwise agreement
+    ```
+
+`print_matrix()` produces:
+
+```
+Cross-Model Alignment
+========================================
+
+Spearman matrix:
+                 4o-mini 4.1-mini
+   4o-mini          1.00     0.92
+  4.1-mini          0.92     1.00
+
+Score-shift bias:
+  4.1-mini scores 0.11 higher than 4o-mini on average
+
+Agreement with ground truth:
+      judge   mae  spearman  kendall
+    4o-mini  0.256     0.87     1.00
+   4.1-mini  0.367     0.87     1.00
+
+Recommendations:
+  - 4o-mini and 4.1-mini are interchangeable (Spearman 0.92).
+```
+
+Use this before swapping the model behind a production judge, to confirm the new
+model ranks examples the same way and to quantify any systematic score shift.

--- a/docs/component_guides/evaluation/cross_model_alignment.md
+++ b/docs/component_guides/evaluation/cross_model_alignment.md
@@ -1,7 +1,8 @@
 # Cross-Model Alignment
 
-When you switch the model behind a judge (`gpt-4o-mini` to `gpt-4.1-nano`, or one
-provider to another) the scores can shift in ways a single accuracy number hides.
+When you switch the model behind a judge (`llama-3.3-70b` to `llama-3.1-8b`, or
+one provider to another) the scores can shift in ways a single accuracy number
+hides.
 
 `CrossModelAlignment` runs the same feedback method with several judges over one
 golden set and reports how much they agree: pairwise Spearman correlation, mean
@@ -13,7 +14,7 @@ interchangeable and which are outliers.
 
     ```bash
     pip install trulens-benchmark
-    pip install trulens-providers-openai
+    pip install trulens-providers-litellm
     pip install matplotlib  # optional, for report.plot_heatmap()
     ```
 
@@ -22,14 +23,16 @@ interchangeable and which are outliers.
     ```python
     import os
     from trulens.benchmark.cross_model_alignment import CrossModelAlignment
-    from trulens.providers.openai import OpenAI
+    from trulens.providers.litellm import LiteLLM
 
-    os.environ["OPENAI_API_KEY"] = "<replace-with-your-api-key>"
+    os.environ["GROQ_API_KEY"] = "<replace-with-your-api-key>"
 
+    judge_a = LiteLLM(model_engine="groq/llama-3.3-70b-versatile")
+    judge_b = LiteLLM(model_engine="groq/llama-3.1-8b-instant")
     alignment = CrossModelAlignment(
         judges=[
-            {"provider": OpenAI(model_engine="gpt-4o-mini"), "name": "4o-mini"},
-            {"provider": OpenAI(model_engine="gpt-4.1-mini"), "name": "4.1-mini"},
+            {"provider": judge_a, "name": "70b"},
+            {"provider": judge_b, "name": "8b"},
         ],
         feedback_method="relevance",
         golden_set=my_golden_set,
@@ -46,20 +49,20 @@ Cross-Model Alignment
 ========================================
 
 Spearman matrix:
-                 4o-mini 4.1-mini
-   4o-mini          1.00     0.92
-  4.1-mini          0.92     1.00
+            70b      8b
+  70b      1.00    0.92
+   8b      0.92    1.00
 
 Score-shift bias:
-  4.1-mini scores 0.11 higher than 4o-mini on average
+  70b scores 0.11 higher than 8b on average
 
 Agreement with ground truth:
-      judge   mae  spearman  kendall
-    4o-mini  0.256     0.87     1.00
-   4.1-mini  0.367     0.87     1.00
+    judge   mae  spearman  kendall
+      70b  0.256     0.87     1.00
+       8b  0.367     0.87     1.00
 
 Recommendations:
-  - 4o-mini and 4.1-mini are interchangeable (Spearman 0.92).
+  - 70b and 8b are interchangeable (Spearman 0.92).
 ```
 
 Use this before swapping the model behind a production judge, to confirm the new

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -253,6 +253,7 @@ nav:
         - Migrating to Metric API: component_guides/evaluation/metric_migration.md
         - Score Distribution Analysis: component_guides/evaluation/score_distribution.md
         - Criteria A/B Testing: component_guides/evaluation/criteria_ab_test.md
+        - Cross-Model Alignment: component_guides/evaluation/cross_model_alignment.md
         - Metric Implementations:
             - component_guides/evaluation/feedback_implementations/index.md
             - Stock Metrics: component_guides/evaluation/feedback_implementations/stock.md

--- a/src/benchmark/trulens/benchmark/cross_model_alignment.py
+++ b/src/benchmark/trulens/benchmark/cross_model_alignment.py
@@ -1,6 +1,6 @@
 """Cross-model alignment for feedback functions.
 
-When you switch the model behind a judge (``gpt-4o-mini`` to ``gpt-4.1-nano``,
+When you switch the model behind a judge (``llama-3.3-70b`` to ``llama-3.1-8b``,
 or one provider to another) the scores can shift in ways a single accuracy
 number hides. [CrossModelAlignment][trulens.benchmark.cross_model_alignment.CrossModelAlignment]
 runs the same feedback method with several judges over one golden set and reports
@@ -9,19 +9,21 @@ score-shift bias between every pair, plus each judge's agreement with the ground
 truth, and a plain recommendation of which judges are interchangeable and which
 are outliers.
 
-The pairwise metrics are computed with numpy (no scipy dependency) so the utility
-stays dependency-light; they mirror the meta-evaluation metrics in
-`GroundTruthAggregator`.
+The Spearman, Kendall and MAE metrics reuse
+[GroundTruthAggregator][trulens.feedback.groundtruth.GroundTruthAggregator] so
+there is a single source of truth for them rather than a second implementation.
 
 Example:
     ```python
     from trulens.benchmark.cross_model_alignment import CrossModelAlignment
-    from trulens.providers.openai import OpenAI
+    from trulens.providers.litellm import LiteLLM
 
+    judge_a = LiteLLM(model_engine="groq/llama-3.3-70b-versatile")
+    judge_b = LiteLLM(model_engine="groq/llama-3.1-8b-instant")
     alignment = CrossModelAlignment(
         judges=[
-            {"provider": OpenAI(model_engine="gpt-4o-mini"), "name": "4o-mini"},
-            {"provider": OpenAI(model_engine="gpt-4.1-mini"), "name": "4.1-mini"},
+            {"provider": judge_a, "name": "70b"},
+            {"provider": judge_b, "name": "8b"},
         ],
         feedback_method="relevance",
         golden_set=my_golden_set,
@@ -36,6 +38,7 @@ import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
+from trulens.feedback import groundtruth as feedback_groundtruth
 
 log = logging.getLogger(__name__)
 
@@ -54,44 +57,28 @@ def _to_score(result: Any) -> float:
     return float(result)
 
 
-def _rankdata(values: np.ndarray) -> np.ndarray:
-    """Average ranks of ``values`` (ties share their mean rank)."""
-    values = np.asarray(values, dtype=float)
-    order = np.argsort(values, kind="mergesort")
-    ranks = np.empty(len(values), dtype=float)
-    ranks[order] = np.arange(1, len(values) + 1)
-    _, inverse, counts = np.unique(
-        values, return_inverse=True, return_counts=True
+def _aggregator(
+    reference: np.ndarray,
+) -> "feedback_groundtruth.GroundTruthAggregator":
+    """A GroundTruthAggregator with ``reference`` as the labels to score against."""
+    return feedback_groundtruth.GroundTruthAggregator(
+        true_labels=[float(x) for x in reference]
     )
-    rank_sums = np.zeros(len(counts))
-    np.add.at(rank_sums, inverse, ranks)
-    return (rank_sums / counts)[inverse]
 
 
 def _spearman(a: np.ndarray, b: np.ndarray) -> float:
-    """Spearman rank correlation between two equal-length sequences."""
-    ranks_a, ranks_b = _rankdata(a), _rankdata(b)
-    if np.std(ranks_a) == 0 or np.std(ranks_b) == 0:
-        return float("nan")
-    return float(np.corrcoef(ranks_a, ranks_b)[0, 1])
+    """Spearman correlation between two sequences, via GroundTruthAggregator."""
+    return float(_aggregator(b).spearman_correlation([float(x) for x in a]))
 
 
 def _kendall_tau(a: np.ndarray, b: np.ndarray) -> float:
-    """Kendall's tau (concordant minus discordant pairs, ties excluded)."""
-    a, b = np.asarray(a, dtype=float), np.asarray(b, dtype=float)
-    n = len(a)
-    if n < 2:
-        return float("nan")
-    concordant = discordant = 0
-    for i in range(n):
-        for j in range(i + 1, n):
-            sign = np.sign(a[i] - a[j]) * np.sign(b[i] - b[j])
-            if sign > 0:
-                concordant += 1
-            elif sign < 0:
-                discordant += 1
-    total = concordant + discordant
-    return float((concordant - discordant) / total) if total else float("nan")
+    """Kendall's tau between two sequences, via GroundTruthAggregator."""
+    return float(_aggregator(b).kendall_tau([float(x) for x in a]))
+
+
+def _mae(a: np.ndarray, b: np.ndarray) -> float:
+    """Mean absolute error between two sequences, via GroundTruthAggregator."""
+    return float(_aggregator(b).mae([float(x) for x in a]))
 
 
 class CrossModelAlignmentReport:
@@ -101,6 +88,10 @@ class CrossModelAlignmentReport:
         names: Judge names, one per score sequence.
         scores: Per-judge score sequences, all aligned and equal length.
         expected: Optional ground-truth scores aligned with ``scores``.
+        interchangeable_spearman: Pairs whose Spearman correlation is at least
+            this are reported as interchangeable.
+        outlier_mean_spearman: A judge whose mean correlation with the others is
+            below this is reported as an outlier.
     """
 
     def __init__(
@@ -108,6 +99,8 @@ class CrossModelAlignmentReport:
         names: List[str],
         scores: List[List[float]],
         expected: Optional[List[float]] = None,
+        interchangeable_spearman: float = INTERCHANGEABLE_SPEARMAN,
+        outlier_mean_spearman: float = OUTLIER_MEAN_SPEARMAN,
     ):
         self.names: List[str] = list(names)
         self.scores: List[np.ndarray] = [
@@ -117,6 +110,8 @@ class CrossModelAlignmentReport:
         self.expected: Optional[np.ndarray] = (
             None if expected is None else np.asarray(expected, dtype=float)
         )
+        self.interchangeable_spearman = interchangeable_spearman
+        self.outlier_mean_spearman = outlier_mean_spearman
 
         self.spearman = np.full((self.n, self.n), np.nan)
         self.mean_abs_diff = np.full((self.n, self.n), np.nan)
@@ -124,9 +119,7 @@ class CrossModelAlignmentReport:
         for i in range(self.n):
             for j in range(self.n):
                 self.spearman[i, j] = _spearman(self.scores[i], self.scores[j])
-                self.mean_abs_diff[i, j] = float(
-                    np.mean(np.abs(self.scores[i] - self.scores[j]))
-                )
+                self.mean_abs_diff[i, j] = _mae(self.scores[i], self.scores[j])
                 self.bias[i, j] = float(
                     np.mean(self.scores[i]) - np.mean(self.scores[j])
                 )
@@ -141,7 +134,7 @@ class CrossModelAlignmentReport:
         out: Dict[str, Dict[str, float]] = {}
         for name, judge_scores in zip(self.names, self.scores):
             out[name] = {
-                "mae": float(np.mean(np.abs(judge_scores - self.expected))),
+                "mae": _mae(judge_scores, self.expected),
                 "spearman": _spearman(judge_scores, self.expected),
                 "kendall": _kendall_tau(judge_scores, self.expected),
             }
@@ -152,7 +145,7 @@ class CrossModelAlignmentReport:
         recs: List[str] = []
         for i in range(self.n):
             for j in range(i + 1, self.n):
-                if self.spearman[i, j] >= INTERCHANGEABLE_SPEARMAN:
+                if self.spearman[i, j] >= self.interchangeable_spearman:
                     recs.append(
                         f"{self.names[i]} and {self.names[j]} are "
                         f"interchangeable (Spearman "
@@ -161,7 +154,7 @@ class CrossModelAlignmentReport:
         for i in range(self.n):
             others = [self.spearman[i, j] for j in range(self.n) if j != i]
             others = [o for o in others if not np.isnan(o)]
-            if others and np.mean(others) < OUTLIER_MEAN_SPEARMAN:
+            if others and np.mean(others) < self.outlier_mean_spearman:
                 recs.append(
                     f"{self.names[i]} is an outlier (mean Spearman "
                     f"{np.mean(others):.2f} with the other judges)."
@@ -269,6 +262,12 @@ class CrossModelAlignment:
         args_fn: Optional function mapping a golden row to the positional
             arguments passed to each judge. Defaults to
             ``(row["query"], row["expected_response"])``.
+        interchangeable_spearman: Pairs whose Spearman correlation is at least
+            this are reported as interchangeable.
+        outlier_mean_spearman: A judge whose mean correlation with the others is
+            below this is reported as an outlier.
+        skip_warn_fraction: Warn if more than this fraction of rows are skipped
+            because a judge errored on them.
     """
 
     def __init__(
@@ -277,6 +276,9 @@ class CrossModelAlignment:
         feedback_method: str,
         golden_set: List[Dict[str, Any]],
         args_fn: Optional[Callable[[Dict[str, Any]], Tuple]] = None,
+        interchangeable_spearman: float = INTERCHANGEABLE_SPEARMAN,
+        outlier_mean_spearman: float = OUTLIER_MEAN_SPEARMAN,
+        skip_warn_fraction: float = 0.2,
     ):
         if len(judges) < 2:
             raise ValueError("Provide at least two judges to compare.")
@@ -284,6 +286,9 @@ class CrossModelAlignment:
         self.feedback_method = feedback_method
         self.golden_set = golden_set
         self.args_fn = args_fn or self._default_args
+        self.interchangeable_spearman = interchangeable_spearman
+        self.outlier_mean_spearman = outlier_mean_spearman
+        self.skip_warn_fraction = skip_warn_fraction
 
     @staticmethod
     def _default_args(row: Dict[str, Any]) -> Tuple:
@@ -304,6 +309,7 @@ class CrossModelAlignment:
         names = [judge["name"] for judge in self.judges]
         per_judge: Dict[str, List[float]] = {name: [] for name in names}
         expected: List[float] = []
+        skipped = 0
         for row in self.golden_set:
             args = self.args_fn(row)
             row_scores: Dict[str, float] = {}
@@ -318,10 +324,22 @@ class CrossModelAlignment:
                     )
                     break
             if len(row_scores) != len(self.judges):
+                skipped += 1
                 continue
             for name, score in row_scores.items():
                 per_judge[name].append(score)
             expected.append(row.get("expected_score"))
+
+        total = len(self.golden_set)
+        if total and skipped / total > self.skip_warn_fraction:
+            log.warning(
+                "%d of %d rows (%.0f%%) were skipped because a judge errored; "
+                "the alignment is computed on the remaining %d rows.",
+                skipped,
+                total,
+                100 * skipped / total,
+                total - skipped,
+            )
 
         scores = [per_judge[name] for name in names]
         if not scores[0]:
@@ -331,5 +349,9 @@ class CrossModelAlignment:
             )
         has_expected = all(e is not None for e in expected)
         return CrossModelAlignmentReport(
-            names, scores, expected if has_expected else None
+            names,
+            scores,
+            expected if has_expected else None,
+            interchangeable_spearman=self.interchangeable_spearman,
+            outlier_mean_spearman=self.outlier_mean_spearman,
         )

--- a/src/benchmark/trulens/benchmark/cross_model_alignment.py
+++ b/src/benchmark/trulens/benchmark/cross_model_alignment.py
@@ -1,0 +1,335 @@
+"""Cross-model alignment for feedback functions.
+
+When you switch the model behind a judge (``gpt-4o-mini`` to ``gpt-4.1-nano``,
+or one provider to another) the scores can shift in ways a single accuracy
+number hides. [CrossModelAlignment][trulens.benchmark.cross_model_alignment.CrossModelAlignment]
+runs the same feedback method with several judges over one golden set and reports
+how much they agree: pairwise Spearman correlation, mean absolute difference and
+score-shift bias between every pair, plus each judge's agreement with the ground
+truth, and a plain recommendation of which judges are interchangeable and which
+are outliers.
+
+The pairwise metrics are computed with numpy (no scipy dependency) so the utility
+stays dependency-light; they mirror the meta-evaluation metrics in
+`GroundTruthAggregator`.
+
+Example:
+    ```python
+    from trulens.benchmark.cross_model_alignment import CrossModelAlignment
+    from trulens.providers.openai import OpenAI
+
+    alignment = CrossModelAlignment(
+        judges=[
+            {"provider": OpenAI(model_engine="gpt-4o-mini"), "name": "4o-mini"},
+            {"provider": OpenAI(model_engine="gpt-4.1-mini"), "name": "4.1-mini"},
+        ],
+        feedback_method="relevance",
+        golden_set=my_golden_set,
+    )
+    report = alignment.run()
+    report.print_matrix()
+    report.plot_heatmap()
+    ```
+"""
+
+import logging
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+# Pairs whose Spearman correlation is at least this are called interchangeable.
+INTERCHANGEABLE_SPEARMAN = 0.9
+# A judge whose mean correlation with the others is below this is an outlier.
+OUTLIER_MEAN_SPEARMAN = 0.5
+
+
+def _to_score(result: Any) -> float:
+    if isinstance(result, tuple):
+        result = result[0]
+    if isinstance(result, dict):
+        values = [v for v in result.values() if isinstance(v, (int, float))]
+        result = float(np.mean(values)) if values else float("nan")
+    return float(result)
+
+
+def _rankdata(values: np.ndarray) -> np.ndarray:
+    """Average ranks of ``values`` (ties share their mean rank)."""
+    values = np.asarray(values, dtype=float)
+    order = np.argsort(values, kind="mergesort")
+    ranks = np.empty(len(values), dtype=float)
+    ranks[order] = np.arange(1, len(values) + 1)
+    _, inverse, counts = np.unique(
+        values, return_inverse=True, return_counts=True
+    )
+    rank_sums = np.zeros(len(counts))
+    np.add.at(rank_sums, inverse, ranks)
+    return (rank_sums / counts)[inverse]
+
+
+def _spearman(a: np.ndarray, b: np.ndarray) -> float:
+    """Spearman rank correlation between two equal-length sequences."""
+    ranks_a, ranks_b = _rankdata(a), _rankdata(b)
+    if np.std(ranks_a) == 0 or np.std(ranks_b) == 0:
+        return float("nan")
+    return float(np.corrcoef(ranks_a, ranks_b)[0, 1])
+
+
+def _kendall_tau(a: np.ndarray, b: np.ndarray) -> float:
+    """Kendall's tau (concordant minus discordant pairs, ties excluded)."""
+    a, b = np.asarray(a, dtype=float), np.asarray(b, dtype=float)
+    n = len(a)
+    if n < 2:
+        return float("nan")
+    concordant = discordant = 0
+    for i in range(n):
+        for j in range(i + 1, n):
+            sign = np.sign(a[i] - a[j]) * np.sign(b[i] - b[j])
+            if sign > 0:
+                concordant += 1
+            elif sign < 0:
+                discordant += 1
+    total = concordant + discordant
+    return float((concordant - discordant) / total) if total else float("nan")
+
+
+class CrossModelAlignmentReport:
+    """Pairwise agreement between judges plus per-judge ground-truth metrics.
+
+    Args:
+        names: Judge names, one per score sequence.
+        scores: Per-judge score sequences, all aligned and equal length.
+        expected: Optional ground-truth scores aligned with ``scores``.
+    """
+
+    def __init__(
+        self,
+        names: List[str],
+        scores: List[List[float]],
+        expected: Optional[List[float]] = None,
+    ):
+        self.names: List[str] = list(names)
+        self.scores: List[np.ndarray] = [
+            np.asarray(s, dtype=float) for s in scores
+        ]
+        self.n: int = len(self.names)
+        self.expected: Optional[np.ndarray] = (
+            None if expected is None else np.asarray(expected, dtype=float)
+        )
+
+        self.spearman = np.full((self.n, self.n), np.nan)
+        self.mean_abs_diff = np.full((self.n, self.n), np.nan)
+        self.bias = np.full((self.n, self.n), np.nan)
+        for i in range(self.n):
+            for j in range(self.n):
+                self.spearman[i, j] = _spearman(self.scores[i], self.scores[j])
+                self.mean_abs_diff[i, j] = float(
+                    np.mean(np.abs(self.scores[i] - self.scores[j]))
+                )
+                self.bias[i, j] = float(
+                    np.mean(self.scores[i]) - np.mean(self.scores[j])
+                )
+
+    def ground_truth_metrics(self) -> Dict[str, Dict[str, float]]:
+        """Per-judge agreement with the ground truth (mae, spearman, kendall).
+
+        Empty when no expected scores were provided.
+        """
+        if self.expected is None:
+            return {}
+        out: Dict[str, Dict[str, float]] = {}
+        for name, judge_scores in zip(self.names, self.scores):
+            out[name] = {
+                "mae": float(np.mean(np.abs(judge_scores - self.expected))),
+                "spearman": _spearman(judge_scores, self.expected),
+                "kendall": _kendall_tau(judge_scores, self.expected),
+            }
+        return out
+
+    def recommendations(self) -> List[str]:
+        """Plain-language notes on interchangeable judges and outliers."""
+        recs: List[str] = []
+        for i in range(self.n):
+            for j in range(i + 1, self.n):
+                if self.spearman[i, j] >= INTERCHANGEABLE_SPEARMAN:
+                    recs.append(
+                        f"{self.names[i]} and {self.names[j]} are "
+                        f"interchangeable (Spearman "
+                        f"{self.spearman[i, j]:.2f})."
+                    )
+        for i in range(self.n):
+            others = [self.spearman[i, j] for j in range(self.n) if j != i]
+            others = [o for o in others if not np.isnan(o)]
+            if others and np.mean(others) < OUTLIER_MEAN_SPEARMAN:
+                recs.append(
+                    f"{self.names[i]} is an outlier (mean Spearman "
+                    f"{np.mean(others):.2f} with the other judges)."
+                )
+        return recs
+
+    def print_matrix(self) -> None:
+        """Print the pairwise agreement matrices and recommendations."""
+        width = max((len(n) for n in self.names), default=4)
+        header = " " * (width + 2) + "".join(f"{n[:8]:>9}" for n in self.names)
+        lines = ["Cross-Model Alignment", "=" * 40, "", "Spearman matrix:"]
+        lines.append(header)
+        for i, name in enumerate(self.names):
+            row = "".join(f"{self.spearman[i, j]:>9.2f}" for j in range(self.n))
+            lines.append(f"{name:>{width}}  {row}")
+
+        notable = []
+        for i in range(self.n):
+            for j in range(i + 1, self.n):
+                bias = self.bias[i, j]
+                if abs(bias) >= 0.05:
+                    higher, lower = (
+                        (self.names[i], self.names[j])
+                        if bias > 0
+                        else (self.names[j], self.names[i])
+                    )
+                    notable.append(
+                        f"  {higher} scores {abs(bias):.2f} higher than "
+                        f"{lower} on average"
+                    )
+        if notable:
+            lines.append("")
+            lines.append("Score-shift bias:")
+            lines.extend(notable)
+
+        gt = self.ground_truth_metrics()
+        if gt:
+            lines.append("")
+            lines.append("Agreement with ground truth:")
+            lines.append(f"  {'judge':>{width}}   mae  spearman  kendall")
+            for name, metric in gt.items():
+                lines.append(
+                    f"  {name:>{width}}  {metric['mae']:.3f}  "
+                    f"{metric['spearman']:>7.2f}  {metric['kendall']:>7.2f}"
+                )
+
+        recs = self.recommendations()
+        lines.append("")
+        if recs:
+            lines.append("Recommendations:")
+            for rec in recs:
+                lines.append(f"  - {rec}")
+        else:
+            lines.append("No interchangeable judges or outliers detected.")
+        print("\n".join(lines))
+
+    def plot_heatmap(self):  # pragma: no cover - needs matplotlib and a display
+        """Plot the pairwise Spearman matrix as a heatmap.
+
+        Returns:
+            The created ``matplotlib`` figure.
+
+        Raises:
+            ImportError: If ``matplotlib`` is not installed.
+        """
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError as e:
+            raise ImportError(
+                "matplotlib is required for plotting. Install it with "
+                "`pip install matplotlib`."
+            ) from e
+        fig, ax = plt.subplots(figsize=(6, 5))
+        image = ax.imshow(self.spearman, vmin=-1, vmax=1, cmap="RdYlGn")
+        ax.set_xticks(range(self.n))
+        ax.set_yticks(range(self.n))
+        ax.set_xticklabels(self.names, rotation=45, ha="right")
+        ax.set_yticklabels(self.names)
+        for i in range(self.n):
+            for j in range(self.n):
+                ax.text(
+                    j,
+                    i,
+                    f"{self.spearman[i, j]:.2f}",
+                    ha="center",
+                    va="center",
+                    color="black",
+                )
+        ax.set_title("Pairwise Spearman correlation")
+        fig.colorbar(image, ax=ax)
+        fig.tight_layout()
+        return fig
+
+
+class CrossModelAlignment:
+    """Run one feedback method with several judges and compare their scores.
+
+    Args:
+        judges: A list of dicts, each with a ``provider`` (a feedback provider
+            instance) and a ``name``.
+        feedback_method: The provider method to call as the judge, e.g.
+            ``"relevance"``.
+        golden_set: A list of dicts, each with ``query``, ``expected_response``
+            and, optionally, ``expected_score``.
+        args_fn: Optional function mapping a golden row to the positional
+            arguments passed to each judge. Defaults to
+            ``(row["query"], row["expected_response"])``.
+    """
+
+    def __init__(
+        self,
+        judges: List[Dict[str, Any]],
+        feedback_method: str,
+        golden_set: List[Dict[str, Any]],
+        args_fn: Optional[Callable[[Dict[str, Any]], Tuple]] = None,
+    ):
+        if len(judges) < 2:
+            raise ValueError("Provide at least two judges to compare.")
+        self.judges = judges
+        self.feedback_method = feedback_method
+        self.golden_set = golden_set
+        self.args_fn = args_fn or self._default_args
+
+    @staticmethod
+    def _default_args(row: Dict[str, Any]) -> Tuple:
+        return (row["query"], row["expected_response"])
+
+    def run(self) -> CrossModelAlignmentReport:
+        """Score the golden set with every judge and build the report.
+
+        Rows on which any judge errors are skipped so all judges stay aligned.
+
+        Returns:
+            A populated
+            [CrossModelAlignmentReport][trulens.benchmark.cross_model_alignment.CrossModelAlignmentReport].
+
+        Raises:
+            ValueError: If no row was scored by every judge.
+        """
+        names = [judge["name"] for judge in self.judges]
+        per_judge: Dict[str, List[float]] = {name: [] for name in names}
+        expected: List[float] = []
+        for row in self.golden_set:
+            args = self.args_fn(row)
+            row_scores: Dict[str, float] = {}
+            for judge in self.judges:
+                fn = getattr(judge["provider"], self.feedback_method)
+                try:
+                    row_scores[judge["name"]] = _to_score(fn(*args))
+                except Exception:
+                    log.exception(
+                        "judge %s failed on a row; skipping the row",
+                        judge["name"],
+                    )
+                    break
+            if len(row_scores) != len(self.judges):
+                continue
+            for name, score in row_scores.items():
+                per_judge[name].append(score)
+            expected.append(row.get("expected_score"))
+
+        scores = [per_judge[name] for name in names]
+        if not scores[0]:
+            raise ValueError(
+                "No row was scored by every judge; check the judges and "
+                "golden_set."
+            )
+        has_expected = all(e is not None for e in expected)
+        return CrossModelAlignmentReport(
+            names, scores, expected if has_expected else None
+        )

--- a/tests/unit/test_cross_model_alignment.py
+++ b/tests/unit/test_cross_model_alignment.py
@@ -1,0 +1,103 @@
+"""Unit tests for cross-model alignment. No model or API key needed."""
+
+import pytest
+
+cross_model_alignment = pytest.importorskip(
+    "trulens.benchmark.cross_model_alignment"
+)
+CrossModelAlignment = cross_model_alignment.CrossModelAlignment
+CrossModelAlignmentReport = cross_model_alignment.CrossModelAlignmentReport
+
+
+def test_identical_judges_are_interchangeable():
+    scores = [0.1, 0.4, 0.6, 0.9, 0.3]
+    report = CrossModelAlignmentReport(["a", "b"], [scores, scores])
+    assert report.spearman[0, 1] == pytest.approx(1.0)
+    assert any("interchangeable" in r for r in report.recommendations())
+
+
+def test_diagonal_spearman_is_one():
+    report = CrossModelAlignmentReport(
+        ["a", "b"], [[0.1, 0.5, 0.9], [0.2, 0.4, 0.8]]
+    )
+    assert report.spearman[0, 0] == pytest.approx(1.0)
+    assert report.spearman[1, 1] == pytest.approx(1.0)
+
+
+def test_bias_detects_consistent_offset():
+    high = [0.3, 0.5, 0.7]
+    low = [0.1, 0.3, 0.5]
+    report = CrossModelAlignmentReport(["high", "low"], [high, low])
+    assert report.bias[0, 1] == pytest.approx(0.2, abs=1e-6)
+
+
+def test_mean_abs_diff():
+    report = CrossModelAlignmentReport(["a", "b"], [[0.0, 1.0], [1.0, 0.0]])
+    assert report.mean_abs_diff[0, 1] == pytest.approx(1.0)
+
+
+def test_outlier_detected():
+    a = [0.10, 0.20, 0.30, 0.40, 0.50, 0.60]
+    b = [0.12, 0.22, 0.32, 0.42, 0.52, 0.62]
+    c = [0.15, 0.25, 0.35, 0.45, 0.55, 0.65]
+    d = [0.50, 0.10, 0.60, 0.20, 0.40, 0.30]  # uncorrelated with a/b/c
+    report = CrossModelAlignmentReport(["a", "b", "c", "d"], [a, b, c, d])
+    recs = report.recommendations()
+    assert any("d is an outlier" in r for r in recs)
+    assert not any("a is an outlier" in r for r in recs)
+
+
+def test_ground_truth_metrics():
+    perfect = [0.2, 0.5, 0.8]
+    flat = [0.5, 0.5, 0.5]
+    report = CrossModelAlignmentReport(
+        ["perfect", "flat"], [perfect, flat], expected=[0.2, 0.5, 0.8]
+    )
+    gt = report.ground_truth_metrics()
+    assert gt["perfect"]["mae"] == pytest.approx(0.0)
+    assert gt["perfect"]["spearman"] == pytest.approx(1.0)
+    assert gt["flat"]["mae"] > 0.0
+
+
+class _FakeProvider:
+    def __init__(self, scores):
+        self._scores = iter(scores)
+
+    def relevance(self, query, response):
+        return next(self._scores)
+
+
+def test_run_with_fake_providers():
+    golden = [
+        {"query": "q1", "expected_response": "r1", "expected_score": 0.2},
+        {"query": "q2", "expected_response": "r2", "expected_score": 0.8},
+    ]
+    judges = [
+        {"provider": _FakeProvider([0.25, 0.75]), "name": "a"},
+        {"provider": _FakeProvider([0.3, 0.7]), "name": "b"},
+    ]
+    report = CrossModelAlignment(judges, "relevance", golden).run()
+    assert report.n == 2
+    assert report.scores[0].tolist() == [0.25, 0.75]
+    assert report.expected is not None
+
+
+def test_requires_at_least_two_judges():
+    with pytest.raises(ValueError):
+        CrossModelAlignment(
+            [{"provider": object(), "name": "a"}], "relevance", []
+        )
+
+
+def test_run_raises_when_all_rows_fail():
+    class _Boom:
+        def relevance(self, query, response):
+            raise RuntimeError("judge down")
+
+    golden = [{"query": "q", "expected_response": "r"}]
+    judges = [
+        {"provider": _Boom(), "name": "a"},
+        {"provider": _Boom(), "name": "b"},
+    ]
+    with pytest.raises(ValueError):
+        CrossModelAlignment(judges, "relevance", golden).run()


### PR DESCRIPTION
## Summary

Closes #2508.

Switching the model behind a judge (`gpt-4o-mini` to `gpt-4.1-nano`, or one provider to another) can shift scores in ways a single accuracy number hides. `CrossModelAlignment` runs the same feedback method with several judges over one golden set and reports how much they agree.

## Implementation

`src/benchmark/trulens/benchmark/cross_model_alignment.py`:

- `CrossModelAlignment(judges, feedback_method, golden_set, ...)` runs `feedback_method` for every judge over each golden row (skipping any row a judge errors on so all judges stay aligned) and returns a `CrossModelAlignmentReport`.
- `CrossModelAlignmentReport` computes:
  - **pairwise Spearman correlation** matrix between judges
  - **mean absolute difference** matrix
  - **score-shift bias** matrix (does judge A score consistently higher than judge B?)
  - **per-judge ground-truth metrics** (MAE, Spearman, Kendall's tau) when `expected_score` is available
  - **recommendations** — which judges are interchangeable (Spearman ≥ 0.9) and which are outliers
  - `print_matrix()` (text) and `plot_heatmap()` (matplotlib, imported lazily so it stays optional)

The pairwise metrics are computed with numpy (no scipy dependency) to keep the benchmark utility dependency-light; they mirror the meta-evaluation metrics in `GroundTruthAggregator`.

## Testing

- `tests/unit/test_cross_model_alignment.py`: 9 unit tests covering the Spearman matrix, bias, mean-abs-diff, outlier detection, ground-truth metrics, the run loop with fake providers, and the input guards. No model or API key required.
- `ruff format` + `ruff check` clean against the repo config.
- Verified end-to-end: ran two judges over `answer_relevance_golden_set` against live OpenAI-compatible models; the report correctly identified the two judges as rank-identical (Spearman 1.0) while flagging that one scored ~0.11 higher on average.

## Docs

Adds a usage guide at `docs/component_guides/evaluation/cross_model_alignment.md` (registered in the nav). The API reference picks the module up automatically from its docstrings.
