### PR TITLE
feat: add CriteriaABTest for comparing judge configurations

### DIFF
--- a/docs/component_guides/evaluation/criteria_ab_test.md
+++ b/docs/component_guides/evaluation/criteria_ab_test.md
@@ -1,0 +1,66 @@
+# Criteria A/B Testing
+
+TruLens feedback functions accept `criteria` and `additional_instructions` to
+tune judge behaviour, but there is no easy way to tell whether a new criteria
+string actually agrees with human judgement better than the old one.
+
+`CriteriaABTest` runs two configurations of a feedback function over the same
+golden set and reports which one aligns better: side-by-side MAE / Spearman /
+Kendall / Brier against the ground truth, the examples where the two disagree
+most, a paired significance test (a sign-flip permutation test, no scipy
+dependency) on the score differences, and a winner.
+
+!!! Initial Setup
+
+    ```bash
+    pip install trulens-benchmark
+    pip install trulens-providers-openai
+    ```
+
+!!! example
+
+    ```python
+    import os
+    from trulens.benchmark.criteria_ab_test import CriteriaABTest
+    from trulens.providers.openai import OpenAI
+
+    os.environ["OPENAI_API_KEY"] = "<replace-with-your-api-key>"
+    provider = OpenAI()
+
+    test = CriteriaABTest(
+        golden_set=my_golden_set,
+        variant_a={"fn": provider.relevance, "name": "default"},
+        variant_b={
+            "fn": provider.relevance,
+            "kwargs": {"criteria": "Be strict; a high score only if fully relevant."},
+            "name": "strict",
+        },
+    )
+    report = test.run()
+    report.print_comparison()
+    ```
+
+`print_comparison()` produces:
+
+```
+Criteria A/B Test
+========================================
+A = default    B = strict    n = 8
+
+  metric           default        strict
+  mae                0.383         0.425
+  spearman           0.438         0.319
+  kendall            0.500         0.455
+  brier              0.200         0.244
+
+Mean difference (A - B): +0.042  (permutation p = 1.000)
+
+Largest disagreements:
+  +0.33  A=0.33 B=0.00  How does the social structure of a lion pride im...
+
+Winner: default (lower MAE vs ground truth; difference not significant at alpha=0.05).
+```
+
+Use this when iterating on a judge's `criteria` or `additional_instructions`, to
+confirm a change actually improves alignment with human labels rather than just
+shifting scores around.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -252,6 +252,7 @@ nav:
         - Anatomy of a Metric: component_guides/evaluation/feedback_anatomy.md
         - Migrating to Metric API: component_guides/evaluation/metric_migration.md
         - Score Distribution Analysis: component_guides/evaluation/score_distribution.md
+        - Criteria A/B Testing: component_guides/evaluation/criteria_ab_test.md
         - Metric Implementations:
             - component_guides/evaluation/feedback_implementations/index.md
             - Stock Metrics: component_guides/evaluation/feedback_implementations/stock.md

--- a/src/benchmark/trulens/benchmark/criteria_ab_test.py
+++ b/src/benchmark/trulens/benchmark/criteria_ab_test.py
@@ -9,8 +9,11 @@ one aligns better: side-by-side MAE / Spearman / Kendall / Brier against the
 ground truth, the examples where the two disagree most, a paired significance
 test on the score differences, and a winner.
 
-Metrics are computed with numpy (no scipy dependency); significance uses a
-sign-flip permutation test so the utility stays dependency-light.
+Spearman and Kendall reuse
+[GroundTruthAggregator][trulens.feedback.groundtruth.GroundTruthAggregator] so
+there is a single source of truth for those metrics; the paired sign-flip
+permutation significance test lives alongside it in
+[groundtruth][trulens.feedback.groundtruth].
 
 Example:
     ```python
@@ -36,11 +39,10 @@ import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
+from trulens.feedback import groundtruth as feedback_groundtruth
 
 log = logging.getLogger(__name__)
 
-# Number of sign-flip permutations for the significance test.
-PERMUTATIONS = 10000
 # Significance level below which the two variants are called different.
 SIGNIFICANCE_ALPHA = 0.05
 
@@ -54,61 +56,15 @@ def _to_score(result: Any) -> float:
     return float(result)
 
 
-def _rankdata(values: np.ndarray) -> np.ndarray:
-    values = np.asarray(values, dtype=float)
-    order = np.argsort(values, kind="mergesort")
-    ranks = np.empty(len(values), dtype=float)
-    ranks[order] = np.arange(1, len(values) + 1)
-    _, inverse, counts = np.unique(
-        values, return_inverse=True, return_counts=True
-    )
-    rank_sums = np.zeros(len(counts))
-    np.add.at(rank_sums, inverse, ranks)
-    return (rank_sums / counts)[inverse]
-
-
-def _spearman(a: np.ndarray, b: np.ndarray) -> float:
-    ranks_a, ranks_b = _rankdata(a), _rankdata(b)
-    if np.std(ranks_a) == 0 or np.std(ranks_b) == 0:
-        return float("nan")
-    return float(np.corrcoef(ranks_a, ranks_b)[0, 1])
-
-
-def _kendall_tau(a: np.ndarray, b: np.ndarray) -> float:
-    a, b = np.asarray(a, dtype=float), np.asarray(b, dtype=float)
-    n = len(a)
-    if n < 2:
-        return float("nan")
-    concordant = discordant = 0
-    for i in range(n):
-        for j in range(i + 1, n):
-            sign = np.sign(a[i] - a[j]) * np.sign(b[i] - b[j])
-            if sign > 0:
-                concordant += 1
-            elif sign < 0:
-                discordant += 1
-    total = concordant + discordant
-    return float((concordant - discordant) / total) if total else float("nan")
-
-
-def _permutation_pvalue(diffs: np.ndarray, seed: int = 0) -> float:
-    """Two-sided paired sign-flip permutation p-value for ``mean(diffs)==0``."""
-    diffs = np.asarray(diffs, dtype=float)
-    n = len(diffs)
-    if n == 0 or np.allclose(diffs, 0.0):
-        return 1.0
-    observed = abs(float(np.mean(diffs)))
-    rng = np.random.default_rng(seed)
-    signs = rng.choice([-1.0, 1.0], size=(PERMUTATIONS, n))
-    perm_means = np.abs((signs * diffs).mean(axis=1))
-    return float((np.sum(perm_means >= observed) + 1) / (PERMUTATIONS + 1))
-
-
 def _metrics(scores: np.ndarray, expected: np.ndarray) -> Dict[str, float]:
+    aggregator = feedback_groundtruth.GroundTruthAggregator(
+        true_labels=[float(x) for x in expected]
+    )
+    score_list = [float(x) for x in scores]
     return {
         "mae": float(np.mean(np.abs(scores - expected))),
-        "spearman": _spearman(scores, expected),
-        "kendall": _kendall_tau(scores, expected),
+        "spearman": float(aggregator.spearman_correlation(score_list)),
+        "kendall": float(aggregator.kendall_tau(score_list)),
         "brier": float(np.mean((scores - expected) ** 2)),
     }
 
@@ -158,7 +114,9 @@ class CriteriaABTestReport:
         """Mean score difference (A - B) and its permutation p-value."""
         return {
             "mean_difference": float(np.mean(self.diffs)),
-            "p_value": _permutation_pvalue(self.diffs),
+            "p_value": feedback_groundtruth.paired_permutation_pvalue(
+                self.diffs
+            ),
         }
 
     def top_disagreements(self, k: int = 5) -> List[Dict[str, Any]]:

--- a/src/benchmark/trulens/benchmark/criteria_ab_test.py
+++ b/src/benchmark/trulens/benchmark/criteria_ab_test.py
@@ -1,0 +1,332 @@
+"""A/B test two judge configurations against a golden set.
+
+TruLens feedback functions accept `criteria` and `additional_instructions` to
+tune judge behaviour, but there is no easy way to tell whether a new criteria
+string actually agrees with human judgement better than the old one.
+[CriteriaABTest][trulens.benchmark.criteria_ab_test.CriteriaABTest] runs two
+configurations of a feedback function over the same golden set and reports which
+one aligns better: side-by-side MAE / Spearman / Kendall / Brier against the
+ground truth, the examples where the two disagree most, a paired significance
+test on the score differences, and a winner.
+
+Metrics are computed with numpy (no scipy dependency); significance uses a
+sign-flip permutation test so the utility stays dependency-light.
+
+Example:
+    ```python
+    from trulens.benchmark.criteria_ab_test import CriteriaABTest
+    from trulens.providers.openai import OpenAI
+
+    provider = OpenAI()
+    test = CriteriaABTest(
+        golden_set=my_golden_set,
+        variant_a={"fn": provider.relevance, "name": "default"},
+        variant_b={
+            "fn": provider.relevance,
+            "kwargs": {"criteria": "Score strictly."},
+            "name": "strict",
+        },
+    )
+    report = test.run()
+    report.print_comparison()
+    ```
+"""
+
+import logging
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+# Number of sign-flip permutations for the significance test.
+PERMUTATIONS = 10000
+# Significance level below which the two variants are called different.
+SIGNIFICANCE_ALPHA = 0.05
+
+
+def _to_score(result: Any) -> float:
+    if isinstance(result, tuple):
+        result = result[0]
+    if isinstance(result, dict):
+        values = [v for v in result.values() if isinstance(v, (int, float))]
+        result = float(np.mean(values)) if values else float("nan")
+    return float(result)
+
+
+def _rankdata(values: np.ndarray) -> np.ndarray:
+    values = np.asarray(values, dtype=float)
+    order = np.argsort(values, kind="mergesort")
+    ranks = np.empty(len(values), dtype=float)
+    ranks[order] = np.arange(1, len(values) + 1)
+    _, inverse, counts = np.unique(
+        values, return_inverse=True, return_counts=True
+    )
+    rank_sums = np.zeros(len(counts))
+    np.add.at(rank_sums, inverse, ranks)
+    return (rank_sums / counts)[inverse]
+
+
+def _spearman(a: np.ndarray, b: np.ndarray) -> float:
+    ranks_a, ranks_b = _rankdata(a), _rankdata(b)
+    if np.std(ranks_a) == 0 or np.std(ranks_b) == 0:
+        return float("nan")
+    return float(np.corrcoef(ranks_a, ranks_b)[0, 1])
+
+
+def _kendall_tau(a: np.ndarray, b: np.ndarray) -> float:
+    a, b = np.asarray(a, dtype=float), np.asarray(b, dtype=float)
+    n = len(a)
+    if n < 2:
+        return float("nan")
+    concordant = discordant = 0
+    for i in range(n):
+        for j in range(i + 1, n):
+            sign = np.sign(a[i] - a[j]) * np.sign(b[i] - b[j])
+            if sign > 0:
+                concordant += 1
+            elif sign < 0:
+                discordant += 1
+    total = concordant + discordant
+    return float((concordant - discordant) / total) if total else float("nan")
+
+
+def _permutation_pvalue(diffs: np.ndarray, seed: int = 0) -> float:
+    """Two-sided paired sign-flip permutation p-value for ``mean(diffs)==0``."""
+    diffs = np.asarray(diffs, dtype=float)
+    n = len(diffs)
+    if n == 0 or np.allclose(diffs, 0.0):
+        return 1.0
+    observed = abs(float(np.mean(diffs)))
+    rng = np.random.default_rng(seed)
+    signs = rng.choice([-1.0, 1.0], size=(PERMUTATIONS, n))
+    perm_means = np.abs((signs * diffs).mean(axis=1))
+    return float((np.sum(perm_means >= observed) + 1) / (PERMUTATIONS + 1))
+
+
+def _metrics(scores: np.ndarray, expected: np.ndarray) -> Dict[str, float]:
+    return {
+        "mae": float(np.mean(np.abs(scores - expected))),
+        "spearman": _spearman(scores, expected),
+        "kendall": _kendall_tau(scores, expected),
+        "brier": float(np.mean((scores - expected) ** 2)),
+    }
+
+
+class CriteriaABTestReport:
+    """Comparison of two judge configurations over the same golden set.
+
+    Args:
+        name_a: Name of variant A.
+        scores_a: Variant A scores, aligned with ``scores_b``.
+        name_b: Name of variant B.
+        scores_b: Variant B scores.
+        expected: Optional ground-truth scores aligned with the variants.
+        queries: Optional per-example labels (e.g. query strings) used when
+            listing the largest disagreements.
+    """
+
+    def __init__(
+        self,
+        name_a: str,
+        scores_a: List[float],
+        name_b: str,
+        scores_b: List[float],
+        expected: Optional[List[float]] = None,
+        queries: Optional[List[str]] = None,
+    ):
+        self.name_a = name_a
+        self.name_b = name_b
+        self.scores_a = np.asarray(scores_a, dtype=float)
+        self.scores_b = np.asarray(scores_b, dtype=float)
+        self.expected = (
+            None if expected is None else np.asarray(expected, dtype=float)
+        )
+        self.queries = queries
+        self.diffs = self.scores_a - self.scores_b
+
+    def metrics(self) -> Dict[str, Dict[str, float]]:
+        """Per-variant agreement with ground truth. Empty if no expected."""
+        if self.expected is None:
+            return {}
+        return {
+            self.name_a: _metrics(self.scores_a, self.expected),
+            self.name_b: _metrics(self.scores_b, self.expected),
+        }
+
+    def significance(self) -> Dict[str, float]:
+        """Mean score difference (A - B) and its permutation p-value."""
+        return {
+            "mean_difference": float(np.mean(self.diffs)),
+            "p_value": _permutation_pvalue(self.diffs),
+        }
+
+    def top_disagreements(self, k: int = 5) -> List[Dict[str, Any]]:
+        """The ``k`` examples where the two variants differ most."""
+        order = np.argsort(-np.abs(self.diffs))[:k]
+        out: List[Dict[str, Any]] = []
+        for i in order:
+            item: Dict[str, Any] = {
+                "index": int(i),
+                self.name_a: float(self.scores_a[i]),
+                self.name_b: float(self.scores_b[i]),
+                "difference": float(self.diffs[i]),
+            }
+            if self.queries is not None and i < len(self.queries):
+                item["query"] = self.queries[i]
+            out.append(item)
+        return out
+
+    def winner(self) -> Optional[str]:
+        """The variant with lower MAE vs ground truth, or None."""
+        metrics = self.metrics()
+        if not metrics:
+            return None
+        mae_a = metrics[self.name_a]["mae"]
+        mae_b = metrics[self.name_b]["mae"]
+        if mae_a < mae_b:
+            return self.name_a
+        if mae_b < mae_a:
+            return self.name_b
+        return None
+
+    def print_comparison(self) -> None:
+        """Print the side-by-side metrics, disagreements and the winner."""
+        lines = [
+            "Criteria A/B Test",
+            "=" * 40,
+            f"A = {self.name_a}    B = {self.name_b}    n = {len(self.diffs)}",
+        ]
+        metrics = self.metrics()
+        if metrics:
+            lines.append("")
+            lines.append(
+                f"  {'metric':<10}{self.name_a[:12]:>14}{self.name_b[:12]:>14}"
+            )
+            for key in ("mae", "spearman", "kendall", "brier"):
+                a = metrics[self.name_a][key]
+                b = metrics[self.name_b][key]
+                lines.append(f"  {key:<10}{a:>14.3f}{b:>14.3f}")
+        sig = self.significance()
+        lines.append("")
+        lines.append(
+            f"Mean difference (A - B): {sig['mean_difference']:+.3f}  "
+            f"(permutation p = {sig['p_value']:.3f})"
+        )
+        disagreements = self.top_disagreements()
+        if disagreements:
+            lines.append("")
+            lines.append("Largest disagreements:")
+            for d in disagreements:
+                label = str(d.get("query") or f"example {d['index']}")
+                label = (label[:48] + "...") if len(label) > 48 else label
+                lines.append(
+                    f"  {d['difference']:+.2f}  A={d[self.name_a]:.2f} "
+                    f"B={d[self.name_b]:.2f}  {label}"
+                )
+        lines.append("")
+        winner = self.winner()
+        if not metrics:
+            lines.append(
+                "No ground truth: cannot pick a winner (showing drift only)."
+            )
+        elif winner is None:
+            lines.append(
+                "Tie: both variants have the same MAE vs ground truth."
+            )
+        else:
+            note = (
+                "significant"
+                if sig["p_value"] < SIGNIFICANCE_ALPHA
+                else "not significant"
+            )
+            lines.append(
+                f"Winner: {winner} (lower MAE vs ground truth; difference "
+                f"{note} at alpha={SIGNIFICANCE_ALPHA})."
+            )
+        print("\n".join(lines))
+
+
+class CriteriaABTest:
+    """Run two configurations of a feedback function and compare them.
+
+    Args:
+        golden_set: A list of dicts, each with ``query``, ``expected_response``
+            and, optionally, ``expected_score``.
+        variant_a: A dict with a ``fn`` (the feedback function), a ``name`` and
+            optional ``kwargs`` passed to ``fn`` on every call.
+        variant_b: A second variant in the same shape as ``variant_a``.
+        args_fn: Optional function mapping a golden row to the positional
+            arguments passed to each ``fn``. Defaults to
+            ``(row["query"], row["expected_response"])``.
+    """
+
+    def __init__(
+        self,
+        golden_set: List[Dict[str, Any]],
+        variant_a: Dict[str, Any],
+        variant_b: Dict[str, Any],
+        args_fn: Optional[Callable[[Dict[str, Any]], Tuple]] = None,
+    ):
+        for variant in (variant_a, variant_b):
+            if "fn" not in variant or "name" not in variant:
+                raise ValueError("each variant needs a 'fn' and a 'name'.")
+        self.golden_set = golden_set
+        self.variant_a = variant_a
+        self.variant_b = variant_b
+        self.args_fn = args_fn or self._default_args
+
+    @staticmethod
+    def _default_args(row: Dict[str, Any]) -> Tuple:
+        return (row["query"], row["expected_response"])
+
+    def run(self) -> CriteriaABTestReport:
+        """Score the golden set with both variants and build the report.
+
+        Rows on which either variant errors are skipped so both stay aligned.
+
+        Returns:
+            A populated
+            [CriteriaABTestReport][trulens.benchmark.criteria_ab_test.CriteriaABTestReport].
+
+        Raises:
+            ValueError: If no row was scored by both variants.
+        """
+        scores_a: List[float] = []
+        scores_b: List[float] = []
+        expected: List[Optional[float]] = []
+        queries: List[str] = []
+        for row in self.golden_set:
+            args = self.args_fn(row)
+            try:
+                a = _to_score(
+                    self.variant_a["fn"](
+                        *args, **self.variant_a.get("kwargs", {})
+                    )
+                )
+                b = _to_score(
+                    self.variant_b["fn"](
+                        *args, **self.variant_b.get("kwargs", {})
+                    )
+                )
+            except Exception:
+                log.exception("a variant failed on a row; skipping the row")
+                continue
+            scores_a.append(a)
+            scores_b.append(b)
+            expected.append(row.get("expected_score"))
+            queries.append(str(row.get("query", "")))
+        if not scores_a:
+            raise ValueError(
+                "No row was scored by both variants; check the variants and "
+                "golden_set."
+            )
+        has_expected = all(e is not None for e in expected)
+        return CriteriaABTestReport(
+            self.variant_a["name"],
+            scores_a,
+            self.variant_b["name"],
+            scores_b,
+            expected if has_expected else None,
+            queries,
+        )

--- a/src/feedback/trulens/feedback/groundtruth.py
+++ b/src/feedback/trulens/feedback/groundtruth.py
@@ -41,6 +41,42 @@ with import_utils.OptionalImports(
 logger = logging.getLogger(__name__)
 
 
+def paired_permutation_pvalue(
+    diffs: Union[List[float], np.ndarray],
+    seed: int = 0,
+    permutations: int = 10000,
+) -> float:
+    """Two-sided paired sign-flip permutation p-value for ``mean(diffs) == 0``.
+
+    Tests whether the mean of paired score differences differs significantly
+    from zero without assuming normality, by comparing the observed absolute
+    mean against the distribution obtained from random sign flips. Useful for
+    meta-evaluation, e.g. whether one judge configuration aligns with ground
+    truth better than another.
+
+    Args:
+        diffs: Paired differences, e.g. per-example score deltas between two
+            judge configurations.
+
+        seed: Seed for the permutation random number generator.
+
+        permutations: Number of sign-flip permutations to sample.
+
+    Returns:
+        float: The two-sided p-value in ``(0, 1]``. Returns ``1.0`` when there
+            are no differences or all differences are zero.
+    """
+    diffs = np.asarray(diffs, dtype=float)
+    n = len(diffs)
+    if n == 0 or np.allclose(diffs, 0.0):
+        return 1.0
+    observed = abs(float(np.mean(diffs)))
+    rng = np.random.default_rng(seed)
+    signs = rng.choice([-1.0, 1.0], size=(permutations, n))
+    perm_means = np.abs((signs * diffs).mean(axis=1))
+    return float((np.sum(perm_means >= observed) + 1) / (permutations + 1))
+
+
 # TODEP
 class GroundTruthAgreement(
     pyschema_utils.WithClassInfo, serial_utils.SerialModel

--- a/tests/unit/test_criteria_ab_test.py
+++ b/tests/unit/test_criteria_ab_test.py
@@ -1,0 +1,103 @@
+"""Unit tests for criteria A/B testing. No model or API key needed."""
+
+import pytest
+
+criteria_ab_test = pytest.importorskip("trulens.benchmark.criteria_ab_test")
+CriteriaABTest = criteria_ab_test.CriteriaABTest
+CriteriaABTestReport = criteria_ab_test.CriteriaABTestReport
+
+
+def test_metrics_perfect_vs_flat():
+    report = CriteriaABTestReport(
+        "perfect",
+        [0.2, 0.5, 0.8],
+        "flat",
+        [0.5, 0.5, 0.5],
+        expected=[0.2, 0.5, 0.8],
+    )
+    metrics = report.metrics()
+    assert metrics["perfect"]["mae"] == pytest.approx(0.0)
+    assert metrics["perfect"]["spearman"] == pytest.approx(1.0)
+    assert metrics["flat"]["mae"] > 0.0
+
+
+def test_winner_is_lower_mae():
+    report = CriteriaABTestReport(
+        "good",
+        [0.2, 0.5, 0.8],
+        "bad",
+        [0.9, 0.1, 0.4],
+        expected=[0.2, 0.5, 0.8],
+    )
+    assert report.winner() == "good"
+
+
+def test_significance_identical_is_not_significant():
+    scores = [0.2, 0.5, 0.8, 0.4]
+    report = CriteriaABTestReport("a", scores, "b", scores)
+    sig = report.significance()
+    assert sig["mean_difference"] == pytest.approx(0.0)
+    assert sig["p_value"] == pytest.approx(1.0)
+
+
+def test_significance_consistent_shift_is_significant():
+    a = [0.6, 0.7, 0.8, 0.9, 0.5, 0.65, 0.75, 0.85]
+    b = [0.3, 0.4, 0.5, 0.6, 0.2, 0.35, 0.45, 0.55]  # B is consistently -0.3
+    report = CriteriaABTestReport("a", a, "b", b)
+    sig = report.significance()
+    assert sig["mean_difference"] == pytest.approx(0.3, abs=1e-6)
+    assert sig["p_value"] < 0.05
+
+
+def test_top_disagreements_orders_by_abs_difference():
+    report = CriteriaABTestReport(
+        "a",
+        [0.1, 0.9, 0.5],
+        "b",
+        [0.1, 0.2, 0.45],
+        queries=["q0", "q1", "q2"],
+    )
+    top = report.top_disagreements(k=1)
+    assert top[0]["index"] == 1
+    assert top[0]["query"] == "q1"
+
+
+def test_run_with_fake_variants_and_kwargs():
+    golden = [
+        {"query": "q1", "expected_response": "r1", "expected_score": 0.2},
+        {"query": "q2", "expected_response": "r2", "expected_score": 0.8},
+    ]
+    a_scores = iter([0.25, 0.75])
+    b_scores = iter([0.5, 0.5])
+
+    def fn_a(query, response):
+        return next(a_scores)
+
+    def fn_b(query, response, criteria=None):
+        assert criteria == "strict"  # kwargs are forwarded
+        return next(b_scores)
+
+    report = CriteriaABTest(
+        golden,
+        {"fn": fn_a, "name": "default"},
+        {"fn": fn_b, "kwargs": {"criteria": "strict"}, "name": "strict"},
+    ).run()
+    assert report.scores_a.tolist() == [0.25, 0.75]
+    assert report.scores_b.tolist() == [0.5, 0.5]
+    assert report.expected is not None
+
+
+def test_variant_requires_fn_and_name():
+    with pytest.raises(ValueError):
+        CriteriaABTest([], {"name": "a"}, {"fn": lambda *a: 0.5, "name": "b"})
+
+
+def test_run_raises_when_all_rows_fail():
+    def boom(query, response):
+        raise RuntimeError("judge down")
+
+    golden = [{"query": "q", "expected_response": "r"}]
+    with pytest.raises(ValueError):
+        CriteriaABTest(
+            golden, {"fn": boom, "name": "a"}, {"fn": boom, "name": "b"}
+        ).run()


### PR DESCRIPTION
## Summary

Closes #2504.

TruLens feedback functions accept `criteria` and `additional_instructions` to tune judge behaviour, but there is no easy way to tell whether a new criteria string actually agrees with human judgement better than the old one. `CriteriaABTest` runs two configurations of a feedback function over the same golden set and reports which one aligns better.

## Implementation

`src/benchmark/trulens/benchmark/criteria_ab_test.py`:

- `CriteriaABTest(golden_set, variant_a, variant_b, ...)` runs each variant (a `{"fn", "name", "kwargs"}` dict, where `kwargs` is forwarded to `fn`, e.g. `criteria=...`) over each golden row, skipping any row where either variant errors so they stay aligned, and returns a `CriteriaABTestReport`.
- `CriteriaABTestReport` computes:
  - **side-by-side metrics** vs the ground truth: MAE, Spearman, Kendall's tau, Brier
  - **top disagreements** — the examples where the two variants differ most
  - **significance** — mean score difference and a paired **sign-flip permutation** p-value
  - **winner** — the variant with lower MAE vs ground truth
  - `print_comparison()`

Metrics and the significance test are computed with numpy (no scipy dependency) to keep the benchmark utility dependency-light.

## Testing

- `tests/unit/test_criteria_ab_test.py`: 8 unit tests covering the metrics, winner, the permutation significance test (identical → p=1.0, consistent shift → significant), top disagreements, the run loop with kwargs forwarding, and the guards. No model or API key required; guarded with `pytest.importorskip` since `trulens-benchmark` is optional.
- `ruff format` + `ruff check` clean against the repo config.
- Verified end-to-end: ran default vs strict-`criteria` `relevance` over `answer_relevance_golden_set` against a live OpenAI-compatible model; the report produced the side-by-side metrics and correctly reported the difference as not statistically significant (only one example diverged).

## Docs

Adds a usage guide at `docs/component_guides/evaluation/criteria_ab_test.md` (registered in the nav). The API reference picks the module up automatically from its docstrings.
