### PR TITLE
fix(bedrock): serialize Amazon Nova with the Messages API schema

### DIFF
--- a/src/providers/bedrock/trulens/providers/bedrock/provider.py
+++ b/src/providers/bedrock/trulens/providers/bedrock/provider.py
@@ -74,7 +74,31 @@ class Bedrock(llm_provider.LLMProvider):
         else:
             raise ValueError("Either 'messages' or 'prompt' must be supplied.")
 
-        if self.model_id.startswith("amazon"):
+        # Cross-region inference profile ids are the provider id prefixed with a
+        # region (e.g. "us.amazon.nova-lite-v1:0"). Strip the prefix so the
+        # family routing below matches the same way it does for on-demand ids.
+        base_model_id = self.model_id
+        for region_prefix in ("us.", "eu.", "apac.", "us-gov."):
+            if base_model_id.startswith(region_prefix):
+                base_model_id = base_model_id[len(region_prefix) :]
+                break
+
+        if "nova" in base_model_id:
+            # Amazon Nova uses the Messages API schema, not the legacy Titan
+            # text-generation schema used by other amazon.* models.
+            # https://docs.aws.amazon.com/nova/latest/userguide/using-invoke-api.html
+            body = json.dumps({
+                "schemaVersion": "messages-v1",
+                "messages": [
+                    {"role": "user", "content": [{"text": messages_str}]}
+                ],
+                "inferenceConfig": {
+                    "maxTokens": 4095,
+                    "temperature": 0,
+                    "topP": 1,
+                },
+            })
+        elif base_model_id.startswith("amazon"):
             body = json.dumps({
                 "inputText": messages_str,
                 "textGenerationConfig": {
@@ -84,7 +108,7 @@ class Bedrock(llm_provider.LLMProvider):
                     "topP": 1,
                 },
             })
-        elif self.model_id.startswith("anthropic"):
+        elif base_model_id.startswith("anthropic"):
             if not messages:
                 raise ValueError(
                     "`messages` argument must be supplied for Anthropic Bedrock models."
@@ -101,14 +125,14 @@ class Bedrock(llm_provider.LLMProvider):
                 "max_tokens": 4095,
                 "anthropic_version": "bedrock-2023-05-31",
             })
-        elif self.model_id.startswith("cohere"):
+        elif base_model_id.startswith("cohere"):
             body = json.dumps({
                 "prompt": messages_str,
                 "temperature": 0,
                 "p": 1,
                 "max_tokens": 4095,
             })
-        elif self.model_id.startswith("ai21"):
+        elif base_model_id.startswith("ai21"):
             body = json.dumps({
                 "prompt": messages_str,
                 "temperature": 0,
@@ -116,7 +140,7 @@ class Bedrock(llm_provider.LLMProvider):
                 "maxTokens": 8191,
             })
 
-        elif self.model_id.startswith("mistral"):
+        elif base_model_id.startswith("mistral"):
             body = json.dumps({
                 "prompt": messages_str,
                 "temperature": 0,
@@ -124,7 +148,7 @@ class Bedrock(llm_provider.LLMProvider):
                 "max_tokens": 4095,
             })
 
-        elif self.model_id.startswith("meta"):
+        elif base_model_id.startswith("meta"):
             body = json.dumps({
                 "prompt": messages_str,
                 "temperature": 0,
@@ -147,30 +171,37 @@ class Bedrock(llm_provider.LLMProvider):
             body=body, modelId=modelId, accept=accept, contentType=content_type
         )
 
-        if self.model_id.startswith("amazon"):
+        if "nova" in base_model_id:
+            # Nova returns the Messages API response shape.
+            # https://docs.aws.amazon.com/nova/latest/userguide/using-invoke-api.html
+            response_body = json.loads(response.get("body").read())["output"][
+                "message"
+            ]["content"][0]["text"]
+
+        elif base_model_id.startswith("amazon"):
             response_body = json.loads(response.get("body").read()).get(
                 "results"
             )[0]["outputText"]
 
-        elif self.model_id.startswith("anthropic"):
+        elif base_model_id.startswith("anthropic"):
             response_body = json.loads(response.get("body").read()).get(
                 "content"
             )[0]["text"]
 
-        elif self.model_id.startswith("cohere"):
+        elif base_model_id.startswith("cohere"):
             response_body = json.loads(response.get("body").read()).get(
                 "generations"
             )[0]["text"]
 
-        elif self.model_id.startswith("mistral"):
+        elif base_model_id.startswith("mistral"):
             response_body = json.loads(response.get("body").read()).get(
                 "output"
             )[0]["text"]
-        elif self.model_id.startswith("meta"):
+        elif base_model_id.startswith("meta"):
             response_body = json.loads(response.get("body").read()).get(
                 "generation"
             )
-        elif self.model_id.startswith("ai21"):
+        elif base_model_id.startswith("ai21"):
             response_body = (
                 json.loads(response.get("body").read())
                 .get("completions")[0]

--- a/tests/unit/providers/test_bedrock_nova_serialization.py
+++ b/tests/unit/providers/test_bedrock_nova_serialization.py
@@ -1,0 +1,152 @@
+# pyright: reportMissingImports=false, reportMissingModuleSource=false
+"""Regression tests for Bedrock Amazon Nova request/response serialization.
+
+The default Bedrock model is ``amazon.nova-lite-v1:0`` (set in #2511). Nova uses
+the Messages API schema for ``InvokeModel`` (``schemaVersion: messages-v1``,
+``messages``/``inferenceConfig``) and returns text at
+``output.message.content[0].text`` -- not the legacy Titan
+``inputText``/``results[0].outputText`` schema used by other ``amazon.*`` models.
+
+References:
+- https://docs.aws.amazon.com/nova/latest/userguide/using-invoke-api.html
+- https://docs.aws.amazon.com/nova/latest/userguide/complete-request-schema.html
+
+These tests mock the boto3 ``invoke_model`` seam, so no AWS account or
+credentials are required.
+"""
+
+import json
+from typing import Any, Dict, List
+
+import pytest
+
+
+class _DummyBody:
+    """Mimics botocore's StreamingBody: a single ``.read()`` of JSON bytes."""
+
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+class _DummyBedrockClient:
+    """Stands in for the boto3 ``bedrock-runtime`` client.
+
+    Records each ``invoke_model`` call and returns a canned response body, so no
+    AWS call or credentials are needed.
+    """
+
+    def __init__(self, response_payload: Dict[str, Any]):
+        self._payload = json.dumps(response_payload).encode()
+        self.calls: List[Dict[str, Any]] = []
+
+    def invoke_model(self, *, body, modelId, accept, contentType):  # noqa: N803
+        self.calls.append({
+            "body": body,
+            "modelId": modelId,
+            "accept": accept,
+            "contentType": contentType,
+        })
+        return {"body": _DummyBody(self._payload)}
+
+
+# A canonical Nova ``InvokeModel`` response (Messages API shape).
+_NOVA_RESPONSE = {
+    "output": {
+        "message": {
+            "role": "assistant",
+            "content": [{"text": "nova-ok"}],
+        }
+    },
+    "stopReason": "end_turn",
+    "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2},
+}
+
+
+def _make_provider(model_id: str, response_payload: Dict[str, Any]):
+    from trulens.providers.bedrock import (
+        Bedrock,  # type: ignore[import-not-found]
+    )
+
+    provider = Bedrock(model_id=model_id)
+    # Replace the boto3-backed client with our dummy (no AWS, no credentials).
+    provider.endpoint.client = _DummyBedrockClient(response_payload)
+    return provider
+
+
+@pytest.mark.optional
+def test_default_model_is_nova():
+    """The default Bedrock model is Nova Lite (#2511)."""
+    from trulens.providers.bedrock import (
+        Bedrock,  # type: ignore[import-not-found]
+    )
+
+    assert Bedrock.DEFAULT_MODEL_ID == "amazon.nova-lite-v1:0"
+
+
+@pytest.mark.optional
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "amazon.nova-lite-v1:0",  # default
+        "amazon.nova-pro-v1:0",
+        "us.amazon.nova-lite-v1:0",  # cross-region inference profile id
+    ],
+)
+def test_nova_request_uses_messages_api_schema(model_id):
+    """Nova serializes to the Messages API schema, not the Titan schema."""
+    provider = _make_provider(model_id, _NOVA_RESPONSE)
+
+    out = provider._create_chat_completion(
+        messages=[{"role": "user", "content": "hi"}]
+    )
+
+    assert out == "nova-ok"
+
+    calls = provider.endpoint.client.calls
+    assert len(calls) == 1
+    assert calls[0]["modelId"] == model_id
+
+    body = json.loads(calls[0]["body"])
+    # Messages API schema (Nova) -- must NOT be the Titan text schema.
+    assert body["schemaVersion"] == "messages-v1"
+    assert "messages" in body
+    assert body["messages"][0]["role"] == "user"
+    assert body["messages"][0]["content"][0]["text"]  # non-empty prompt text
+    assert "inferenceConfig" in body
+    assert body["inferenceConfig"]["maxTokens"] == 4095
+    # The legacy Titan keys must be absent for Nova.
+    assert "inputText" not in body
+    assert "textGenerationConfig" not in body
+
+
+@pytest.mark.optional
+def test_nova_response_parses_messages_api_shape():
+    """Nova response text is read from output.message.content[0].text."""
+    provider = _make_provider("amazon.nova-lite-v1:0", _NOVA_RESPONSE)
+
+    out = provider._create_chat_completion(prompt="hello")
+
+    assert out == "nova-ok"
+
+
+@pytest.mark.optional
+def test_titan_still_uses_legacy_schema():
+    """Non-Nova amazon.* models keep the Titan text-generation schema."""
+    provider = _make_provider(
+        "amazon.titan-text-express-v1",
+        {"results": [{"outputText": "titan-ok"}]},
+    )
+
+    out = provider._create_chat_completion(
+        messages=[{"role": "user", "content": "hi"}]
+    )
+
+    assert out == "titan-ok"
+
+    body = json.loads(provider.endpoint.client.calls[0]["body"])
+    assert "inputText" in body
+    assert "textGenerationConfig" in body
+    assert "schemaVersion" not in body


### PR DESCRIPTION
Thanks for TruLens and for modernizing the default provider models in #2511 — this PR just fills in the serialization that the new Nova default needs.

### Problem (reproduce)

`Bedrock()` now defaults to `amazon.nova-lite-v1:0` (set in #2511), but `_create_chat_completion` still serializes all `amazon.*` ids with the legacy Titan schema (`inputText`/`textGenerationConfig`) and parses responses from `results[0].outputText`. Amazon Nova's `InvokeModel` uses the Messages API schema and returns text at `output.message.content[0].text`, so the **default provider path is rejected by Bedrock out-of-box**.

```python
from trulens.providers.bedrock import Bedrock
Bedrock()._create_chat_completion(messages=[{"role": "user", "content": "hi"}])
# TypeError: 'NoneType' object is not subscriptable  (.get("results") is None)
```

### Cause

This is a regression from #2511: the default model id changed (`amazon.titan-text-express-v1` → `amazon.nova-lite-v1:0`) but the `startswith("amazon")` Titan branch did not.

### Change (minimal)

Following the existing per-family `startswith` convention, route any id containing `nova` to the Messages API request/response shape **before** the generic `amazon` branch. The Titan branch (`amazon.titan-*`) is unchanged. Also strip cross-region inference-profile prefixes (`us.`/`eu.`/`apac.`/`us-gov.`) before family routing, so profile ids like `us.amazon.nova-lite-v1:0` route correctly instead of hitting `NotImplementedError`.

### Before / After

| Item | Before | After |
|------|--------|-------|
| `Bedrock()` (default `amazon.nova-lite-v1:0`) request body | ❌ Titan `{"inputText", "textGenerationConfig"}` | ✅ Messages API `{"schemaVersion":"messages-v1","messages":[...],"inferenceConfig":{...}}` |
| Nova response parsing | ❌ `results[0].outputText` → `TypeError` | ✅ `output.message.content[0].text` |
| CRIS id `us.amazon.nova-lite-v1:0` | ❌ falls to `else` → `NotImplementedError` | ✅ prefix stripped, routes to Nova branch |
| Titan (`amazon.titan-text-express-v1`) request/response | ✅ Titan schema | ✅ Titan schema (unchanged) |
| anthropic / cohere / ai21 / mistral / meta branches | ✅ | ✅ unchanged (now also CRIS-prefix tolerant) |
| Public API / `Bedrock` signature / `DEFAULT_MODEL_ID` | — | ✅ unchanged |

### AWS schema sources

- Request `schemaVersion: messages-v1`, `messages`, `inferenceConfig`: https://docs.aws.amazon.com/nova/latest/userguide/using-invoke-api.html , https://docs.aws.amazon.com/nova/latest/userguide/complete-request-schema.html
- Response `output.message.content[0].text`: aws-samples/amazon-bedrock-samples Nova `invoke_model` notebook (`response_body['output']['message']['content'][0]['text']`).

### Tests

New credential-free regression test mocks the boto3 `invoke_model` seam: `tests/unit/providers/test_bedrock_nova_serialization.py`.

After fix (fix applied):
```
$ TEST_OPTIONAL=1 pytest tests/unit/providers/test_bedrock_nova_serialization.py -q
......                                                                   [100%]
6 passed in 1.42s
```

Before fix (source reverted, tests kept) — the new tests catch the bug:
```
$ git stash push -- src/providers/bedrock/trulens/providers/bedrock/provider.py
$ TEST_OPTIONAL=1 pytest tests/unit/providers/test_bedrock_nova_serialization.py -q
...
>           response_body = json.loads(response.get("body").read()).get("results")[0]["outputText"]
E           TypeError: 'NoneType' object is not subscriptable
...
FAILED ... test_nova_request_uses_messages_api_schema[amazon.nova-lite-v1:0]
FAILED ... test_nova_request_uses_messages_api_schema[amazon.nova-pro-v1:0]
FAILED ... test_nova_request_uses_messages_api_schema[us.amazon.nova-lite-v1:0]
FAILED ... test_nova_response_parses_messages_api_shape
4 failed, 2 passed in 1.51s
```

Lint/format (ruff v0.5.5, matching the pre-commit pin):
```
$ ruff check src/providers/bedrock/.../provider.py tests/unit/providers/test_bedrock_nova_serialization.py
All checks passed!
$ ruff format --check <same files>
2 files already formatted
```

### Related

Fixes #2565 (Bedrock Nova serialization regression).

Note on #2536 (open, "Add Bedrock provider capability tests"): its parametrized cases currently assert the **pre-fix** behavior for the `amazon.nova-*` id (Titan `inputText` body, `outputText` response). If both land, that PR's `amazon.nova-*` expectations should move to the Messages API shape — happy to coordinate so the suites agree. I deliberately used a separate file name (`test_bedrock_nova_serialization.py`) to avoid colliding with `test_bedrock_capabilities.py`.

---
*This contribution was prepared with the help of an AI agent (Claude Code); a human reviewed the change, the AWS schema sources, and the test results before submitting.*
