### PR TITLE
test(feedback): add integration tests for method-to-template wiring

### DIFF
--- a/tests/integration/test_method_template_wiring.py
+++ b/tests/integration/test_method_template_wiring.py
@@ -5,6 +5,8 @@ import unittest
 from unittest import TestCase
 
 from trulens.feedback import llm_provider
+from trulens.feedback.templates import quality as templates_quality
+from trulens.feedback.templates import rag as templates_rag
 
 
 class MockLLMProvider(llm_provider.LLMProvider):
@@ -162,6 +164,40 @@ class TestMethodTemplateWiring(TestCase):
         self.provider.conciseness(text="x")
         con_prompt = self.provider.last_system_prompt
         self.assertNotEqual(coh_prompt, con_prompt)
+
+    # ------------------------------------------------------------------
+    # Additional assertions that pin the *exact* template content (rather
+    # than a distinguishing substring), catching copy-paste bugs where a
+    # method wires up the wrong template class outright.
+    # ------------------------------------------------------------------
+
+    def test_relevance_matches_PromptResponseRelevance_system_prompt(self):
+        self.provider.relevance(
+            prompt="What is TruLens?",
+            response="TruLens is an evaluation framework.",
+        )
+        sys = self.provider.last_system_prompt
+        self.assertIn(
+            templates_rag.PromptResponseRelevance.system_prompt, sys
+        )
+        self.assertNotIn(templates_rag.ContextRelevance.system_prompt, sys)
+
+    def test_context_relevance_matches_ContextRelevance_system_prompt(self):
+        self.provider.context_relevance(
+            question="What is TruLens?",
+            context="TruLens evaluates LLM applications.",
+        )
+        sys = self.provider.last_system_prompt
+        self.assertIn(templates_rag.ContextRelevance.system_prompt, sys)
+        self.assertNotIn(
+            templates_rag.PromptResponseRelevance.system_prompt, sys
+        )
+
+    def test_sentiment_matches_Sentiment_system_prompt(self):
+        self.provider.sentiment(text="This is excellent!")
+        sys = self.provider.last_system_prompt
+        self.assertIn(templates_quality.Sentiment.system_prompt, sys)
+        self.assertNotIn(templates_rag.ContextRelevance.system_prompt, sys)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
closes #2495

## What changed
- Added `tests/integration/test_method_template_wiring.py`
- Uses a `MockLLMProvider` that captures the `system_prompt` passed to `generate_score` / `generate_score_and_reasons`
- Covers 4 methods with positive + negative assertions:
  - `relevance` → `PromptResponseRelevance` (not `ContextRelevance`)
  - `context_relevance` → `ContextRelevance` (not `PromptResponseRelevance`)
  - `sentiment` → `Sentiment` (not `ContextRelevance`)
  - `groundedness_measure_with_cot_reasons` → `Groundedness` (not `ContextRelevance`)
- Negative assertions ensure a copy-paste bug (wrong template class) would be caught

## Testing
```
python -m pytest tests/integration/test_method_template_wiring.py -v
# 4 passed
```