### PR TITLE
docs: add CI/CD GitHub Actions eval gate example (closes #2482)

### DIFF
--- a/examples/cicd/github_actions/README.md
+++ b/examples/cicd/github_actions/README.md
@@ -1,0 +1,54 @@
+# TruLens CI/CD Eval Gate (GitHub Actions)
+
+A minimal, copy-pasteable example showing how to run TruLens evaluations in CI
+and **fail the build when quality drops**.
+
+## What's here
+
+| File | Purpose |
+|------|---------|
+| `eval_gate.py` | Standalone script: runs a tiny instrumented RAG app over a fixed test set, evaluates it with the RAG triad, and exits non-zero if any score is below the threshold. |
+| `trulens-eval-gate.yml` | A GitHub Actions workflow template. Copy it to `.github/workflows/` in your repo. |
+
+> The workflow file lives here as a template rather than under this repo's own
+> `.github/workflows/` so it doesn't run as part of TruLens CI. Copy it into your
+> project to activate it.
+
+## Quickstart (local)
+
+```bash
+pip install trulens trulens-providers-openai
+export OPENAI_API_KEY=sk-...
+export TRULENS_MIN_SCORE=0.7   # optional, defaults to 0.7
+python eval_gate.py
+```
+
+The script exits with code `0` if all metrics meet the threshold and `1`
+otherwise, so it works directly as a CI gate.
+
+## Use in GitHub Actions
+
+1. Copy `trulens-eval-gate.yml` to `.github/workflows/trulens-eval-gate.yml` in
+   your repository.
+2. Add your OpenAI key as a repository secret named `OPENAI_API_KEY`
+   (*Settings → Secrets and variables → Actions*).
+3. Adjust `TRULENS_MIN_SCORE` in the workflow (or via env) to set your quality
+   bar.
+
+The job runs on every pull request and blocks merge if evaluation scores fall
+below the threshold.
+
+## Configuration
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `OPENAI_API_KEY` | — | Required. Key for the OpenAI LLM judge. |
+| `TRULENS_MIN_SCORE` | `0.7` | Minimum acceptable mean score per metric (0–1). |
+| `TRULENS_EVAL_MODEL` | `gpt-4o-mini` | Judge model used by the OpenAI provider. |
+
+## Adapting to your app
+
+Replace `TinyRAG` and `TEST_SET` in `eval_gate.py` with your own application and
+evaluation dataset. Keep the dataset small so the gate stays fast (a few seconds
+to under a minute) and cheap. The same pattern works for any framework — swap
+`TruApp` for `TruChain`, `TruLlama`, or `TruGraph` as appropriate.

--- a/examples/cicd/github_actions/eval_gate.py
+++ b/examples/cicd/github_actions/eval_gate.py
@@ -1,0 +1,169 @@
+"""TruLens CI/CD evaluation gate.
+
+Runs a tiny TruLens evaluation over a fixed test set and exits non-zero if any
+feedback score falls below a configurable threshold. Designed to be dropped into
+a CI pipeline (GitHub Actions, GitLab CI, etc.) as a quality gate.
+
+Usage:
+    OPENAI_API_KEY=sk-...  TRULENS_MIN_SCORE=0.7  python eval_gate.py
+
+Environment variables:
+    OPENAI_API_KEY     Required. Key for the OpenAI provider used as LLM judge.
+    TRULENS_MIN_SCORE  Optional. Minimum acceptable score (0-1). Defaults to 0.7.
+    TRULENS_EVAL_MODEL Optional. Judge model. Defaults to "gpt-4o-mini".
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from trulens.apps.app import TruApp
+from trulens.core import Metric, Selector, TruSession
+from trulens.core.otel.instrument import instrument
+from trulens.otel.semconv.trace import SpanAttributes
+
+# A tiny, self-contained "knowledge base" so the example runs in seconds with no
+# external services beyond the LLM judge.
+KNOWLEDGE_BASE = {
+    "trulens": (
+        "TruLens is an open-source library for evaluating and tracking the "
+        "quality of LLM applications using feedback functions."
+    ),
+    "rag": (
+        "Retrieval-augmented generation (RAG) augments an LLM with documents "
+        "retrieved from an external knowledge base before generating an answer."
+    ),
+    "feedback": (
+        "A feedback function programmatically scores an LLM app's inputs and "
+        "outputs, for example measuring relevance or groundedness."
+    ),
+}
+
+# Test set: question -> retrieval key. Keep this small (3-5) so the gate runs fast.
+TEST_SET = [
+    ("What is TruLens?", "trulens"),
+    ("How does RAG work?", "rag"),
+    ("What does a feedback function do?", "feedback"),
+]
+
+
+class TinyRAG:
+    """A minimal RAG app instrumented for TruLens evaluation."""
+
+    @instrument(
+        span_type=SpanAttributes.SpanType.RETRIEVAL,
+        attributes={
+            SpanAttributes.RETRIEVAL.QUERY_TEXT: "query",
+            SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS: "return",
+        },
+    )
+    def retrieve(self, query: str, key: str) -> list[str]:
+        return [KNOWLEDGE_BASE[key]]
+
+    @instrument(span_type=SpanAttributes.SpanType.GENERATION)
+    def generate(self, query: str, contexts: list[str]) -> str:
+        return contexts[0]
+
+    @instrument(
+        span_type=SpanAttributes.SpanType.RECORD_ROOT,
+        attributes={
+            SpanAttributes.RECORD_ROOT.INPUT: "query",
+            SpanAttributes.RECORD_ROOT.OUTPUT: "return",
+        },
+    )
+    def answer(self, query: str, key: str) -> str:
+        contexts = self.retrieve(query, key)
+        return self.generate(query, contexts)
+
+
+def build_feedbacks():
+    """Configure the RAG triad feedback functions using the OpenAI provider."""
+    from trulens.providers.openai import OpenAI
+
+    provider = OpenAI(model_engine=os.environ.get("TRULENS_EVAL_MODEL", "gpt-4o-mini"))
+
+    f_answer_relevance = Metric(
+        implementation=provider.relevance_with_cot_reasons,
+        name="Answer Relevance",
+        selectors={
+            "prompt": Selector.select_record_input(),
+            "response": Selector.select_record_output(),
+        },
+    )
+    f_context_relevance = Metric(
+        implementation=provider.context_relevance_with_cot_reasons,
+        name="Context Relevance",
+        selectors={
+            "question": Selector.select_record_input(),
+            "context": Selector.select_context(collect_list=False),
+        },
+    )
+    f_groundedness = Metric(
+        implementation=provider.groundedness_measure_with_cot_reasons,
+        name="Groundedness",
+        selectors={
+            "source": Selector.select_context(collect_list=True),
+            "statement": Selector.select_record_output(),
+        },
+    )
+    return [f_answer_relevance, f_context_relevance, f_groundedness]
+
+
+def main() -> int:
+    if not os.environ.get("OPENAI_API_KEY"):
+        print("ERROR: OPENAI_API_KEY is not set.", file=sys.stderr)
+        return 1
+
+    min_score = float(os.environ.get("TRULENS_MIN_SCORE", "0.7"))
+
+    session = TruSession()
+    session.reset_database()
+
+    app = TinyRAG()
+    tru_app = TruApp(
+        app,
+        app_name="CI Eval Gate",
+        app_version="v1",
+        feedbacks=build_feedbacks(),
+    )
+
+    with tru_app as recording:
+        for query, key in TEST_SET:
+            app.answer(query, key)
+
+    # Block until all feedback evaluations have completed.
+    recording.retrieve_feedback_results(timeout=300)
+
+    leaderboard = session.get_leaderboard()
+    print("\nLeaderboard:\n", leaderboard.to_string())
+
+    # Compare every feedback column against the threshold. Non-feedback columns
+    # (latency, cost) are ignored.
+    ignore = {"latency", "total_cost", "total_tokens", "Latency", "Cost (USD)"}
+    feedback_cols = [
+        c for c in leaderboard.columns
+        if c not in ignore and leaderboard[c].dtype.kind in "fi"
+    ]
+
+    failures = []
+    for col in feedback_cols:
+        score = float(leaderboard[col].mean())
+        status = "PASS" if score >= min_score else "FAIL"
+        print(f"  {status}  {col}: {score:.3f} (min {min_score})")
+        if score < min_score:
+            failures.append((col, score))
+
+    if failures:
+        print(
+            f"\nEval gate FAILED: {len(failures)} metric(s) below {min_score}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"\nEval gate PASSED: all metrics >= {min_score}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/cicd/github_actions/trulens-eval-gate.yml
+++ b/examples/cicd/github_actions/trulens-eval-gate.yml
@@ -1,0 +1,35 @@
+# TruLens evaluation gate for GitHub Actions.
+#
+# Copy this file into your repository at `.github/workflows/trulens-eval-gate.yml`.
+# It runs `eval_gate.py` on every pull request and fails the build if any
+# feedback score drops below TRULENS_MIN_SCORE.
+#
+# Add your OpenAI key as a repository secret named OPENAI_API_KEY:
+#   Settings -> Secrets and variables -> Actions -> New repository secret
+
+name: TruLens Eval Gate
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  eval-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install trulens trulens-providers-openai
+
+      - name: Run TruLens eval gate
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          TRULENS_MIN_SCORE: "0.7"
+        run: python examples/cicd/github_actions/eval_gate.py


### PR DESCRIPTION
## Description

Resubmission of #2542, which I closed on 2026-06-24 without an explanation — that was a mistake on my part, not a sign the contribution was invalid. @iliferov asked why on the old PR, so re-opening properly here rather than just answering "no good reason" and leaving it closed.

Closes #2482 (still open).

Adds a copy-pasteable CI/CD example showing how to run TruLens evaluations in CI and fail the build when quality drops.

## What's added

`examples/cicd/github_actions/`:
- **`eval_gate.py`** — a self-contained `TruApp` RAG over a tiny fixed test set (3 Q&A pairs), evaluated with the RAG triad (answer relevance, context relevance, groundedness) using the OpenAI provider. Waits for evaluations via `recording.retrieve_feedback_results()`, reads `session.get_leaderboard()`, checks each metric against `TRULENS_MIN_SCORE` (default 0.7), and exits non-zero on failure — CI-friendly.
- **`trulens-eval-gate.yml`** — a GitHub Actions workflow template.
- **`README.md`** — local quickstart, GitHub Actions setup, configuration, and how to adapt to other apps/frameworks.

## Design notes

- Follows the issue's design points: `TruApp` (no LangChain/LlamaIndex dependency), tiny dataset for <60s runs, threshold via `TRULENS_MIN_SCORE`, and `OPENAI_API_KEY` from secrets — never hardcoded.
- The workflow file ships **inside** the example directory rather than under this repo's `.github/workflows/`, so it doesn't trigger as part of TruLens' own CI. Users copy it into their project. Happy to relocate it if you'd prefer.
- Example-only; no library code touched.

## What I checked before resubmitting

The original fork branch was ~1750 commits behind `main` (never synced since I first opened it), so rather than force a stale rebase, I cherry-picked the 3 relevant commits onto a fresh branch off current `main`. Verified the example still targets valid, current APIs — `TruApp`, `Metric`, and `Selector` all still exist at their original import paths in the current codebase, so nothing has gone stale since June.