### PR TITLE
docs: add DaoXE OpenAI-compatible base_url example for feedback providers

### DIFF
--- a/docs/component_guides/evaluation/feedback_providers.md
+++ b/docs/component_guides/evaluation/feedback_providers.md
@@ -97,6 +97,56 @@ instance), there are three options:
         )
         ```
 
+### Using the OpenAI provider with a custom `base_url`
+
+The [OpenAI provider][trulens.providers.openai.OpenAI] forwards constructor
+kwargs to the official OpenAI Python client. That means you can point feedback
+functions at any OpenAI-compatible Chat Completions endpoint by setting
+`base_url` (and usually `api_key`).
+
+!!! example "OpenAI-compatible multi-model gateway (DaoXE)"
+
+    [DaoXE](https://daoxe.com) is a multi-model multi-protocol API gateway
+    (OpenAI Chat Completions / Responses and Anthropic Messages for other
+    clients). TruLens's OpenAI provider uses the Chat Completions path.
+
+    Get an API key from the DaoXE dashboard and pass an **exact model ID from
+    your account catalog** (`GET https://daoxe.com/v1/models`). Do not hardcode
+    a public price list. DaoXE is **not available in mainland China**.
+
+    ```python
+    import os
+
+    from trulens.providers.openai import OpenAI
+
+    provider = OpenAI(
+        model_engine=os.environ["DAOXE_MODEL"],  # exact ID from GET /v1/models
+        api_key=os.environ["DAOXE_API_KEY"],
+        base_url="https://daoxe.com/v1",
+    )
+
+    # Example feedback call
+    score, reasons = provider.relevance_with_cot_reasons(
+        "What is the capital of France?",
+        "Paris is the capital of France.",
+    )
+    ```
+
+    Equivalent LiteLLM route (useful when you already use
+    `trulens-providers-litellm`):
+
+    ```python
+    import os
+
+    from trulens.providers.litellm import LiteLLM
+
+    provider = LiteLLM(
+        model_engine=f"openai/{os.environ['DAOXE_MODEL']}",
+        api_base="https://daoxe.com/v1",
+        api_key=os.environ["DAOXE_API_KEY"],
+    )
+    ```
+
 ## Embedding-based Providers
 
 - [Embeddings][trulens.feedback.embeddings.Embeddings]


### PR DESCRIPTION
## Description

Adds a short example under **Feedback Providers** showing how to point TruLens's OpenAI feedback provider (and the equivalent LiteLLM route) at an OpenAI-compatible multi-model gateway using `base_url` / `api_base`.

Example gateway used in the snippet: [DaoXE](https://daoxe.com) (`https://daoxe.com/v1`).

Motivation: the OpenAI provider already forwards kwargs to the official OpenAI client, so custom endpoints work today—but the docs only documented custom endpoints under LiteLLM (e.g. Ollama). This makes the OpenAI-provider path explicit for OpenAI-compatible gateways.

### What the example covers

- `trulens.providers.openai.OpenAI(..., base_url="https://daoxe.com/v1", api_key=..., model_engine=...)`
- Equivalent `LiteLLM(model_engine="openai/...", api_base="https://daoxe.com/v1", api_key=...)`
- Model IDs taken from the caller's account catalog (`GET /v1/models`), not a hardcoded public list
- Multi-protocol note: DaoXE also exposes OpenAI Responses and Anthropic Messages for other clients; this TruLens path uses Chat Completions
- Regional note: not available in mainland China

## Other details good to know for developers

- Docs-only change to `docs/component_guides/evaluation/feedback_providers.md`
- No code, dependency, or golden-test changes
- Affiliation: PR author maintains DaoXE examples / community docs
- AI-assisted drafting used for this contribution

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [x] This change requires a documentation update