### PR TITLE
docs: add DaoXE OpenAI-compatible base_url example for feedback providers

### DIFF
--- a/docs/component_guides/evaluation/feedback_providers.md
+++ b/docs/component_guides/evaluation/feedback_providers.md
@@ -97,6 +97,56 @@ instance), there are three options:
         )
         ```
 
+### Using the OpenAI provider with a custom `base_url`
+
+The [OpenAI provider][trulens.providers.openai.OpenAI] forwards constructor
+kwargs to the official OpenAI Python client. That means you can point feedback
+functions at any OpenAI-compatible Chat Completions endpoint by setting
+`base_url` (and usually `api_key`).
+
+!!! example "OpenAI-compatible multi-model gateway (DaoXE)"
+
+    [DaoXE](https://daoxe.com) is a multi-model multi-protocol API gateway
+    (OpenAI Chat Completions / Responses and Anthropic Messages for other
+    clients). TruLens's OpenAI provider uses the Chat Completions path.
+
+    Get an API key from the DaoXE dashboard and pass an **exact model ID from
+    your account catalog** (`GET https://daoxe.com/v1/models`). Do not hardcode
+    a public price list. DaoXE is **not available in mainland China**.
+
+    ```python
+    import os
+
+    from trulens.providers.openai import OpenAI
+
+    provider = OpenAI(
+        model_engine=os.environ["DAOXE_MODEL"],  # exact ID from GET /v1/models
+        api_key=os.environ["DAOXE_API_KEY"],
+        base_url="https://daoxe.com/v1",
+    )
+
+    # Example feedback call
+    score, reasons = provider.relevance_with_cot_reasons(
+        "What is the capital of France?",
+        "Paris is the capital of France.",
+    )
+    ```
+
+    Equivalent LiteLLM route (useful when you already use
+    `trulens-providers-litellm`):
+
+    ```python
+    import os
+
+    from trulens.providers.litellm import LiteLLM
+
+    provider = LiteLLM(
+        model_engine=f"openai/{os.environ['DAOXE_MODEL']}",
+        api_base="https://daoxe.com/v1",
+        api_key=os.environ["DAOXE_API_KEY"],
+    )
+    ```
+
 ## Embedding-based Providers
 
 - [Embeddings][trulens.feedback.embeddings.Embeddings]

--- a/docs/component_guides/evaluation/feedback_providers.md
+++ b/docs/component_guides/evaluation/feedback_providers.md
@@ -104,25 +104,31 @@ kwargs to the official OpenAI Python client. That means you can point feedback
 functions at any OpenAI-compatible Chat Completions endpoint by setting
 `base_url` (and usually `api_key`).
 
-!!! example "OpenAI-compatible multi-model gateway (DaoXE)"
+Common options include self-hosted gateways (vLLM, Ollama with an OpenAI
+shim), cloud gateways (OpenRouter, Together, Fireworks, DaoXE, and others),
+or any reverse-proxy that speaks `/v1/chat/completions`.
 
-    [DaoXE](https://daoxe.com) is a multi-model multi-protocol API gateway
-    (OpenAI Chat Completions / Responses and Anthropic Messages for other
-    clients). TruLens's OpenAI provider uses the Chat Completions path.
+!!! example "OpenAI-compatible custom endpoint"
 
-    Get an API key from the DaoXE dashboard and pass an **exact model ID from
-    your account catalog** (`GET https://daoxe.com/v1/models`). Do not hardcode
-    a public price list. DaoXE is **not available in mainland China**.
+    Pass the gateway's Chat Completions base URL and a model ID that endpoint
+    accepts. Model IDs differ by provider — use a concrete ID from that
+    provider's catalog (examples below are illustrative).
 
     ```python
     import os
 
     from trulens.providers.openai import OpenAI
 
+    # Examples of base_url values (pick one):
+    #   "https://openrouter.ai/api/v1"
+    #   "https://api.together.xyz/v1"
+    #   "https://api.fireworks.ai/inference/v1"
+    #   "https://daoxe.com/v1"
+    #   "http://localhost:8000/v1"  # vLLM / local OpenAI shim
     provider = OpenAI(
-        model_engine=os.environ["DAOXE_MODEL"],  # exact ID from GET /v1/models
-        api_key=os.environ["DAOXE_API_KEY"],
-        base_url="https://daoxe.com/v1",
+        model_engine="gpt-4o-mini",  # or "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", etc.
+        api_key=os.environ["OPENAI_API_KEY"],  # gateway token / key
+        base_url=os.environ["OPENAI_BASE_URL"],
     )
 
     # Example feedback call
@@ -141,9 +147,9 @@ functions at any OpenAI-compatible Chat Completions endpoint by setting
     from trulens.providers.litellm import LiteLLM
 
     provider = LiteLLM(
-        model_engine=f"openai/{os.environ['DAOXE_MODEL']}",
-        api_base="https://daoxe.com/v1",
-        api_key=os.environ["DAOXE_API_KEY"],
+        model_engine="openai/gpt-4o-mini",
+        api_base=os.environ["OPENAI_BASE_URL"],
+        api_key=os.environ["OPENAI_API_KEY"],
     )
     ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -250,6 +250,7 @@ nav:
     - 🎯 Evaluation:
         - component_guides/evaluation/index.md
         - Anatomy of a Metric: component_guides/evaluation/feedback_anatomy.md
+        - Feedback Providers: component_guides/evaluation/feedback_providers.md
         - Migrating to Metric API: component_guides/evaluation/metric_migration.md
         - Metric Implementations:
             - component_guides/evaluation/feedback_implementations/index.md

--- a/src/providers/openai/trulens/providers/openai/provider.py
+++ b/src/providers/openai/trulens/providers/openai/provider.py
@@ -61,6 +61,22 @@ class OpenAI(llm_provider.LLMProvider):
         openai_provider = OpenAI()
         ```
 
+        OpenAI-compatible gateways (for example DaoXE) work by forwarding
+        client kwargs such as `base_url` and `api_key`:
+
+        ```python
+        import os
+        from trulens.providers.openai import OpenAI
+
+        # DaoXE multi-protocol gateway Chat Completions path:
+        # base_url=https://daoxe.com/v1 ; model IDs are account-scoped.
+        provider = OpenAI(
+            model_engine=os.environ["DAOXE_MODEL"],
+            api_key=os.environ["DAOXE_API_KEY"],
+            base_url="https://daoxe.com/v1",
+        )
+        ```
+
     Args:
         model_engine: The OpenAI completion model. Defaults to
             `gpt-4o-mini`
@@ -69,7 +85,8 @@ class OpenAI(llm_provider.LLMProvider):
             [OpenAIEndpoint][trulens.providers.openai.endpoint.OpenAIEndpoint]
             which are then passed to
             [OpenAIClient][trulens.providers.openai.endpoint.OpenAIClient]
-            and finally to the OpenAI client.
+            and finally to the OpenAI client (for example `api_key`,
+            `base_url` for OpenAI-compatible endpoints).
     """
 
     DEFAULT_MODEL_ENGINE: ClassVar[str] = "gpt-4o-mini"

--- a/src/providers/openai/trulens/providers/openai/provider.py
+++ b/src/providers/openai/trulens/providers/openai/provider.py
@@ -61,19 +61,18 @@ class OpenAI(llm_provider.LLMProvider):
         openai_provider = OpenAI()
         ```
 
-        OpenAI-compatible gateways (for example DaoXE) work by forwarding
-        client kwargs such as `base_url` and `api_key`:
+        OpenAI-compatible endpoints work by forwarding client kwargs such as
+        `base_url` and `api_key` (OpenRouter, Together, Fireworks, DaoXE,
+        vLLM, and similar):
 
         ```python
         import os
         from trulens.providers.openai import OpenAI
 
-        # DaoXE multi-protocol gateway Chat Completions path:
-        # base_url=https://daoxe.com/v1 ; model IDs are account-scoped.
         provider = OpenAI(
-            model_engine=os.environ["DAOXE_MODEL"],
-            api_key=os.environ["DAOXE_API_KEY"],
-            base_url="https://daoxe.com/v1",
+            model_engine="gpt-4o-mini",
+            api_key=os.environ["OPENAI_API_KEY"],
+            base_url=os.environ["OPENAI_BASE_URL"],  # e.g. https://openrouter.ai/api/v1
         )
         ```
 


### PR DESCRIPTION
## Summary
- Document how to point TruLens's existing OpenAI feedback provider at an OpenAI-compatible Chat Completions endpoint via `base_url` / `api_key`.
- Example uses [DaoXE](https://daoxe.com) at `https://daoxe.com/v1` with account-scoped model IDs from env (`DAOXE_MODEL` from `GET /v1/models`), no hardcoded public model/price catalog.
- Notes multi-protocol context (OpenAI Chat Completions / Responses and Anthropic Messages for other clients); TruLens OpenAI provider uses the Chat Completions path.
- Includes an equivalent LiteLLM (`api_base`) route for users of `trulens-providers-litellm`.
- Notes DaoXE is not available in mainland China.

Docs-only change under `docs/component_guides/evaluation/feedback_providers.md` (alongside the existing LiteLLM custom-endpoint section). No provider runtime code changes.

I maintain DaoXE. Examples: https://github.com/seven7763/DaoXE-AI

## Type of Change
- [x] Documentation

## Testing
- [x] `git diff --check`
- [x] Diff limited to docs markdown
- [ ] Unit tests (N/A — docs only)

## Checklist
- [x] Documentation updated
- [x] No secrets or credentials committed
- [x] Self-review completed
- [x] Model IDs left account-scoped (env / `GET /v1/models`)

## Related Issues
N/A — docs-only OpenAI-compatible gateway example.