### PR TITLE
fix(otel): make instrument_method idempotent (closes #2477)

### DIFF
--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -144,7 +144,9 @@ def _set_span_attributes(
                 func_exception,
             )
         # Set function call attributes.
-        set_function_call_attributes(span, ret, func_name, func_exception, all_kwargs)
+        set_function_call_attributes(
+            span, ret, func_name, func_exception, all_kwargs
+        )
     # Resolve the attributes.
     if instance is not None:
         args_with_self_possibly = (instance,) + args
@@ -167,7 +169,9 @@ def _set_span_attributes(
         set_genai_generation_attributes(
             span,
             model=resolved_attributes.get(SpanAttributes.COST.MODEL),
-            input_tokens=resolved_attributes.get(SpanAttributes.COST.NUM_PROMPT_TOKENS),
+            input_tokens=resolved_attributes.get(
+                SpanAttributes.COST.NUM_PROMPT_TOKENS
+            ),
             output_tokens=resolved_attributes.get(
                 SpanAttributes.COST.NUM_COMPLETION_TOKENS
             ),
@@ -178,7 +182,9 @@ def _set_span_attributes(
     elif span_type == SpanAttributes.SpanType.RETRIEVAL:
         set_genai_retrieval_attributes(
             span,
-            query_text=resolved_attributes.get(SpanAttributes.RETRIEVAL.QUERY_TEXT),
+            query_text=resolved_attributes.get(
+                SpanAttributes.RETRIEVAL.QUERY_TEXT
+            ),
             documents=resolved_attributes.get(
                 SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS
             ),
@@ -297,7 +303,9 @@ class instrument:
             if target is None:
                 return func_name
             module = getattr(target, "__module__", "")
-            qualname = getattr(target, "__qualname__", getattr(target, "__name__", ""))
+            qualname = getattr(
+                target, "__qualname__", getattr(target, "__name__", "")
+            )
             base = ".".join([p for p in [module, qualname] if p])
             if not base:
                 return func_name
@@ -635,9 +643,13 @@ class OtelRecordingContext(OtelBaseRecordingContext):
             SpanAttributes.RECORD_ROOT.GROUND_TRUTH_OUTPUT,
             self.ground_truth_output,
         )
-        self.attach_to_context("__trulens_input_selector__", self.input_selector)
+        self.attach_to_context(
+            "__trulens_input_selector__", self.input_selector
+        )
         if self.conversation_id is not None:
-            self.attach_to_context(SpanAttributes.CONVERSATION_ID, self.conversation_id)
+            self.attach_to_context(
+                SpanAttributes.CONVERSATION_ID, self.conversation_id
+            )
 
         ret = Recording(self.tru_app)
         self.attach_to_context("__trulens_recording__", ret)
@@ -666,7 +678,9 @@ class OtelFeedbackComputationRecordingContext(OtelBaseRecordingContext):
             SpanAttributes.EVAL.TARGET_RECORD_ID, self.target_record_id
         )
         self.attach_to_context(SpanAttributes.INPUT_ID, self.input_id)
-        self.attach_to_context(SpanAttributes.EVAL.METRIC_NAME, self.feedback_name)
+        self.attach_to_context(
+            SpanAttributes.EVAL.METRIC_NAME, self.feedback_name
+        )
 
         # Use start_as_current_span as a context manager
         self.span_context = tracer.start_as_current_span("eval_root")
@@ -679,7 +693,9 @@ class OtelFeedbackComputationRecordingContext(OtelBaseRecordingContext):
         )
 
         # Set general span attributes
-        set_general_span_attributes(root_span, SpanAttributes.SpanType.EVAL_ROOT)
+        set_general_span_attributes(
+            root_span, SpanAttributes.SpanType.EVAL_ROOT
+        )
         root_span.set_attribute(
             SpanAttributes.EVAL_ROOT.METRIC_NAME, self.feedback_name
         )
@@ -761,7 +777,11 @@ def extract_tool_calls(ret) -> Optional[str]:
             if isinstance(tc, dict)
             else getattr(tc, "name", "unknown")
         )
-        args = tc.get("args", {}) if isinstance(tc, dict) else getattr(tc, "args", {})
+        args = (
+            tc.get("args", {})
+            if isinstance(tc, dict)
+            else getattr(tc, "args", {})
+        )
 
         if isinstance(args, dict):
             args_str = ", ".join(f"{k}={v}" for k, v in args.items())

--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -144,9 +144,7 @@ def _set_span_attributes(
                 func_exception,
             )
         # Set function call attributes.
-        set_function_call_attributes(
-            span, ret, func_name, func_exception, all_kwargs
-        )
+        set_function_call_attributes(span, ret, func_name, func_exception, all_kwargs)
     # Resolve the attributes.
     if instance is not None:
         args_with_self_possibly = (instance,) + args
@@ -169,9 +167,7 @@ def _set_span_attributes(
         set_genai_generation_attributes(
             span,
             model=resolved_attributes.get(SpanAttributes.COST.MODEL),
-            input_tokens=resolved_attributes.get(
-                SpanAttributes.COST.NUM_PROMPT_TOKENS
-            ),
+            input_tokens=resolved_attributes.get(SpanAttributes.COST.NUM_PROMPT_TOKENS),
             output_tokens=resolved_attributes.get(
                 SpanAttributes.COST.NUM_COMPLETION_TOKENS
             ),
@@ -182,9 +178,7 @@ def _set_span_attributes(
     elif span_type == SpanAttributes.SpanType.RETRIEVAL:
         set_genai_retrieval_attributes(
             span,
-            query_text=resolved_attributes.get(
-                SpanAttributes.RETRIEVAL.QUERY_TEXT
-            ),
+            query_text=resolved_attributes.get(SpanAttributes.RETRIEVAL.QUERY_TEXT),
             documents=resolved_attributes.get(
                 SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS
             ),
@@ -303,9 +297,7 @@ class instrument:
             if target is None:
                 return func_name
             module = getattr(target, "__module__", "")
-            qualname = getattr(
-                target, "__qualname__", getattr(target, "__name__", "")
-            )
+            qualname = getattr(target, "__qualname__", getattr(target, "__name__", ""))
             base = ".".join([p for p in [module, qualname] if p])
             if not base:
                 return func_name
@@ -643,13 +635,9 @@ class OtelRecordingContext(OtelBaseRecordingContext):
             SpanAttributes.RECORD_ROOT.GROUND_TRUTH_OUTPUT,
             self.ground_truth_output,
         )
-        self.attach_to_context(
-            "__trulens_input_selector__", self.input_selector
-        )
+        self.attach_to_context("__trulens_input_selector__", self.input_selector)
         if self.conversation_id is not None:
-            self.attach_to_context(
-                SpanAttributes.CONVERSATION_ID, self.conversation_id
-            )
+            self.attach_to_context(SpanAttributes.CONVERSATION_ID, self.conversation_id)
 
         ret = Recording(self.tru_app)
         self.attach_to_context("__trulens_recording__", ret)
@@ -678,9 +666,7 @@ class OtelFeedbackComputationRecordingContext(OtelBaseRecordingContext):
             SpanAttributes.EVAL.TARGET_RECORD_ID, self.target_record_id
         )
         self.attach_to_context(SpanAttributes.INPUT_ID, self.input_id)
-        self.attach_to_context(
-            SpanAttributes.EVAL.METRIC_NAME, self.feedback_name
-        )
+        self.attach_to_context(SpanAttributes.EVAL.METRIC_NAME, self.feedback_name)
 
         # Use start_as_current_span as a context manager
         self.span_context = tracer.start_as_current_span("eval_root")
@@ -693,9 +679,7 @@ class OtelFeedbackComputationRecordingContext(OtelBaseRecordingContext):
         )
 
         # Set general span attributes
-        set_general_span_attributes(
-            root_span, SpanAttributes.SpanType.EVAL_ROOT
-        )
+        set_general_span_attributes(root_span, SpanAttributes.SpanType.EVAL_ROOT)
         root_span.set_attribute(
             SpanAttributes.EVAL_ROOT.METRIC_NAME, self.feedback_name
         )
@@ -777,11 +761,7 @@ def extract_tool_calls(ret) -> Optional[str]:
             if isinstance(tc, dict)
             else getattr(tc, "name", "unknown")
         )
-        args = (
-            tc.get("args", {})
-            if isinstance(tc, dict)
-            else getattr(tc, "args", {})
-        )
+        args = tc.get("args", {}) if isinstance(tc, dict) else getattr(tc, "args", {})
 
         if isinstance(args, dict):
             args_str = ", ".join(f"{k}={v}" for k, v in args.items())

--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -490,12 +490,16 @@ def instrument_method(
     attributes: Attributes = None,
     must_be_first_wrapper: bool = False,
 ) -> None:
+    method = getattr(cls, method_name)
+    if hasattr(method, TRULENS_INSTRUMENT_WRAPPER_FLAG):
+        return
+
     wrapper = instrument(
         span_type=span_type,
         attributes=attributes,
         must_be_first_wrapper=must_be_first_wrapper,
     )
-    setattr(cls, method_name, wrapper(getattr(cls, method_name)))
+    setattr(cls, method_name, wrapper(method))
 
 
 def instrument_cost_computer(

--- a/tests/unit/test_otel_instrument.py
+++ b/tests/unit/test_otel_instrument.py
@@ -15,6 +15,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
 import pandas as pd
 from trulens.core.otel.instrument import get_func_name
 from trulens.core.otel.instrument import instrument
+from trulens.core.otel.instrument import instrument_method
 from trulens.core.otel.recording import Recording
 from trulens.experimental.otel_tracing.core.session import (
     _set_up_tracer_provider,
@@ -277,3 +278,93 @@ class TestOtelInstrument(unittest.TestCase):
         my_function()
         self.assertEqual(instrument_info["cnt"], 2)
         self.assertEqual(instrument_info["ret"], "Kojikun is the best baby!")
+
+
+    def test_instrument_method_basic_third_party_class(self) -> None:
+        class ThirdPartyRetriever:
+            def retrieve(self, query: str) -> str:
+                return f"result for {query}"
+
+        instrument_method(ThirdPartyRetriever, "retrieve")
+
+        result = ThirdPartyRetriever().retrieve("TruLens")
+
+        self.assertEqual(result, "result for TruLens")
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertTrue(spans[0].name.endswith("ThirdPartyRetriever.retrieve"))
+
+    def test_instrument_method_span_type_and_attribute_mapping(self) -> None:
+        class ThirdPartyRetriever:
+            def retrieve(self, query: str) -> list[str]:
+                return [f"context for {query}"]
+
+        instrument_method(
+            ThirdPartyRetriever,
+            "retrieve",
+            span_type=SpanAttributes.SpanType.RETRIEVAL,
+            attributes={
+                SpanAttributes.RETRIEVAL.QUERY_TEXT: "query",
+                SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS: "return",
+            },
+        )
+
+        result = ThirdPartyRetriever().retrieve("What is TruLens?")
+
+        self.assertEqual(result, ["context for What is TruLens?"])
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(
+            spans[0].attributes[SpanAttributes.SPAN_TYPE],
+            SpanAttributes.SpanType.RETRIEVAL,
+        )
+        self.assertEqual(
+            spans[0].attributes[SpanAttributes.RETRIEVAL.QUERY_TEXT],
+            "What is TruLens?",
+        )
+        self.assertTupleEqual(
+            spans[0].attributes[SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS],
+            ("context for What is TruLens?",),
+        )
+
+    def test_instrument_method_lambda_attributes(self) -> None:
+        class ThirdPartyScorer:
+            def score(self, text: str) -> int:
+                return len(text)
+
+        instrument_method(
+            ThirdPartyScorer,
+            "score",
+            attributes=lambda ret, exception, *args, **kwargs: {
+                f"{SpanAttributes.UNKNOWN.base}.score": ret,
+                f"{SpanAttributes.UNKNOWN.base}.input_text": args[1],
+            },
+        )
+
+        result = ThirdPartyScorer().score("abc")
+
+        self.assertEqual(result, 3)
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(
+            spans[0].attributes[f"{SpanAttributes.UNKNOWN.base}.score"],
+            3,
+        )
+        self.assertEqual(
+            spans[0].attributes[f"{SpanAttributes.UNKNOWN.base}.input_text"],
+            "abc",
+        )
+
+    def test_instrument_method_twice_is_idempotent(self) -> None:
+        class ThirdPartyClient:
+            def call(self, value: str) -> str:
+                return value.upper()
+
+        instrument_method(ThirdPartyClient, "call")
+        instrument_method(ThirdPartyClient, "call")
+
+        result = ThirdPartyClient().call("trulens")
+
+        self.assertEqual(result, "TRULENS")
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)

--- a/tests/unit/test_otel_instrument.py
+++ b/tests/unit/test_otel_instrument.py
@@ -45,10 +45,14 @@ class TestOtelInstrument(unittest.TestCase):
         # root.
         self.tokens = []
         self.tokens.append(
-            context_api.attach(set_baggage("__trulens_recording__", Recording(None)))
+            context_api.attach(
+                set_baggage("__trulens_recording__", Recording(None))
+            )
         )
         self.tokens.append(
-            context_api.attach(set_baggage(SpanAttributes.RECORD_ID, "test_record_id"))
+            context_api.attach(
+                set_baggage(SpanAttributes.RECORD_ID, "test_record_id")
+            )
         )
         return super().setUp()
 
@@ -149,7 +153,9 @@ class TestOtelInstrument(unittest.TestCase):
             yield "Nolan"
             yield "Sachiboy"
 
-        self._test_sync_generator_function(my_function, "test_sync_generator_function")
+        self._test_sync_generator_function(
+            my_function, "test_sync_generator_function"
+        )
 
     def test_sync_generator_passed_through_function(self) -> None:
         # Set up instrumented function.

--- a/tests/unit/test_otel_instrument.py
+++ b/tests/unit/test_otel_instrument.py
@@ -45,14 +45,10 @@ class TestOtelInstrument(unittest.TestCase):
         # root.
         self.tokens = []
         self.tokens.append(
-            context_api.attach(
-                set_baggage("__trulens_recording__", Recording(None))
-            )
+            context_api.attach(set_baggage("__trulens_recording__", Recording(None)))
         )
         self.tokens.append(
-            context_api.attach(
-                set_baggage(SpanAttributes.RECORD_ID, "test_record_id")
-            )
+            context_api.attach(set_baggage(SpanAttributes.RECORD_ID, "test_record_id"))
         )
         return super().setUp()
 
@@ -153,9 +149,7 @@ class TestOtelInstrument(unittest.TestCase):
             yield "Nolan"
             yield "Sachiboy"
 
-        self._test_sync_generator_function(
-            my_function, "test_sync_generator_function"
-        )
+        self._test_sync_generator_function(my_function, "test_sync_generator_function")
 
     def test_sync_generator_passed_through_function(self) -> None:
         # Set up instrumented function.
@@ -278,7 +272,6 @@ class TestOtelInstrument(unittest.TestCase):
         my_function()
         self.assertEqual(instrument_info["cnt"], 2)
         self.assertEqual(instrument_info["ret"], "Kojikun is the best baby!")
-
 
     def test_instrument_method_basic_third_party_class(self) -> None:
         class ThirdPartyRetriever:


### PR DESCRIPTION
Resubmission of #2551, closed on 2026-06-24 without explanation as part of a batch-close on my end. Closes #2477 (still open, unassigned).

## Real bug, still present on current main

`instrument_method()` has no idempotency guard — calling it twice on the same class/method (which happens in practice when instrumenting third-party classes from multiple entry points) double-wraps the method, producing duplicate spans for a single call.

Verified this is still an active bug on current `main` (not something already fixed since June) by temporarily reverting to the un-fixed version and re-running the new test:

```
AssertionError: 2 != 1
```

(two spans emitted for one instrumented call, instead of one)

## Fix

`instrument_method()` now checks for the `TRULENS_INSTRUMENT_WRAPPER_FLAG` marker before wrapping — if the method is already instrumented, it's a no-op.

## Verification

```
$ pytest tests/unit/test_otel_instrument.py -v
11 passed in 1.28s
```

Includes `test_instrument_method_twice_is_idempotent`, which I confirmed genuinely catches the bug (not just passes trivially) — reverting the fix locally makes it fail with `2 != 1`, matching the bug description above; re-applying the fix passes clean.