### PR TITLE
ci: let examples/docs-only PRs satisfy the required eval check without admin merge

### DIFF
--- a/.azure_pipelines/README.md
+++ b/.azure_pipelines/README.md
@@ -4,7 +4,19 @@ Note that the pipeline definitions in this folder are for azure pipelines, not
 github pipelines. There are differences between these systems.
 
 - `ci-eval-pr.yaml` is run for all PRs to _TruLens_. Success is needed for
-  merging into `main`.
+  merging into `main`. It is the single required status check ("PR Validation
+  Eval") for branch protection, so it must **always run and report success**.
+  A `DetectChanges` gate job inspects the changed paths: code-affecting PRs run
+  the full conda build + test matrix, while docs/examples-only PRs skip those
+  heavy jobs and the pipeline still succeeds. This lets docs/examples PRs merge
+  normally instead of getting stuck on a "skipped" required check.
+
+  > Do **not** add a `paths:` filter to this pipeline (in the YAML `pr:` trigger
+  > or via the Azure DevOps UI "Override the YAML trigger from here" option).
+  > A path-filtered required check reports **skipped** rather than **success**
+  > for excluded PRs, which GitHub branch protection treats as unmet — forcing
+  > an admin override to merge. Keep triggering in YAML and let `DetectChanges`
+  > decide what work to run.
 - `ci-eval.yaml` for _TruLens_ releases. This includes database migration
   tests as well as running notebooks. Success is needed for merging into
   `releases/*`. Also, any branch named `releases/*` needs to pass the pipeline

--- a/.azure_pipelines/README.md
+++ b/.azure_pipelines/README.md
@@ -6,10 +6,15 @@ github pipelines. There are differences between these systems.
 - `ci-eval-pr.yaml` is run for all PRs to _TruLens_. Success is needed for
   merging into `main`. It is the single required status check ("PR Validation
   Eval") for branch protection, so it must **always run and report success**.
-  A `DetectChanges` gate job inspects the changed paths: code-affecting PRs run
-  the full conda build + test matrix, while docs/examples-only PRs skip those
-  heavy jobs and the pipeline still succeeds. This lets docs/examples PRs merge
-  normally instead of getting stuck on a "skipped" required check.
+  It has two tiers of validation:
+    - **Lightweight (every PR):** the `PreCommit` job runs `make run-precommit`
+      (ruff, ruff-format, yaml/whitespace, nb-clean, ...) on all PRs — including
+      docs/examples-only ones — so formatting/lint issues are always caught.
+    - **Expensive (code PRs only):** the conda build + full unit test matrix run
+      only when the `DetectChanges` gate finds code-affecting changes.
+  Docs/examples-only PRs skip the expensive jobs but still run `PreCommit`, and
+  the pipeline succeeds when lint passes — so they merge normally instead of
+  getting stuck on a "skipped" required check, while still being lint-gated.
 
   > Do **not** add a `paths:` filter to this pipeline (in the YAML `pr:` trigger
   > or via the Azure DevOps UI "Override the YAML trigger from here" option).

--- a/.azure_pipelines/ci-eval-pr.yaml
+++ b/.azure_pipelines/ci-eval-pr.yaml
@@ -3,16 +3,25 @@
 #
 # This pipeline is the required status check ("PR Validation Eval") for merging
 # into `main`. It must ALWAYS run and report success so that branch protection
-# is satisfied for every PR. For docs/examples-only PRs the expensive jobs are
-# skipped via the `DetectChanges` gate below, but the pipeline still succeeds so
-# the required check turns green without an admin override.
+# is satisfied for every PR.
+#
+# Two tiers of validation:
+#   * Lightweight checks (pre-commit: ruff, ruff-format, yaml/whitespace,
+#     nb-clean) run on EVERY PR via the `PreCommit` job, so docs/examples-only
+#     PRs still get linted and can't merge with formatting/lint issues.
+#   * Expensive checks (conda build + full unit test matrix) run only when the
+#     PR touches code, gated by the `DetectChanges` job below.
+#
+# For docs/examples-only PRs the expensive jobs skip but the pipeline still
+# completes successfully (assuming pre-commit passes), so the required check
+# turns green without an admin override.
 #
 # IMPORTANT: Do not add a `paths:` filter to the `pr` trigger below, and do not
 # configure a path filter on this pipeline in the Azure DevOps UI ("Override the
 # YAML trigger from here"). A path-filtered required check reports "skipped"
 # (not "success") for excluded PRs, which GitHub treats as an unmet requirement
 # and blocks the merge. Keep triggering here in YAML and let `DetectChanges`
-# decide what work to run.
+# decide what heavy work to run.
 
 trigger: none
 
@@ -23,7 +32,7 @@ pr:
 
 jobs:
   # Fast, always-runs gate. Determines whether the PR touches anything other
-  # than docs/examples so downstream heavy jobs can be skipped for docs-only
+  # than docs/examples so the expensive jobs can be skipped for docs-only
   # changes while this pipeline still reports success.
   - job: DetectChanges
     displayName: "Detect changed paths"
@@ -65,7 +74,7 @@ jobs:
                 echo "Code-affecting files changed -> running full validation."
                 IS_CODE=true
               else
-                echo "Docs/examples-only PR -> skipping heavy validation (gate passes)."
+                echo "Docs/examples-only PR -> skipping heavy validation (lint still runs)."
                 IS_CODE=false
               fi
             else
@@ -78,6 +87,20 @@ jobs:
           echo "##vso[task.setvariable variable=isCode;isOutput=true]${IS_CODE}"
         name: detect
         displayName: "Determine change type"
+
+  # Lightweight lint/format gate. Runs for EVERY PR (including docs/examples)
+  # so formatting/lint issues are always caught, even when the heavy test
+  # matrix is skipped.
+  - job: PreCommit
+    displayName: "Lint & format (pre-commit)"
+    variables:
+      python-version: 3.11
+    pool:
+      vmImage: ubuntu-latest
+    timeoutInMinutes: 20
+    steps:
+      - template: templates/env-setup.yaml
+      - template: templates/run-precommits.yaml
 
   - template: templates/build-conda-packages.yaml
     parameters:
@@ -105,7 +128,6 @@ jobs:
 
     steps:
       - template: templates/env-setup.yaml
-      - template: templates/run-precommits.yaml
       - template: templates/run-tests.yaml
         parameters:
           pytestMarker: basic

--- a/.azure_pipelines/ci-eval-pr.yaml
+++ b/.azure_pipelines/ci-eval-pr.yaml
@@ -1,5 +1,18 @@
 # This a definition for azure pipelines, not github pipelines. There are
 # differences between these systems.
+#
+# This pipeline is the required status check ("PR Validation Eval") for merging
+# into `main`. It must ALWAYS run and report success so that branch protection
+# is satisfied for every PR. For docs/examples-only PRs the expensive jobs are
+# skipped via the `DetectChanges` gate below, but the pipeline still succeeds so
+# the required check turns green without an admin override.
+#
+# IMPORTANT: Do not add a `paths:` filter to the `pr` trigger below, and do not
+# configure a path filter on this pipeline in the Azure DevOps UI ("Override the
+# YAML trigger from here"). A path-filtered required check reports "skipped"
+# (not "success") for excluded PRs, which GitHub treats as an unmet requirement
+# and blocks the merge. Keep triggering here in YAML and let `DetectChanges`
+# decide what work to run.
 
 trigger: none
 
@@ -9,8 +22,72 @@ pr:
       - main
 
 jobs:
+  # Fast, always-runs gate. Determines whether the PR touches anything other
+  # than docs/examples so downstream heavy jobs can be skipped for docs-only
+  # changes while this pipeline still reports success.
+  - job: DetectChanges
+    displayName: "Detect changed paths"
+    pool:
+      vmImage: ubuntu-latest
+    timeoutInMinutes: 5
+    steps:
+      - checkout: self
+        fetchDepth: 0
+      - bash: |
+          set -uo pipefail
+
+          TARGET="$(System.PullRequest.TargetBranch)"
+          TARGET="${TARGET#refs/heads/}"
+          TARGET="${TARGET:-main}"
+
+          # Fail-safe default: run full validation unless we can positively
+          # prove the PR only touches docs/examples.
+          IS_CODE=true
+
+          if git fetch --no-tags --prune origin "+refs/heads/${TARGET}:refs/remotes/origin/${TARGET}"; then
+            CHANGED="$(git diff --name-only "origin/${TARGET}...HEAD")"
+            if [ $? -eq 0 ]; then
+              echo "Changed files vs origin/${TARGET}:"
+              printf '%s\n' "$CHANGED"
+
+              # Anything outside docs/, examples/, top-level *.md, or mkdocs.yml
+              # counts as a code-affecting change.
+              CODE_FILES="$(printf '%s\n' "$CHANGED" \
+                | grep -vE '^(docs/|examples/)' \
+                | grep -vE '(^|/)[^/]*\.md$' \
+                | grep -vE '^mkdocs\.yml$' \
+                || true)"
+
+              if [ -z "$CHANGED" ]; then
+                echo "No changed files detected; running full validation to be safe."
+                IS_CODE=true
+              elif [ -n "$CODE_FILES" ]; then
+                echo "Code-affecting files changed -> running full validation."
+                IS_CODE=true
+              else
+                echo "Docs/examples-only PR -> skipping heavy validation (gate passes)."
+                IS_CODE=false
+              fi
+            else
+              echo "git diff failed; running full validation to be safe."
+            fi
+          else
+            echo "Could not fetch target branch; running full validation to be safe."
+          fi
+
+          echo "##vso[task.setvariable variable=isCode;isOutput=true]${IS_CODE}"
+        name: detect
+        displayName: "Determine change type"
+
   - template: templates/build-conda-packages.yaml
+    parameters:
+      dependsOn:
+        - DetectChanges
+      condition: and(succeeded(), eq(dependencies.DetectChanges.outputs['detect.isCode'], 'true'))
+
   - job: PRBranchProtect # name seems to be important but cannot figure out why
+    dependsOn: DetectChanges
+    condition: and(succeeded(), eq(dependencies.DetectChanges.outputs['detect.isCode'], 'true'))
     pool:
       vmImage: ubuntu-latest
     timeoutInMinutes: 45

--- a/.azure_pipelines/templates/build-conda-packages.yaml
+++ b/.azure_pipelines/templates/build-conda-packages.yaml
@@ -1,5 +1,20 @@
+parameters:
+# Jobs this one should wait on. Defaults to none to preserve prior behavior.
+- name: dependsOn
+  type: object
+  default: []
+# Optional job-level condition. Empty string means "no condition" (always run
+# when reached), matching the previous unconditional behavior.
+- name: condition
+  type: string
+  default: ""
+
 jobs:
 - job: BuildCondaPackages
+  ${{ if parameters.dependsOn }}:
+    dependsOn: ${{ parameters.dependsOn }}
+  ${{ if parameters.condition }}:
+    condition: ${{ parameters.condition }}
   variables:
     python-version: 3.11
   pool:

--- a/examples/cicd/azure_pipelines/eval_gate.py
+++ b/examples/cicd/azure_pipelines/eval_gate.py
@@ -14,12 +14,14 @@ Environment variables:
 from __future__ import annotations
 
 import os
+from pathlib import Path
 import sys
 import xml.etree.ElementTree as ET
-from pathlib import Path
 
 from trulens.apps.app import TruApp
-from trulens.core import Metric, Selector, TruSession
+from trulens.core import Metric
+from trulens.core import Selector
+from trulens.core import TruSession
 from trulens.core.otel.instrument import instrument
 from trulens.otel.semconv.trace import SpanAttributes
 
@@ -78,7 +80,9 @@ def build_feedbacks():
     """Configure RAG triad feedback functions using the OpenAI provider."""
     from trulens.providers.openai import OpenAI
 
-    provider = OpenAI(model_engine=os.environ.get("TRULENS_EVAL_MODEL", "gpt-4o-mini"))
+    provider = OpenAI(
+        model_engine=os.environ.get("TRULENS_EVAL_MODEL", "gpt-4o-mini")
+    )
 
     return [
         Metric(
@@ -108,7 +112,12 @@ def build_feedbacks():
     ]
 
 
-def write_junit(path: str, failures: list[tuple[str, float]], scores: dict[str, float], min_score: float) -> None:
+def write_junit(
+    path: str,
+    failures: list[tuple[str, float]],
+    scores: dict[str, float],
+    min_score: float,
+) -> None:
     suite = ET.Element(
         "testsuite",
         name="trulens-eval-gate",
@@ -117,9 +126,13 @@ def write_junit(path: str, failures: list[tuple[str, float]], scores: dict[str, 
     )
     failed = {name: score for name, score in failures}
     for name, score in scores.items():
-        case = ET.SubElement(suite, "testcase", classname="TruLensEvalGate", name=name)
+        case = ET.SubElement(
+            suite, "testcase", classname="TruLensEvalGate", name=name
+        )
         if name in failed:
-            failure = ET.SubElement(case, "failure", message=f"{name} below threshold")
+            failure = ET.SubElement(
+                case, "failure", message=f"{name} below threshold"
+            )
             failure.text = f"{name}: {score:.3f} < {min_score:.3f}"
 
     output = Path(path)
@@ -156,7 +169,8 @@ def main() -> int:
 
     ignore = {"latency", "total_cost", "total_tokens", "Latency", "Cost (USD)"}
     feedback_cols = [
-        col for col in leaderboard.columns
+        col
+        for col in leaderboard.columns
         if col not in ignore and leaderboard[col].dtype.kind in "fi"
     ]
 
@@ -175,7 +189,10 @@ def main() -> int:
         print(f"\nWrote JUnit report to {junit_path}")
 
     if failures:
-        print(f"\nEval gate FAILED: {len(failures)} metric(s) below {min_score}.", file=sys.stderr)
+        print(
+            f"\nEval gate FAILED: {len(failures)} metric(s) below {min_score}.",
+            file=sys.stderr,
+        )
         return 1
 
     print(f"\nEval gate PASSED: all metrics >= {min_score}.")

--- a/examples/cicd/github_actions/eval_gate.py
+++ b/examples/cicd/github_actions/eval_gate.py
@@ -19,7 +19,9 @@ import os
 import sys
 
 from trulens.apps.app import TruApp
-from trulens.core import Metric, Selector, TruSession
+from trulens.core import Metric
+from trulens.core import Selector
+from trulens.core import TruSession
 from trulens.core.otel.instrument import instrument
 from trulens.otel.semconv.trace import SpanAttributes
 
@@ -81,7 +83,9 @@ def build_feedbacks():
     """Configure the RAG triad feedback functions using the OpenAI provider."""
     from trulens.providers.openai import OpenAI
 
-    provider = OpenAI(model_engine=os.environ.get("TRULENS_EVAL_MODEL", "gpt-4o-mini"))
+    provider = OpenAI(
+        model_engine=os.environ.get("TRULENS_EVAL_MODEL", "gpt-4o-mini")
+    )
 
     f_answer_relevance = Metric(
         implementation=provider.relevance_with_cot_reasons,
@@ -142,7 +146,8 @@ def main() -> int:
     # (latency, cost) are ignored.
     ignore = {"latency", "total_cost", "total_tokens", "Latency", "Cost (USD)"}
     feedback_cols = [
-        c for c in leaderboard.columns
+        c
+        for c in leaderboard.columns
         if c not in ignore and leaderboard[c].dtype.kind in "fi"
     ]
 

--- a/examples/cicd/pre_commit/eval_smoke_test.py
+++ b/examples/cicd/pre_commit/eval_smoke_test.py
@@ -15,7 +15,9 @@ import os
 import sys
 
 from trulens.apps.app import TruApp
-from trulens.core import Metric, Selector, TruSession
+from trulens.core import Metric
+from trulens.core import Selector
+from trulens.core import TruSession
 from trulens.core.otel.instrument import instrument
 from trulens.otel.semconv.trace import SpanAttributes
 
@@ -47,7 +49,9 @@ def main() -> int:
     from trulens.providers.openai import OpenAI
 
     min_score = float(os.environ.get("TRULENS_MIN_SCORE", "0.7"))
-    provider = OpenAI(model_engine=os.environ.get("TRULENS_EVAL_MODEL", "gpt-4o-mini"))
+    provider = OpenAI(
+        model_engine=os.environ.get("TRULENS_EVAL_MODEL", "gpt-4o-mini")
+    )
 
     f_relevance = Metric(
         implementation=provider.relevance,


### PR DESCRIPTION
## Problem

`PR Validation Eval` is the single required status check for merging to `main`. It's path-filtered, so examples/docs-only PRs **skip** it entirely — and GitHub branch protection treats a *skipped* required check as **unmet**. The result: docs/examples PRs (e.g. #2586, #2589, #2594) can only be merged with an **admin override**, quietly bypassing merge rules.

Observed on #2593 (examples-only): `PR Validation Eval` shows `skipped`, PR state = `BLOCKED`, even though nothing is actually failing.

## Approach

Rather than path-filter the pipeline (which is what produces the "skipped" state), keep it **always triggering** and let it decide what work to run:

1. **`DetectChanges`** — a fast (<5 min) gate job that diffs the PR against its target branch and sets an `isCode` output.
2. **Heavy jobs gated on `isCode`** — `BuildCondaPackages` and `PRBranchProtect` (the full conda build + 3.10/3.11/3.12 test matrix) now `dependsOn: DetectChanges` and only run when code-affecting files changed.
3. **Docs/examples-only PRs** skip those jobs, but the pipeline still completes **successfully**, so the required check turns green and the PR is mergeable normally — no admin override.
4. **Fail-safe:** if change detection can't run (fetch/diff error, empty diff), it defaults to running full validation.

"Code-affecting" = anything outside `docs/`, `examples/`, top-level `*.md`, or `mkdocs.yml`.

## Changes

- `templates/build-conda-packages.yaml`: optional `dependsOn`/`condition` params with backward-compatible defaults (empty → no change to existing behavior).
- `ci-eval-pr.yaml`: add `DetectChanges`; gate the heavy jobs on it.
- `README.md`: document the gate and warn against re-introducing path filters (YAML or Azure UI trigger override).

## Required settings change (cannot be done in a PR)

For this to take effect, the **Azure DevOps UI trigger override** for this pipeline must be disabled so triggering is governed by the YAML `pr:` block (no path exclusions). Branch protection should keep requiring the top-level **`PR Validation Eval`** context only — **not** the per-matrix sub-contexts (`PR Validation Eval (PRBranchProtect ...)`), since those legitimately skip for docs/examples PRs.

## Test plan

- [ ] Open/observe a code PR → `DetectChanges` sets `isCode=true`, full matrix runs, check passes.
- [ ] Open/observe a docs/examples-only PR → heavy jobs skip, `PR Validation Eval` reports **success**, PR mergeable without admin.
- [ ] Confirm branch protection requires only the top-level `PR Validation Eval` context.

Draft pending a live CI run to confirm the pipeline reports success when the heavy jobs are skipped.