### PR TITLE
fix(dashboard): don't split app tag strings into characters in tag filter

### DIFF
--- a/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
@@ -508,6 +508,24 @@ def _handle_reset_filters(
             del st.query_params[query_param_key]
 
 
+def get_unique_app_tags(app_versions_df: pd.DataFrame) -> List[str]:
+    """Return the sorted unique app tags for the tag filter multiselect.
+
+    Each app version's ``tags`` value is a single string (see
+    ``trulens.core.schema.types.Tags``), so tags are collected as whole
+    strings. Using ``set(app_version["tags"])`` here would iterate the string
+    into individual characters (e.g. ``"prod"`` -> ``{"p", "r", "o", "d"}``),
+    which is what surfaced the garbled single-character tags in issue #1689.
+    Empty tag strings are skipped so they do not show up as a blank option.
+    """
+    tags: set = set()
+    for _, app_version in app_versions_df.iterrows():
+        tag = app_version["tags"]
+        if tag:
+            tags.add(tag)
+    return sorted(tags)
+
+
 def render_app_version_filters(
     app_name: str,
     other_query_params_kv: Optional[Dict[str, str]] = None,
@@ -541,10 +559,7 @@ def render_app_version_filters(
     with col1.popover("Advanced Filters", width="stretch"):
         # get tag options
         st.header("Advanced Filters")
-        tags = set()
-        for _, app_version in app_versions_df.iterrows():
-            tags |= set(app_version["tags"])
-        tags = sorted(tags)
+        tags = get_unique_app_tags(app_versions_df)
         # select tags
 
         selected_tags = _render_filter_multiselect(

--- a/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
@@ -2,7 +2,7 @@ import argparse
 import json
 import os
 import sys
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import pandas as pd
 import sqlalchemy as sa

--- a/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
+++ b/src/dashboard/trulens/dashboard/utils/dashboard_utils.py
@@ -508,7 +508,7 @@ def _handle_reset_filters(
             del st.query_params[query_param_key]
 
 
-def get_unique_app_tags(app_versions_df: pd.DataFrame) -> List[str]:
+def _get_unique_app_tags(app_versions_df: pd.DataFrame) -> List[str]:
     """Return the sorted unique app tags for the tag filter multiselect.
 
     Each app version's ``tags`` value is a single string (see
@@ -518,7 +518,7 @@ def get_unique_app_tags(app_versions_df: pd.DataFrame) -> List[str]:
     which is what surfaced the garbled single-character tags in issue #1689.
     Empty tag strings are skipped so they do not show up as a blank option.
     """
-    tags: set = set()
+    tags: Set[str] = set()
     for _, app_version in app_versions_df.iterrows():
         tag = app_version["tags"]
         if tag:
@@ -559,7 +559,7 @@ def render_app_version_filters(
     with col1.popover("Advanced Filters", width="stretch"):
         # get tag options
         st.header("Advanced Filters")
-        tags = get_unique_app_tags(app_versions_df)
+        tags = _get_unique_app_tags(app_versions_df)
         # select tags
 
         selected_tags = _render_filter_multiselect(

--- a/tests/unit/streamlit/test_dashboard_utils.py
+++ b/tests/unit/streamlit/test_dashboard_utils.py
@@ -1,0 +1,37 @@
+"""Unit tests for ``trulens.dashboard.utils.dashboard_utils``."""
+
+import pandas as pd
+from trulens.dashboard.utils.dashboard_utils import get_unique_app_tags
+
+
+class TestGetUniqueAppTags:
+    """Tests for ``get_unique_app_tags`` (regression for issue #1689).
+
+    Each app version's ``tags`` value is a single string, so the tag filter
+    must collect whole tag strings. The previous ``set(app_version["tags"])``
+    iterated a string into its individual characters.
+    """
+
+    def test_tags_are_not_split_into_characters(self):
+        # Regression for #1689: a tag string used to be exploded into single
+        # characters (e.g. "production" -> "p", "r", "o", "d", ...).
+        df = pd.DataFrame({"tags": ["production", "staging"]})
+        assert get_unique_app_tags(df) == ["production", "staging"]
+
+    def test_single_tag_kept_whole(self):
+        # Even one app with one tag must stay intact, not become characters.
+        df = pd.DataFrame({"tags": ["production"]})
+        assert get_unique_app_tags(df) == ["production"]
+
+    def test_duplicate_tags_deduplicated_and_sorted(self):
+        df = pd.DataFrame({"tags": ["prod", "dev", "prod", "abc"]})
+        assert get_unique_app_tags(df) == ["abc", "dev", "prod"]
+
+    def test_empty_tag_strings_skipped(self):
+        # "" is the default tag value and must not appear as a blank option.
+        df = pd.DataFrame({"tags": ["prod", "", "dev", ""]})
+        assert get_unique_app_tags(df) == ["dev", "prod"]
+
+    def test_all_empty_yields_no_tags(self):
+        df = pd.DataFrame({"tags": ["", ""]})
+        assert get_unique_app_tags(df) == []

--- a/tests/unit/streamlit/test_dashboard_utils.py
+++ b/tests/unit/streamlit/test_dashboard_utils.py
@@ -1,11 +1,11 @@
 """Unit tests for ``trulens.dashboard.utils.dashboard_utils``."""
 
 import pandas as pd
-from trulens.dashboard.utils.dashboard_utils import get_unique_app_tags
+from trulens.dashboard.utils.dashboard_utils import _get_unique_app_tags
 
 
 class TestGetUniqueAppTags:
-    """Tests for ``get_unique_app_tags`` (regression for issue #1689).
+    """Tests for ``_get_unique_app_tags`` (regression for issue #1689).
 
     Each app version's ``tags`` value is a single string, so the tag filter
     must collect whole tag strings. The previous ``set(app_version["tags"])``
@@ -16,22 +16,22 @@ class TestGetUniqueAppTags:
         # Regression for #1689: a tag string used to be exploded into single
         # characters (e.g. "production" -> "p", "r", "o", "d", ...).
         df = pd.DataFrame({"tags": ["production", "staging"]})
-        assert get_unique_app_tags(df) == ["production", "staging"]
+        assert _get_unique_app_tags(df) == ["production", "staging"]
 
     def test_single_tag_kept_whole(self):
         # Even one app with one tag must stay intact, not become characters.
         df = pd.DataFrame({"tags": ["production"]})
-        assert get_unique_app_tags(df) == ["production"]
+        assert _get_unique_app_tags(df) == ["production"]
 
     def test_duplicate_tags_deduplicated_and_sorted(self):
         df = pd.DataFrame({"tags": ["prod", "dev", "prod", "abc"]})
-        assert get_unique_app_tags(df) == ["abc", "dev", "prod"]
+        assert _get_unique_app_tags(df) == ["abc", "dev", "prod"]
 
     def test_empty_tag_strings_skipped(self):
         # "" is the default tag value and must not appear as a blank option.
         df = pd.DataFrame({"tags": ["prod", "", "dev", ""]})
-        assert get_unique_app_tags(df) == ["dev", "prod"]
+        assert _get_unique_app_tags(df) == ["dev", "prod"]
 
     def test_all_empty_yields_no_tags(self):
         df = pd.DataFrame({"tags": ["", ""]})
-        assert get_unique_app_tags(df) == []
+        assert _get_unique_app_tags(df) == []


### PR DESCRIPTION
## Summary

Fixes #1689. In the dashboard's **Advanced Filters → tags** multiselect, each app's tag string was exploded into individual characters — a tag like `production` showed up as the options `p`, `r`, `o`, `d`, `u`, `c`, `t`, `i`, `o`, `n` instead of `production`.

`AppDefinition.tags` / `Record.tags` is a single string (`trulens.core.schema.types.Tags`). The tag-option collection in `render_app_version_filters` did:

```python
tags = set()
for _, app_version in app_versions_df.iterrows():
    tags |= set(app_version["tags"])   # set() on a str iterates its characters
tags = sorted(tags)
```

`set("production")` is `{"p", "r", "o", "d", "u", "c", "t", "i", "o", "n"}` — exactly the garbled single-character tags in the report. Even a single, valid tag is affected.

## Fix

Extract the collection into a small, testable helper `get_unique_app_tags` that gathers **whole** tag strings (and skips empty strings so the default `""` tag doesn't become a blank filter option):

```python
tags = get_unique_app_tags(app_versions_df)
```

Scope is intentionally minimal: the metadata filters and the downstream tag match (`any(tag in x for tag in selected_tags)`) are unchanged — only the character-splitting is fixed, consistent with the existing single-string tag model. (Broader `list[str]` multi-tag support would be a separate, larger enhancement.)

## Test

Adds `tests/unit/streamlit/test_dashboard_utils.py::TestGetUniqueAppTags`:
- regression: tag strings are not split into characters (issue #1689)
- a single tag stays whole
- duplicates de-duplicated and sorted
- empty tag strings skipped
- all-empty yields no options

`ruff check` is clean on both changed files.
