### PR TITLE
feat: set SpanKind per GenAI conventions and add resource attributes

### DIFF
--- a/src/core/trulens/core/otel/function_call_context_manager.py
+++ b/src/core/trulens/core/otel/function_call_context_manager.py
@@ -6,6 +6,7 @@ from opentelemetry.baggage import get_baggage
 from opentelemetry.baggage import remove_baggage
 from opentelemetry.baggage import set_baggage
 import opentelemetry.context as context_api
+from opentelemetry.trace import SpanKind
 from opentelemetry.trace import get_current_span
 from opentelemetry.trace.span import Span
 from trulens.experimental.otel_tracing.core.session import TRULENS_SERVICE_NAME
@@ -34,8 +35,13 @@ class UseCurrentSpanFunctionCallContextManager:
 
 
 class CreateSpanFunctionCallContextManager:
-    def __init__(self, span_name: str) -> None:
+    def __init__(
+        self,
+        span_name: str,
+        span_type: str = SpanAttributes.SpanType.UNKNOWN,
+    ) -> None:
         self.span_name = span_name
+        self.span_type = span_type
         self.span_context_manager = None
         self.token = None
         self._started_record = False
@@ -78,11 +84,18 @@ class CreateSpanFunctionCallContextManager:
                 recording.add_record_id(record_id)
 
         self._started_record = started_record
-        # Create span.
+        # Create span.  Use SpanKind.CLIENT for GENERATION spans
+        # (outbound LLM calls) per the OTel GenAI semantic conventions;
+        # all other span types are in-process work → INTERNAL.
+        span_kind = (
+            SpanKind.CLIENT
+            if self.span_type == SpanAttributes.SpanType.GENERATION
+            else SpanKind.INTERNAL
+        )
         self.span_context_manager = (
             trace.get_tracer_provider()
             .get_tracer(TRULENS_SERVICE_NAME)
-            .start_as_current_span(name=self.span_name)
+            .start_as_current_span(name=self.span_name, kind=span_kind)
         )
         span = self.span_context_manager.__enter__()
         if started_record:
@@ -126,11 +139,15 @@ class CreateSpanFunctionCallContextManager:
 
 
 def create_function_call_context_manager(
-    create_new_span: bool, span_name: str
+    create_new_span: bool,
+    span_name: str,
+    span_type: str = SpanAttributes.SpanType.UNKNOWN,
 ) -> Union[
     UseCurrentSpanFunctionCallContextManager,
     CreateSpanFunctionCallContextManager,
 ]:
     if create_new_span:
-        return CreateSpanFunctionCallContextManager(span_name)
+        return CreateSpanFunctionCallContextManager(
+            span_name, span_type=span_type
+        )
     return UseCurrentSpanFunctionCallContextManager()

--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -349,7 +349,9 @@ class instrument:
             span_end_callbacks = kwargs.pop(TRULENS_SPAN_END_CALLBACKS, [])
             func_name_for_call = _func_name_for_instance(instance)
             with create_function_call_context_manager(
-                self.create_new_span, func_name_for_call
+                self.create_new_span,
+                func_name_for_call,
+                span_type=self.span_type,
             ) as span:
                 ret = None
                 func_exception: Optional[Exception] = None
@@ -395,7 +397,9 @@ class instrument:
             span_end_callbacks = kwargs.pop(TRULENS_SPAN_END_CALLBACKS, [])
             func_name_for_call = _func_name_for_instance(instance)
             with create_function_call_context_manager(
-                self.create_new_span, func_name_for_call
+                self.create_new_span,
+                func_name_for_call,
+                span_type=self.span_type,
             ) as span:
                 ret = None
                 func_exception: Optional[Exception] = None
@@ -454,7 +458,9 @@ class instrument:
             span_end_callbacks = kwargs.pop(TRULENS_SPAN_END_CALLBACKS, [])
             func_name_for_call = _func_name_for_instance(instance)
             with create_function_call_context_manager(
-                self.create_new_span, func_name_for_call
+                self.create_new_span,
+                func_name_for_call,
+                span_type=self.span_type,
             ) as span:
                 ret = None
                 func_exception: Optional[Exception] = None

--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -877,7 +877,9 @@ class Run(BaseModel):
                             f"Creating child span: {span_type} under parent {root_span_id}"
                         )
                         with create_function_call_context_manager(
-                            True, f"{span_type}_virtual"
+                            True,
+                            f"{span_type}_virtual",
+                            span_type=span_type_enum,
                         ) as child_span:
                             set_general_span_attributes(
                                 child_span, span_type_enum

--- a/src/core/trulens/experimental/otel_tracing/core/exporter/utils.py
+++ b/src/core/trulens/experimental/otel_tracing/core/exporter/utils.py
@@ -9,12 +9,22 @@ from opentelemetry.proto.common.v1.common_pb2 import KeyValueList
 from opentelemetry.proto.trace.v1.trace_pb2 import Span as SpanProto
 from opentelemetry.proto.trace.v1.trace_pb2 import Status
 from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.trace import SpanKind
 from opentelemetry.trace import StatusCode
 from trulens.core.schema import event as event_schema
 from trulens.otel.semconv.trace import ResourceAttributes
 from trulens.otel.semconv.trace import SpanAttributes
 
 logger = logging.getLogger(__name__)
+
+# Mapping from OTel SDK SpanKind to protobuf SpanKind enum values.
+_SPAN_KIND_TO_PROTO = {
+    SpanKind.INTERNAL: SpanProto.SpanKind.SPAN_KIND_INTERNAL,
+    SpanKind.SERVER: SpanProto.SpanKind.SPAN_KIND_SERVER,
+    SpanKind.CLIENT: SpanProto.SpanKind.SPAN_KIND_CLIENT,
+    SpanKind.PRODUCER: SpanProto.SpanKind.SPAN_KIND_PRODUCER,
+    SpanKind.CONSUMER: SpanProto.SpanKind.SPAN_KIND_CONSUMER,
+}
 
 
 def convert_to_any_value(value: Any) -> AnyValue:
@@ -81,7 +91,9 @@ def convert_readable_span_to_proto(span: ReadableSpan) -> SpanProto:
         if span.parent
         else b"",
         name=span.name,
-        kind=SpanProto.SpanKind.SPAN_KIND_INTERNAL,
+        kind=_SPAN_KIND_TO_PROTO.get(
+            span.kind, SpanProto.SpanKind.SPAN_KIND_INTERNAL
+        ),
         start_time_unix_nano=span.start_time if span.start_time else 0,
         end_time_unix_nano=span.end_time if span.end_time else 0,
         attributes=[
@@ -144,7 +156,9 @@ def construct_event(span: ReadableSpan) -> event_schema.Event:
         event_id=str(context.span_id),
         record={
             "name": span.name,
-            "kind": SpanProto.SpanKind.SPAN_KIND_INTERNAL,
+            "kind": _SPAN_KIND_TO_PROTO.get(
+                span.kind, SpanProto.SpanKind.SPAN_KIND_INTERNAL
+            ),
             "parent_span_id": str(parent.span_id if parent else ""),
             "status": "STATUS_CODE_ERROR"
             if span.status.status_code == StatusCode.ERROR

--- a/src/core/trulens/experimental/otel_tracing/core/session.py
+++ b/src/core/trulens/experimental/otel_tracing/core/session.py
@@ -1,4 +1,7 @@
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as pkg_version
 import logging
+import os
 import threading
 from typing import Any, Callable, Dict, Optional
 
@@ -28,7 +31,24 @@ _costs_thread: Optional[threading.Thread] = None
 
 
 def _set_up_tracer_provider() -> TracerProvider:
-    resource = Resource.create({"service.name": TRULENS_SERVICE_NAME})
+    resource_attrs = {
+        "service.name": TRULENS_SERVICE_NAME,
+    }
+    try:
+        resource_attrs["service.version"] = pkg_version("trulens-core")
+    except PackageNotFoundError:
+        pass
+    # Only set deployment.environment when explicitly configured via
+    # TruLens-specific env vars.  When unset, Resource.create() will
+    # still honour the standard OTEL_RESOURCE_ATTRIBUTES variable,
+    # e.g. OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production.
+    deployment_env = os.environ.get(
+        "TRULENS_DEPLOYMENT_ENVIRONMENT",
+        os.environ.get("DEPLOYMENT_ENVIRONMENT"),
+    )
+    if deployment_env is not None:
+        resource_attrs["deployment.environment"] = deployment_env
+    resource = Resource.create(resource_attrs)
     provider = TracerProvider(resource=resource)
     trace.set_tracer_provider(provider)
 

--- a/tests/unit/test_otel_instrument.py
+++ b/tests/unit/test_otel_instrument.py
@@ -12,6 +12,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
+from opentelemetry.trace import SpanKind
 import pandas as pd
 from trulens.core.otel.instrument import get_func_name
 from trulens.core.otel.instrument import instrument
@@ -367,3 +368,53 @@ class TestOtelInstrument(unittest.TestCase):
         self.assertEqual(result, "TRULENS")
         spans = self.exporter.get_finished_spans()
         self.assertEqual(len(spans), 1)
+
+    def test_generation_span_has_client_span_kind(self) -> None:
+        """GENERATION spans should have SpanKind.CLIENT (outbound LLM calls)."""
+
+        @instrument(span_type=SpanAttributes.SpanType.GENERATION)
+        def call_llm(prompt: str) -> str:
+            return "response"
+
+        call_llm("hello")
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0].kind, SpanKind.CLIENT)
+
+    def test_non_generation_span_has_internal_span_kind(self) -> None:
+        """Non-GENERATION spans should have SpanKind.INTERNAL."""
+
+        @instrument(span_type=SpanAttributes.SpanType.RETRIEVAL)
+        def retrieve(query: str) -> list:
+            return ["doc1"]
+
+        @instrument()
+        def plain_func() -> str:
+            return "ok"
+
+        retrieve("test")
+        plain_func()
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 2)
+        self.assertEqual(spans[0].kind, SpanKind.INTERNAL)
+        self.assertEqual(spans[1].kind, SpanKind.INTERNAL)
+
+    def test_generation_span_exports_as_client_kind_in_proto(self) -> None:
+        """A GENERATION span should convert to SPAN_KIND_CLIENT in proto."""
+        from opentelemetry.proto.trace.v1.trace_pb2 import Span as SpanProto
+        from trulens.experimental.otel_tracing.core.exporter.utils import (
+            convert_readable_span_to_proto,
+        )
+
+        @instrument(span_type=SpanAttributes.SpanType.GENERATION)
+        def call_llm(prompt: str) -> str:
+            return "response"
+
+        call_llm("hello")
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        proto = convert_readable_span_to_proto(spans[0])
+        self.assertEqual(proto.kind, SpanProto.SpanKind.SPAN_KIND_CLIENT)

--- a/tests/unit/test_otel_tru_session.py
+++ b/tests/unit/test_otel_tru_session.py
@@ -1,13 +1,57 @@
+import os
 from typing import List
+from unittest import mock
 
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
 from trulens.apps.app import TruApp
 from trulens.core.otel.instrument import instrument
 from trulens.core.session import TruSession
 
 from tests.util.otel_test_case import OtelTestCase
 
+TRULENS_SERVICE_NAME = "trulens"
+
 
 class TestOtelTruSession(OtelTestCase):
+    def test_resource_attributes(self):
+        """Tracer provider resource should carry service.name,
+        service.version, and — when configured — deployment.environment."""
+        provider = trace.get_tracer_provider()
+        resource = provider.resource
+        self.assertEqual(resource.attributes["service.name"], "trulens")
+        self.assertIn("service.version", resource.attributes)
+        self.assertIsInstance(resource.attributes["service.version"], str)
+        self.assertTrue(len(resource.attributes["service.version"]) > 0)
+
+    def test_deployment_environment_absent_by_default(self):
+        """deployment.environment should be absent from the resource
+        when no TruLens-specific env var is set."""
+        provider = trace.get_tracer_provider()
+        self.assertNotIn("deployment.environment", provider.resource.attributes)
+
+    def test_deployment_environment_otel_resource_attributes_passthrough(self):
+        """OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production
+        should be picked up by Resource.create().
+
+        We test Resource.create() directly because
+        trace.set_tracer_provider() only takes effect once per process,
+        so calling _set_up_tracer_provider() a second time cannot
+        replace the global provider.
+        """
+        with mock.patch.dict(
+            os.environ,
+            {
+                "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=production",
+            },
+            clear=False,
+        ):
+            resource = Resource.create({"service.name": TRULENS_SERVICE_NAME})
+        self.assertEqual(
+            resource.attributes["deployment.environment"],
+            "production",
+        )
+
     def test_get_records_and_feedback(self):
         # Create app.
         class _TestApp:

--- a/tests/unit/test_virtual_run.py
+++ b/tests/unit/test_virtual_run.py
@@ -147,6 +147,87 @@ class TestVirtualRunMethods(OtelTestCase):
         # Verify OtelRecordingContext was called
         self.assertTrue(mock_otel_context.called)
 
+    def test_virtual_generation_span_has_client_kind(self):
+        """Virtual generation spans should get SpanKind.CLIENT, not INTERNAL."""
+        from opentelemetry.trace import SpanKind
+
+        mock_app = MagicMock()
+        mock_app.app = None
+        mock_app.app_name = "test_gen_kind"
+        mock_app.app_version = "1.0"
+
+        run = Run(
+            run_dao=MagicMock(spec=RunDaoBase),
+            app=mock_app,
+            main_method_name="virtual_main",
+            tru_session=MagicMock(),
+            object_name="TEST_APP",
+            object_type="EXTERNAL AGENT",
+            object_version="1.0",
+            run_name="test_gen_kind_run",
+            run_metadata=Run.RunMetadata(),
+            source_info=Run.SourceInfo(
+                name="TEST_TABLE",
+                column_spec={
+                    "record_root.input": "QUERY",
+                    "record_root.output": "OUTPUT",
+                    "generation.model": "MODEL",
+                },
+                source_type="TABLE",
+            ),
+        )
+
+        # Set up an InMemorySpanExporter to capture the actual spans.
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        exporter = InMemorySpanExporter()
+        provider = trace.get_tracer_provider()
+        processor = SimpleSpanProcessor(exporter)
+        provider.add_span_processor(processor)
+
+        try:
+            row = pd.Series({
+                "QUERY": "What is AI?",
+                "OUTPUT": "AI is...",
+                "MODEL": "gpt-4",
+            })
+            dataset_spec = {
+                "record_root.input": "QUERY",
+                "record_root.output": "OUTPUT",
+                "generation.model": "MODEL",
+            }
+
+            # Create spans within a real recording context so baggage is set.
+            from opentelemetry.baggage import set_baggage
+            import opentelemetry.context as context_api
+            from trulens.core.otel.recording import Recording
+
+            token = context_api.attach(
+                set_baggage("__trulens_recording__", Recording(None))
+            )
+            try:
+                run._create_nested_spans_from_dataset_spec(dataset_spec, row)
+            finally:
+                context_api.detach(token)
+
+            spans = exporter.get_finished_spans()
+            generation_spans = [
+                s for s in spans if "generation_virtual" in s.name
+            ]
+            self.assertEqual(len(generation_spans), 1)
+            self.assertEqual(generation_spans[0].kind, SpanKind.CLIENT)
+
+            # The record root should still be INTERNAL.
+            root_spans = [s for s in spans if "virtual_record" in s.name]
+            self.assertEqual(len(root_spans), 1)
+            self.assertEqual(root_spans[0].kind, SpanKind.INTERNAL)
+        finally:
+            processor.shutdown()
+
     def test_should_process_as_array(self):
         """Test array attribute detection by constant"""
         mock_app = MagicMock()

--- a/tests/util/otel_test_case.py
+++ b/tests/util/otel_test_case.py
@@ -118,7 +118,10 @@ class OtelTestCase(TruTestCase):
         self._convert_column_types(expected)
         if ignore_locators is None:
             ignore_locators = []
-        ignore_locators += ["[resource_attributes][telemetry.sdk.version]"]
+        ignore_locators += [
+            "[resource_attributes][telemetry.sdk.version]",
+            "[resource_attributes][service.version]",
+        ]
         compare_dfs_accounting_for_ids_and_timestamps(
             self,
             expected,


### PR DESCRIPTION
## Summary

Closes #2623

- **Exporter: propagate `span.kind` from SDK spans** — `convert_readable_span_to_proto` and `construct_event` previously hardcoded `SPAN_KIND_INTERNAL`. They now read `span.kind` via a `_SPAN_KIND_TO_PROTO` mapping. Without this change, setting `SpanKind` at span creation would have been silently discarded in both proto export and event construction.
- **Set `SpanKind.CLIENT` for GENERATION spans** — outbound LLM calls now get `SpanKind.CLIENT` per the [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/). All other span types remain `SpanKind.INTERNAL`.
- **Virtual/log-ingestion path** — `run.py:879` now passes `span_type=span_type_enum` to `create_function_call_context_manager`, so virtual `generation` spans also get `SpanKind.CLIENT`. Previously `SpanKind` was chosen at span creation but the span type was only applied afterward via `set_general_span_attributes`, which was too late to affect `SpanKind`.
- **Add `service.version` resource attribute** — resolved from `trulens-core` distribution metadata, guarded against `PackageNotFoundError` so tracing still starts in vendored/frozen environments. `ResourceAttributes.APP_VERSION` already carries the user's app version, so `service.version` fills the SDK-version gap without overlap.
- **Add opt-in `deployment.environment`** — set via `TRULENS_DEPLOYMENT_ENVIRONMENT` or `DEPLOYMENT_ENVIRONMENT` env vars. When unset, `Resource.create()` still honours the standard `OTEL_RESOURCE_ATTRIBUTES` variable.
- **Import placement constraint** — `_set_up_tracer_provider()` must resolve its imports at module level. Importing `trulens.core.utils.imports` lazily inside the function changes module-loading order and causes `test_otel_apps_table` to fail when run after the instrument tests (9 vs 10 entries in `tru_class_info.bases`). Noting it here since nothing in the code makes the constraint obvious.

## Test plan

- [x] `test_generation_span_has_client_span_kind` — GENERATION spans get `SpanKind.CLIENT`
- [x] `test_non_generation_span_has_internal_span_kind` — RETRIEVAL and default spans stay `INTERNAL`
- [x] `test_generation_span_exports_as_client_kind_in_proto` — proto conversion carries `SPAN_KIND_CLIENT`
- [x] `test_virtual_generation_span_has_client_kind` — virtual/log-ingested generation spans get `SpanKind.CLIENT`, root spans stay `INTERNAL`
- [x] `test_resource_attributes` — `service.name` and `service.version` present on provider resource
- [x] `test_deployment_environment_absent_by_default` — absent when no env var is set
- [x] `test_deployment_environment_otel_resource_attributes_passthrough` — `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production` passes through via `Resource.create()`
- [x] `test_otel_apps_table` — no regression in app table serialisation (verified baseline vs branch)
- [x] Golden files — parsed every CSV under `tests/unit/static/golden/`; all span records have `kind=1` (INTERNAL) and no golden test app produces GENERATION spans, so no regeneration needed

## Open question

Should `RETRIEVAL` spans also use `SpanKind.CLIENT`? Kept as `INTERNAL` here to match the acceptance criteria, but I'd lean toward `CLIENT` in a follow-up — vector DB queries are outbound calls over the network, same as LLM calls. Happy either way; flagging rather than expanding scope.

Unblocks #2627, which consumes `SpanKind.CLIENT` for generic LLM-call auto-instrumentation.