### PR TITLE
feat: span_group() context manager for per-segment metric localization

### DIFF
--- a/docs/component_guides/instrumentation/span_groups.md
+++ b/docs/component_guides/instrumentation/span_groups.md
@@ -1,0 +1,84 @@
+# Span Groups — Per-Segment Metric Localization
+
+When one metric matches multiple spans of the same type in a single trace — for
+example, groundedness over the 3 retrieval steps of a multi-hop RAG — the default
+behaviour pools all matched spans into one score or splits per item.  Neither
+gives a score per logical step.
+
+Span groups fix this.  Tag each step's spans with a group label, and
+`compute_feedback_by_span_group` runs the metric **once per group**, localizing
+a same-metric score to a logical segment of the trace.
+
+## Basic usage
+
+Use the `span_group()` context manager to tag every span created inside the
+block:
+
+```python
+from trulens.core.otel.instrument import instrument, span_group
+from trulens.otel.semconv.trace import SpanAttributes
+
+@instrument(
+    span_type=SpanAttributes.SpanType.RETRIEVAL,
+    attributes={
+        SpanAttributes.RETRIEVAL.QUERY_TEXT: "query",
+        SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS: "return",
+    },
+)
+def retrieve(query):
+    # your retrieval logic
+    ...
+
+with span_group("hop1"):
+    ctx1 = retrieve("query 1")
+with span_group("hop2"):
+    ctx2 = retrieve("query 2")
+with span_group("hop3"):
+    ctx3 = retrieve("query 3")
+```
+
+Each retrieval span will carry:
+
+```
+ai.observability.span_groups = ["hop1"]   # or ["hop2"], ["hop3"]
+```
+
+A single groundedness metric then produces three scores — one per hop —
+pinpointing which retrieval step was ungrounded.
+
+## Nesting
+
+Nesting `span_group()` calls merges the labels:
+
+```python
+with span_group("hop1"):
+    with span_group("retry"):
+        retrieve("q")    # SPAN_GROUPS = ["hop1", "retry"]
+```
+
+## How it works
+
+`span_group()` stores the current group name(s) in
+[OpenTelemetry Baggage](https://opentelemetry.io/docs/concepts/signals/baggage/).
+The `@instrument` decorator reads the baggage when building a span and sets
+`SpanAttributes.SPAN_GROUPS` automatically.  No manual argument threading is
+required — every instrumented call inside the block inherits the label.
+
+## Patterns this unlocks
+
+| Pattern | How to tag |
+|---------|-----------|
+| Per-hop quality in multi-hop RAG | `span_group("hop1")`, `span_group("hop2")`, … |
+| Per-source quality (web vs knowledge base) | `span_group("web")`, `span_group("kb")` |
+| Per-agent-turn quality in a multi-turn loop | `span_group("turn_1")`, `span_group("turn_2")`, … |
+| A/B testing two strategies in one trace | `span_group("strategy_a")`, `span_group("strategy_b")` |
+
+## Notes
+
+* The group name must be a string.
+* Spans created outside any `span_group()` block will not have
+  `SPAN_GROUPS` set, which is fully backwards-compatible.
+* The value is stored in OTEL Baggage during the context-manager lifetime and
+  does not leak across concurrent invocations that use different groups.
+* You can also set `SPAN_GROUPS` explicitly via the `attributes` parameter of
+  `@instrument` if you need a span's group to differ from the surrounding block.

--- a/examples/expositional/span_groups/span_groups_example.ipynb
+++ b/examples/expositional/span_groups/span_groups_example.ipynb
@@ -1,0 +1,284 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Span Groups — Per-Hop Metric Localization\n",
+    "\n",
+    "This notebook demonstrates how to use `span_group()` to get **per-hop**\n",
+    "groundedness scores in a multi-hop RAG pipeline, instead of one pooled score\n",
+    "across all retrieval steps.\n",
+    "\n",
+    "## The problem\n",
+    "\n",
+    "A multi-hop RAG pipeline performs several retrieval steps. By default, a\n",
+    "groundedness metric pools all retrieved contexts into one score. You can't\n",
+    "tell *which hop* was ungrounded.\n",
+    "\n",
+    "## The fix\n",
+    "\n",
+    "Tag each hop's spans with a `span_group()` label. `compute_feedback_by_span_group`\n",
+    "then runs the metric **once per group**, giving you per-hop scores."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"TRULENS_OTEL_TRACING\"] = \"1\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Define a simple multi-hop RAG app"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.core.otel.instrument import instrument, span_group\n",
+    "from trulens.otel.semconv.trace import SpanAttributes\n",
+    "\n",
+    "\n",
+    "@instrument(\n",
+    "    span_type=SpanAttributes.SpanType.RETRIEVAL,\n",
+    "    attributes={\n",
+    "        SpanAttributes.RETRIEVAL.QUERY_TEXT: \"query\",\n",
+    "        SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS: \"return\",\n",
+    "    },\n",
+    ")\n",
+    "def retrieve(query: str) -> list:\n",
+    "    \"\"\"Simulated retrieval — returns dummy contexts.\"\"\"\n",
+    "    return [f\"Context for: {query}\"]\n",
+    "\n",
+    "\n",
+    "@instrument()\n",
+    "def multi_hop_rag(question: str) -> str:\n",
+    "    \"\"\"A 3-hop retrieval pipeline.\"\"\"\n",
+    "    with span_group(\"hop1\"):\n",
+    "        ctx1 = retrieve(question)\n",
+    "    with span_group(\"hop2\"):\n",
+    "        ctx2 = retrieve(f\"Follow-up based on {ctx1}\")\n",
+    "    with span_group(\"hop3\"):\n",
+    "        ctx3 = retrieve(f\"Final refinement from {ctx2}\")\n",
+    "\n",
+    "    all_context = ctx1 + ctx2 + ctx3\n",
+    "    return f\"Answer based on {len(all_context)} contexts\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Record a trace"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.apps.app import TruApp\n",
+    "from trulens.core.session import TruSession\n",
+    "\n",
+    "session = TruSession()\n",
+    "session.reset_database()\n",
+    "\n",
+    "tru_app = TruApp(\n",
+    "    multi_hop_rag,\n",
+    "    app_name=\"MultiHopRAG\",\n",
+    "    app_version=\"v1\",\n",
+    ")\n",
+    "\n",
+    "with tru_app as recording:\n",
+    "    result = multi_hop_rag(\"What is TruLens?\")\n",
+    "\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Inspect the span groups\n",
+    "\n",
+    "Each retrieval span now carries a distinct `SPAN_GROUPS` label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "import pandas as pd\n",
+    "import sqlalchemy as sa\n",
+    "\n",
+    "session.force_flush()\n",
+    "\n",
+    "db = session.connector.db\n",
+    "with db.session.begin() as db_session:\n",
+    "    events = pd.read_sql(\n",
+    "        sa.select(db.orm.Event).order_by(db.orm.Event.start_timestamp),\n",
+    "        db_session.bind,\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def _parse(val):\n",
+    "    return val if isinstance(val, dict) else json.loads(val)\n",
+    "\n",
+    "\n",
+    "for _, row in events.iterrows():\n",
+    "    attrs = _parse(row[\"record_attributes\"])\n",
+    "    record = _parse(row[\"record\"])\n",
+    "    groups = attrs.get(SpanAttributes.SPAN_GROUPS, \"(none)\")\n",
+    "    span_type = attrs.get(SpanAttributes.SPAN_TYPE, \"\")\n",
+    "    print(f\"{record['name']:50s}  type={span_type:15s}  groups={groups}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Compute per-hop groundedness\n",
+    "\n",
+    "`compute_feedback_by_span_group` runs the metric once per group.\n",
+    "Instead of one pooled score, you get three — one per hop — plus one\n",
+    "pooled score across all hops."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.core.feedback.selector import Selector\n",
+    "from trulens.core.metric.metric import Metric\n",
+    "from trulens.feedback.computer import compute_feedback_by_span_group\n",
+    "\n",
+    "\n",
+    "def mock_groundedness(query_text: str, retrieved_contexts: list) -> float:\n",
+    "    \"\"\"Deterministic mock keyed on query content.\n",
+    "\n",
+    "    In production, replace with an LLM-based groundedness check.\n",
+    "    Scores are stable regardless of call order because they're\n",
+    "    determined by the query, which is unique per hop.\n",
+    "    Check \"Final refinement\" before \"Follow-up\" because hop3's\n",
+    "    query contains both substrings (from the nested context).\n",
+    "    \"\"\"\n",
+    "    if query_text is None:\n",
+    "        return 0.5  # pooled call with unresolved query\n",
+    "    if \"Final refinement\" in query_text:\n",
+    "        return 0.8  # hop3 — okay\n",
+    "    if \"Follow-up\" in query_text:\n",
+    "        return 0.4  # hop2 — poorly grounded\n",
+    "    return 0.9  # hop1 — well grounded\n",
+    "\n",
+    "\n",
+    "f_groundedness = Metric(\n",
+    "    implementation=mock_groundedness,\n",
+    "    name=\"Groundedness\",\n",
+    "    higher_is_better=True,\n",
+    ").on(\n",
+    "    {\n",
+    "        \"query_text\": Selector(\n",
+    "            span_attribute=SpanAttributes.RETRIEVAL.QUERY_TEXT,\n",
+    "        ),\n",
+    "        \"retrieved_contexts\": Selector(\n",
+    "            span_attribute=SpanAttributes.RETRIEVAL.RETRIEVED_CONTEXTS,\n",
+    "        ),\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "compute_feedback_by_span_group(events, f_groundedness)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. View per-hop scores\n",
+    "\n",
+    "Each `eval_root` span carries `eval_root.span_group` (the hop label)\n",
+    "and `eval_root.score` (the per-hop score).\n",
+    "\n",
+    "The `(pooled)` score is computed without span groups — it tries to\n",
+    "collapse all three retrieval spans into one input, but `query_text`\n",
+    "can't resolve to a single value across hops, so the mock receives\n",
+    "`None`. That's exactly the problem span groups solve: pooling doesn't\n",
+    "just hide which hop failed, it can't even construct a coherent input.\n",
+    "\n",
+    "Expected output:\n",
+    "```\n",
+    "  (pooled)      score=0.5\n",
+    "  hop1          score=0.9\n",
+    "  hop2          score=0.4\n",
+    "  hop3          score=0.8\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session.force_flush()\n",
+    "\n",
+    "with db.session.begin() as db_session:\n",
+    "    updated_events = pd.read_sql(\n",
+    "        sa.select(db.orm.Event).order_by(db.orm.Event.start_timestamp),\n",
+    "        db_session.bind,\n",
+    "    )\n",
+    "\n",
+    "for _, row in updated_events.iterrows():\n",
+    "    attrs = _parse(row[\"record_attributes\"])\n",
+    "    if SpanAttributes.EVAL_ROOT.SCORE in attrs:\n",
+    "        hop = attrs.get(SpanAttributes.EVAL_ROOT.SPAN_GROUP, \"(pooled)\")\n",
+    "        score = attrs[SpanAttributes.EVAL_ROOT.SCORE]\n",
+    "        print(f\"  {hop:12s}  score={score}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Without `span_group()`, the same metric produces one pooled score that\n",
+    "can't even resolve a coherent `query_text` across three different hops.\n",
+    "\n",
+    "With span groups, each hop gets its own score:\n",
+    "- `hop1: 0.9` — well grounded\n",
+    "- `hop2: 0.4` — poorly grounded ← the problem is localized\n",
+    "- `hop3: 0.8` — okay\n",
+    "\n",
+    "This is the per-segment localization that span groups enable."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/expositional/span_groups/span_groups_example.ipynb
+++ b/examples/expositional/span_groups/span_groups_example.ipynb
@@ -23,17 +23,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "os.environ[\"TRULENS_OTEL_TRACING\"] = \"1\""
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -241,6 +241,7 @@ nav:
         - component_guides/instrumentation/langgraph.md
         - component_guides/instrumentation/llama_index.md
         - MCP: component_guides/instrumentation/mcp.md
+        - Span Groups: component_guides/instrumentation/span_groups.md
     - Logging:
         - component_guides/logging/where_to_log/index.md
         - Postgres: component_guides/logging/where_to_log/log_in_postgres.md

--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextvars import ContextVar
 import inspect
 import logging
 import types
@@ -79,6 +80,49 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+# ContextVar holding the current span-group stack as a tuple of strings.
+# Using a tuple (immutable) so that each ContextVar token captures a
+# snapshot — no shared-mutable-state bugs across concurrent contexts.
+_current_span_groups: ContextVar[Tuple[str, ...]] = ContextVar(
+    "_current_span_groups", default=()
+)
+
+
+class span_group:
+    """Context manager that tags every span created inside the block with
+    a group label via ``SpanAttributes.SPAN_GROUPS``.
+
+    Uses a ``contextvars.ContextVar`` — no OTEL baggage, no cross-process
+    propagation.  Span groups are an in-process concept.
+
+    Example::
+
+        with span_group("hop1"):
+            ctx1 = retrieve("query 1")   # span gets SPAN_GROUPS=["hop1"]
+        with span_group("hop2"):
+            ctx2 = retrieve("query 2")   # span gets SPAN_GROUPS=["hop2"]
+
+    Nesting merges groups::
+
+        with span_group("hop1"):
+            with span_group("retry"):
+                retrieve("q")            # SPAN_GROUPS=["hop1", "retry"]
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._token = None
+
+    def __enter__(self):
+        existing = _current_span_groups.get()
+        self._token = _current_span_groups.set(existing + (self.name,))
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._token is not None:
+            _current_span_groups.reset(self._token)
+            self._token = None
 
 
 def get_func_name(func: Callable) -> str:

--- a/src/core/trulens/experimental/otel_tracing/core/span.py
+++ b/src/core/trulens/experimental/otel_tracing/core/span.py
@@ -177,6 +177,14 @@ def set_general_span_attributes(
     set_string_span_attribute_from_baggage(
         span, SpanAttributes.CONVERSATION_ID, context
     )
+    # SPAN_GROUPS is read from a ContextVar (not baggage) and stored as a
+    # list attribute.  The ContextVar is managed by span_group() in
+    # trulens.core.otel.instrument.
+    from trulens.core.otel.instrument import _current_span_groups
+
+    groups = _current_span_groups.get()
+    if groups:
+        span.set_attribute(SpanAttributes.SPAN_GROUPS, list(groups))
 
 
 def set_function_call_attributes(

--- a/tests/unit/test_otel_instrument.py
+++ b/tests/unit/test_otel_instrument.py
@@ -16,6 +16,7 @@ import pandas as pd
 from trulens.core.otel.instrument import get_func_name
 from trulens.core.otel.instrument import instrument
 from trulens.core.otel.instrument import instrument_method
+from trulens.core.otel.instrument import span_group
 from trulens.core.otel.recording import Recording
 from trulens.experimental.otel_tracing.core.session import (
     _set_up_tracer_provider,
@@ -367,3 +368,121 @@ class TestOtelInstrument(unittest.TestCase):
         self.assertEqual(result, "TRULENS")
         spans = self.exporter.get_finished_spans()
         self.assertEqual(len(spans), 1)
+
+    def test_span_group_three_hops_get_distinct_groups(self) -> None:
+        """Three sequential span_group blocks produce three spans
+        with distinct group labels — the core per-hop localization
+        use case."""
+
+        @instrument()
+        def retrieve(query: str) -> str:
+            return f"result for {query}"
+
+        with span_group("hop1"):
+            retrieve("q1")
+        with span_group("hop2"):
+            retrieve("q2")
+        with span_group("hop3"):
+            retrieve("q3")
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 3)
+        # SPAN_GROUPS must be a tuple (OTel SDK converts list→tuple),
+        # not a stringified list — compute_feedback_by_span_group
+        # branches on isinstance(span_groups, str).
+        for s in spans:
+            self.assertIsInstance(
+                s.attributes[SpanAttributes.SPAN_GROUPS], tuple
+            )
+        self.assertEqual(
+            spans[0].attributes[SpanAttributes.SPAN_GROUPS], ("hop1",)
+        )
+        self.assertEqual(
+            spans[1].attributes[SpanAttributes.SPAN_GROUPS], ("hop2",)
+        )
+        self.assertEqual(
+            spans[2].attributes[SpanAttributes.SPAN_GROUPS], ("hop3",)
+        )
+
+    def test_span_group_nesting_merges(self) -> None:
+        """Nested span_group() calls should merge group labels."""
+
+        @instrument()
+        def retrieve(query: str) -> str:
+            return f"result for {query}"
+
+        with span_group("hop1"):
+            with span_group("retry"):
+                retrieve("q")
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(
+            spans[0].attributes[SpanAttributes.SPAN_GROUPS],
+            ("hop1", "retry"),
+        )
+
+    def test_span_group_resets_on_exit(self) -> None:
+        """After the with block exits, spans must not carry the group.
+        Verifies the ContextVar token is properly reset."""
+
+        @instrument()
+        def retrieve(query: str) -> str:
+            return f"result for {query}"
+
+        with span_group("hop1"):
+            retrieve("q1")
+        # This span is created OUTSIDE the span_group block.
+        retrieve("q2")
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 2)
+        self.assertEqual(
+            spans[0].attributes[SpanAttributes.SPAN_GROUPS], ("hop1",)
+        )
+        self.assertNotIn(SpanAttributes.SPAN_GROUPS, spans[1].attributes)
+
+    def test_span_group_resets_after_exception(self) -> None:
+        """If the body of a span_group block raises, the group must
+        still be cleared — no leaking into downstream spans."""
+
+        @instrument()
+        def retrieve(query: str) -> str:
+            return f"result for {query}"
+
+        with self.assertRaises(ValueError):
+            with span_group("x"):
+                raise ValueError("boom")
+
+        retrieve("after_exception")
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertNotIn(SpanAttributes.SPAN_GROUPS, spans[0].attributes)
+
+    def test_span_group_propagates_through_nested_calls(self) -> None:
+        """span_group() must tag all spans inside the block,
+        including nested instrumented calls multiple stack frames
+        deep — without threading an argument."""
+
+        @instrument()
+        def leaf() -> str:
+            return "leaf"
+
+        @instrument()
+        def middle() -> str:
+            return leaf()
+
+        @instrument()
+        def top() -> str:
+            return middle()
+
+        with span_group("group_a"):
+            top()
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 3)
+        for s in spans:
+            self.assertEqual(
+                s.attributes[SpanAttributes.SPAN_GROUPS], ("group_a",)
+            )


### PR DESCRIPTION
## Summary

Closes #2620

### Mechanism: `contextvars.ContextVar`, not OTEL baggage

Per the issue's explicit instruction, `span_group()` uses a `ContextVar[Tuple[str, ...]]` — span groups are an in-process concept and don't need cross-process propagation. The ContextVar `_current_span_groups` holds an immutable tuple; `__enter__` appends and saves the token; `__exit__` resets it. `set_general_span_attributes()` reads from the ContextVar and stores `SPAN_GROUPS` as a list attribute (not stringified — `compute_feedback_by_span_group` branches on `isinstance(span_groups, str)`).

### Changes

- **`span_group()` context manager** in `instrument.py` — tags every span inside the block with `SpanAttributes.SPAN_GROUPS`. Nesting merges labels. Cleanup is automatic via `ContextVar.reset()`.
- **`set_general_span_attributes()` wiring** in `span.py` — reads `_current_span_groups` and sets the attribute as a list.
- **Docs** — `docs/component_guides/instrumentation/span_groups.md` following the `conversation_id.md` pattern, added to mkdocs nav.
- **Example notebook** — `examples/expositional/span_groups/span_groups_example.ipynb`, a multi-hop RAG that produces per-hop groundedness scores. Executed end-to-end: `hop1: 0.9, hop2: 0.4, hop3: 0.8` — matching the issue's example. The pooled score receives `query_text=None` (can't collapse three hops into one input), illustrating why span groups are needed.

### Not in this PR

Deliverable #4 (trace-viewer span-group labels in `record_viewer_otel`) — [scope question posted on the issue](https://github.com/truera/trulens/issues/2620#issuecomment-5074918018), pending maintainer's call on whether it belongs in this PR or a follow-up.

## Test plan

- [x] `test_span_group_three_hops_get_distinct_groups` — three sequential blocks produce three spans with distinct group labels; type assertion confirms tuple, not stringified list
- [x] `test_span_group_nesting_merges` — nested blocks produce `("hop1", "retry")`
- [x] `test_span_group_resets_on_exit` — span outside the block has no `SPAN_GROUPS`
- [x] `test_span_group_resets_after_exception` — group doesn't leak when body raises
- [x] `test_span_group_propagates_through_nested_calls` — three stack frames deep, all spans tagged without argument threading
- [x] Notebook executed end-to-end via `nbconvert --to script | python`, producing `(pooled) 0.5 / hop1 0.9 / hop2 0.4 / hop3 0.8` through `compute_feedback_by_span_group`