### PR TITLE
docs: add agentic evaluation cookbook notebook (closes #2414)

### DIFF
--- a/examples/cookbooks/agentic_evaluations.ipynb
+++ b/examples/cookbooks/agentic_evaluations.ipynb
@@ -1,0 +1,441 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# 📓 Agentic Evaluation Cookbook\n",
+    "\n",
+    "Build a small ReAct-style agent that answers questions using two tools (a\n",
+    "calculator and a fact lookup), instrument it with TruLens, and evaluate its\n",
+    "behavior with all 7 agentic evaluators:\n",
+    "\n",
+    "1. **Plan Quality** — is the agent's plan sound?\n",
+    "2. **Plan Adherence** — did the agent follow its plan?\n",
+    "3. **Execution Efficiency** — did the agent avoid redundant steps?\n",
+    "4. **Logical Consistency** — are the agent's steps and conclusions consistent?\n",
+    "5. **Tool Selection** — did the agent pick the right tool for each step?\n",
+    "6. **Tool Calling** — were the tools called with correct arguments?\n",
+    "7. **Tool Quality** — did the tool results support the final answer?\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/truera/trulens/blob/main/examples/cookbooks/agentic_evaluations.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "install",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install trulens trulens-providers-openai openai -q"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "api-key",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if \"OPENAI_API_KEY\" not in os.environ:\n",
+    "    os.environ[\"OPENAI_API_KEY\"] = \"sk-proj-...\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tools-header",
+   "metadata": {},
+   "source": [
+    "## 1. Define tools\n",
+    "\n",
+    "The agent has access to a calculator (arithmetic only, safely evaluated via\n",
+    "`ast` rather than `eval`) and a small fact lookup table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "tools",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ast\n",
+    "import operator\n",
+    "\n",
+    "_OPS = {\n",
+    "    ast.Add: operator.add,\n",
+    "    ast.Sub: operator.sub,\n",
+    "    ast.Mult: operator.mul,\n",
+    "    ast.Div: operator.truediv,\n",
+    "    ast.Pow: operator.pow,\n",
+    "    ast.USub: operator.neg,\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def _eval_node(node):\n",
+    "    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):\n",
+    "        return node.value\n",
+    "    if isinstance(node, ast.BinOp) and type(node.op) in _OPS:\n",
+    "        return _OPS[type(node.op)](\n",
+    "            _eval_node(node.left), _eval_node(node.right)\n",
+    "        )\n",
+    "    if isinstance(node, ast.UnaryOp) and type(node.op) in _OPS:\n",
+    "        return _OPS[type(node.op)](_eval_node(node.operand))\n",
+    "    raise ValueError(f\"Unsupported expression: {ast.dump(node)}\")\n",
+    "\n",
+    "\n",
+    "def calculator(expression: str) -> str:\n",
+    "    \"\"\"Safely evaluate a basic arithmetic expression.\"\"\"\n",
+    "    try:\n",
+    "        tree = ast.parse(expression, mode=\"eval\")\n",
+    "        return str(_eval_node(tree.body))\n",
+    "    except Exception as e:\n",
+    "        return f\"Error: {e}\"\n",
+    "\n",
+    "\n",
+    "KNOWLEDGE_BASE = {\n",
+    "    \"boiling point of water\": \"100 degrees Celsius at sea level\",\n",
+    "    \"speed of light\": \"299,792,458 meters per second\",\n",
+    "    \"population of france\": \"about 68 million (2024 estimate)\",\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def lookup_fact(topic: str) -> str:\n",
+    "    \"\"\"Look up a known fact by topic.\"\"\"\n",
+    "    return KNOWLEDGE_BASE.get(\n",
+    "        topic.lower().strip(), f\"No fact found for '{topic}'.\"\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "TOOL_IMPLS = {\"calculator\": calculator, \"lookup_fact\": lookup_fact}\n",
+    "\n",
+    "TOOLS_SCHEMA = [\n",
+    "    {\n",
+    "        \"type\": \"function\",\n",
+    "        \"function\": {\n",
+    "            \"name\": \"calculator\",\n",
+    "            \"description\": \"Evaluate a basic arithmetic expression, e.g. '12 * (4 + 1)'.\",\n",
+    "            \"parameters\": {\n",
+    "                \"type\": \"object\",\n",
+    "                \"properties\": {\"expression\": {\"type\": \"string\"}},\n",
+    "                \"required\": [\"expression\"],\n",
+    "            },\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"type\": \"function\",\n",
+    "        \"function\": {\n",
+    "            \"name\": \"lookup_fact\",\n",
+    "            \"description\": \"Look up a known fact by topic, e.g. 'speed of light'.\",\n",
+    "            \"parameters\": {\n",
+    "                \"type\": \"object\",\n",
+    "                \"properties\": {\"topic\": {\"type\": \"string\"}},\n",
+    "                \"required\": [\"topic\"],\n",
+    "            },\n",
+    "        },\n",
+    "    },\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "agent-header",
+   "metadata": {},
+   "source": [
+    "## 2. Build the ReAct agent\n",
+    "\n",
+    "Each planning call and tool call is instrumented with `@instrument` so the\n",
+    "full reasoning trace is captured, not just the final answer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "agent",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "from openai import OpenAI as OpenAIClient\n",
+    "from trulens.core.otel.instrument import instrument\n",
+    "from trulens.otel.semconv.trace import SpanAttributes\n",
+    "\n",
+    "client = OpenAIClient()\n",
+    "\n",
+    "MAX_STEPS = 5\n",
+    "\n",
+    "\n",
+    "class ReActAgent:\n",
+    "    SYSTEM_PROMPT = (\n",
+    "        \"You are a ReAct-style agent. Use the available tools to answer the \"\n",
+    "        \"user's question step by step. Call a tool whenever you need a fact \"\n",
+    "        \"or a calculation; otherwise respond with the final answer directly.\"\n",
+    "    )\n",
+    "\n",
+    "    @instrument(span_type=SpanAttributes.SpanType.TOOL)\n",
+    "    def call_tool(self, name: str, arguments: dict) -> str:\n",
+    "        return TOOL_IMPLS[name](**arguments)\n",
+    "\n",
+    "    @instrument(span_type=SpanAttributes.SpanType.GENERATION)\n",
+    "    def plan_step(self, messages: list):\n",
+    "        response = client.chat.completions.create(\n",
+    "            model=\"gpt-4o\",\n",
+    "            messages=messages,\n",
+    "            tools=TOOLS_SCHEMA,\n",
+    "        )\n",
+    "        return response.choices[0].message\n",
+    "\n",
+    "    @instrument(\n",
+    "        span_type=SpanAttributes.SpanType.RECORD_ROOT,\n",
+    "        attributes={\n",
+    "            SpanAttributes.RECORD_ROOT.INPUT: \"query\",\n",
+    "            SpanAttributes.RECORD_ROOT.OUTPUT: \"return\",\n",
+    "        },\n",
+    "    )\n",
+    "    def run(self, query: str) -> str:\n",
+    "        messages = [\n",
+    "            {\"role\": \"system\", \"content\": self.SYSTEM_PROMPT},\n",
+    "            {\"role\": \"user\", \"content\": query},\n",
+    "        ]\n",
+    "        for _ in range(MAX_STEPS):\n",
+    "            message = self.plan_step(messages)\n",
+    "            if not message.tool_calls:\n",
+    "                return message.content or \"\"\n",
+    "            messages.append(message.model_dump(exclude_none=True))\n",
+    "            for tool_call in message.tool_calls:\n",
+    "                arguments = json.loads(tool_call.function.arguments)\n",
+    "                result = self.call_tool(tool_call.function.name, arguments)\n",
+    "                messages.append({\n",
+    "                    \"role\": \"tool\",\n",
+    "                    \"tool_call_id\": tool_call.id,\n",
+    "                    \"content\": result,\n",
+    "                })\n",
+    "        return \"Could not reach a final answer within the step limit.\"\n",
+    "\n",
+    "\n",
+    "agent = ReActAgent()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "trulens-header",
+   "metadata": {},
+   "source": [
+    "## 3. Set up TruLens logging"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "trulens-setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.core import TruSession\n",
+    "\n",
+    "session = TruSession()\n",
+    "session.reset_database()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eval-header",
+   "metadata": {},
+   "source": [
+    "## 4. Add the 7 agentic evaluators\n",
+    "\n",
+    "Each evaluator is a `Metric` bound to the full trace via\n",
+    "`Selector(trace_level=True)`, so the LLM judge sees every planning and tool\n",
+    "call step, not just the final input/output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eval",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.core import Metric\n",
+    "from trulens.core import Selector\n",
+    "from trulens.providers.openai import OpenAI\n",
+    "\n",
+    "provider = OpenAI(model_engine=\"gpt-4.1\")\n",
+    "trace_selector = {\"trace\": Selector(trace_level=True)}\n",
+    "\n",
+    "f_plan_quality = Metric(\n",
+    "    implementation=provider.plan_quality_with_cot_reasons,\n",
+    "    name=\"Plan Quality\",\n",
+    ").on(trace_selector)\n",
+    "\n",
+    "f_plan_adherence = Metric(\n",
+    "    implementation=provider.plan_adherence_with_cot_reasons,\n",
+    "    name=\"Plan Adherence\",\n",
+    ").on(trace_selector)\n",
+    "\n",
+    "f_execution_efficiency = Metric(\n",
+    "    implementation=provider.execution_efficiency_with_cot_reasons,\n",
+    "    name=\"Execution Efficiency\",\n",
+    ").on(trace_selector)\n",
+    "\n",
+    "f_logical_consistency = Metric(\n",
+    "    implementation=provider.logical_consistency_with_cot_reasons,\n",
+    "    name=\"Logical Consistency\",\n",
+    ").on(trace_selector)\n",
+    "\n",
+    "f_tool_selection = Metric(\n",
+    "    implementation=provider.tool_selection_with_cot_reasons,\n",
+    "    name=\"Tool Selection\",\n",
+    ").on(trace_selector)\n",
+    "\n",
+    "f_tool_calling = Metric(\n",
+    "    implementation=provider.tool_calling_with_cot_reasons,\n",
+    "    name=\"Tool Calling\",\n",
+    ").on(trace_selector)\n",
+    "\n",
+    "f_tool_quality = Metric(\n",
+    "    implementation=provider.tool_quality_with_cot_reasons,\n",
+    "    name=\"Tool Quality\",\n",
+    ").on(trace_selector)\n",
+    "\n",
+    "feedbacks = [\n",
+    "    f_plan_quality,\n",
+    "    f_plan_adherence,\n",
+    "    f_execution_efficiency,\n",
+    "    f_logical_consistency,\n",
+    "    f_tool_selection,\n",
+    "    f_tool_calling,\n",
+    "    f_tool_quality,\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "register-header",
+   "metadata": {},
+   "source": [
+    "## 5. Register the agent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "register",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.apps.app import TruApp\n",
+    "\n",
+    "tru_agent = TruApp(\n",
+    "    agent,\n",
+    "    app_name=\"ReAct Agentic Eval Demo\",\n",
+    "    app_version=\"base\",\n",
+    "    feedbacks=feedbacks,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "run-header",
+   "metadata": {},
+   "source": [
+    "## 6. Run the agent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "run",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_queries = [\n",
+    "    \"What is the boiling point of water, in Fahrenheit?\",\n",
+    "    \"What is the speed of light divided by 1000?\",\n",
+    "    \"What is the population of France plus 12345?\",\n",
+    "]\n",
+    "\n",
+    "with tru_agent as recording:\n",
+    "    for query in test_queries:\n",
+    "        answer = agent.run(query)\n",
+    "        print(f\"Q: {query}\")\n",
+    "        print(f\"A: {answer}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "results-header",
+   "metadata": {},
+   "source": [
+    "## 7. View evaluation results\n",
+    "\n",
+    "You may need to run this cell a few times to see full results, as the LLM\n",
+    "judge evaluations take time to compute."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "leaderboard",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session.get_leaderboard()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dashboard-header",
+   "metadata": {},
+   "source": [
+    "## 8. Visualize traces in the dashboard\n",
+    "\n",
+    "The dashboard renders each recorded trace — planning steps, tool calls, and\n",
+    "the final answer — alongside the score each agentic evaluator assigned."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dashboard",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.dashboard import run_dashboard\n",
+    "\n",
+    "run_dashboard(session)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "summary",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "The 7 agentic evaluators all read the full recorded trace rather than a\n",
+    "single input/output pair, which lets them judge things a record-level\n",
+    "feedback function can't: whether the agent's plan made sense, whether it\n",
+    "stuck to that plan, whether it picked the right tool at each step, and\n",
+    "whether the tool outputs actually supported the final answer."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Adds `examples/cookbooks/agentic_evaluations.ipynb`, a self-contained cookbook demonstrating all 7 agentic evaluators against a small ReAct-style tool-calling agent:

- Plan Quality
- Plan Adherence
- Execution Efficiency
- Logical Consistency
- Tool Selection
- Tool Calling
- Tool Quality

The agent has two tools (a safely-evaluated calculator and a fact lookup) and is instrumented with `@instrument` on its planning and tool-call steps, so the full trace — not just the final input/output — is available to the trace-level evaluators via `Selector(trace_level=True)`. The notebook wraps the agent with `TruApp`, runs a few example queries, and shows results via the leaderboard and the TruLens dashboard (trace visualization).

Closes #2414

## Test plan

- [x] All code cells parse as valid Python (`ast.parse`)
- [x] Verified imports resolve against `trulens-core`, `trulens-providers-openai`, `trulens-dashboard`, `trulens-apps-*`
- [x] Dry-ran the full ReAct loop and TruLens instrumentation/recording wiring with a mocked LLM client (no real API key available in this environment) — agent logic, `@instrument` decorators, and `TruApp` registration all work end-to-end
- [x] Unit-tested the calculator tool, including rejecting code-injection attempts (e.g. `__import__(...)`)
- [x] Ran the repo's pre-commit hooks (`ruff`, `ruff-format`, `nb-clean`) against the notebook — all pass
- [x] Notebook contains no cell outputs, per `docs/contributing/standards.md`