### PR TITLE
docs(blog): fix two broken links in the 2.6 release post

### DIFF
--- a/docs/blog/posts/release_blog_2dot6.md
+++ b/docs/blog/posts/release_blog_2dot6.md
@@ -63,7 +63,7 @@ When you use your favorite coding assistant to work on TruLens, your assistant a
 
 This means your AI assistant can help you write code that passes CI on the first try, follows our conventions, and fits naturally into the codebase architecture.
 
-**Want to contribute?** Check out our updated [contribution guide](https://www.trulens.org/contributing/) and let your AI assistant handle the style details.
+**Want to contribute?** Check out our updated [contribution guide](https://www.trulens.org/contributing/development/) and let your AI assistant handle the style details.
 
 ---
 
@@ -150,7 +150,7 @@ Ready to try TruLens 2.6?
 - [TruLens Documentation](https://www.trulens.org/)
 - [GitHub Repository](https://github.com/truera/trulens)
 - [Quickstart Notebook](https://github.com/truera/trulens/tree/main/examples/quickstart)
-- [PostgreSQL Setup Guide](https://www.trulens.org/component_guides/logging/where_to_log/postgres/)
+- [PostgreSQL Setup Guide](https://www.trulens.org/component_guides/logging/where_to_log/log_in_postgres/)
 
 ---
 **Have feedback or feature requests?** Open an [issue](https://github.com/truera/trulens/issues) or [discussion](https://github.com/truera/trulens/discussions) on GitHub.


### PR DESCRIPTION
## Summary

The 2.6 release blog post contains two links that currently 404. Verified with `curl` against the live docs site (`www.trulens.org`).

| Original | Status | Replacement | Status |
| --- | --- | --- | --- |
| `/contributing/` | 404 | `/contributing/development/` | 200 |
| `/component_guides/logging/where_to_log/postgres/` | 404 | `/component_guides/logging/where_to_log/log_in_postgres/` | 200 |

## Why these replacements

- **Contribution guide** — the `Contributing` node in `mkdocs.yml` is a section header (no top-level `index.md`), so `/contributing/` doesn't render a page. `Development Setup` is the closest first-touch page for a reader who's just been told "want to contribute?" in the AI-assistant section above.
- **PostgreSQL guide** — the sibling page `log_in_postgres/` (referenced correctly earlier in the same post at line 94) is the actual page name matching the mkdocs nav entry, and returns 200.

## Testing

```
$ for url in \
    https://www.trulens.org/contributing/development/ \
    https://www.trulens.org/component_guides/logging/where_to_log/log_in_postgres/; do
    curl -o /dev/null -s -w "%{http_code} $url\n" -L "$url"
  done
200 https://www.trulens.org/contributing/development/
200 https://www.trulens.org/component_guides/logging/where_to_log/log_in_postgres/
```

## Scope

Docs-only, single file, no code paths touched.