### PR TITLE
fix(conda): bump meta.yaml recipe versions and sha256 hashes to 2.10.0

### DIFF
--- a/src/apps/langchain/meta.yaml
+++ b/src/apps/langchain/meta.yaml
@@ -11,7 +11,7 @@ source:
   # path: .
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-apps-langchain/#files
-  sha256: 176edb2932091b384f2a651f5cb1bd57bd4c7520ff298e1b640a5b660604312a
+  sha256: a0c56f39c39888754cc28b5f7d66b8fe6fc2a943bf533e0163d1cac7aed9c64d
 
 build:
   noarch: python

--- a/src/apps/langchain/meta.yaml
+++ b/src/apps/langchain/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-apps-langchain" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.9.0" %}
+{% set version = "2.10.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/apps/langgraph/meta.yaml
+++ b/src/apps/langgraph/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-apps-langgraph" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.9.0" %}
+{% set version = "2.10.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/apps/langgraph/meta.yaml
+++ b/src/apps/langgraph/meta.yaml
@@ -11,7 +11,7 @@ source:
   # path: .
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-apps-langgraph/#files
-  sha256: b9943a312c122425bff49b8e70ceb8126fa5f95ad38143a4d2e852a224c2d703
+  sha256: 827e20a003d0f4d9f9b121868e8ef9c4dcb7dd6965d7dc48f79d6179a9e332dd
 
 build:
   noarch: python

--- a/src/connectors/snowflake/meta.yaml
+++ b/src/connectors/snowflake/meta.yaml
@@ -12,7 +12,7 @@ source:
   {% else %}
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-connectors-snowflake/#files
-  sha256: 6e0b052f44d02c50ca4d8dd0c4915551450f32a1018ad74766481f4797c07d86
+  sha256: a685bd26c00f56a18f6f8a9b6d56215df821b91f01837014940943538cbfb417
   {% endif %}
 
 build:

--- a/src/connectors/snowflake/meta.yaml
+++ b/src/connectors/snowflake/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-connectors-snowflake" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.9.0" %}
+{% set version = "2.10.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-core" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.9.0" %}
+{% set version = "2.10.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -12,7 +12,7 @@ source:
   {% else %}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-core/#files
-  sha256: 957149cc68856d4f3cb4e7c734a10ef35e2111e8c1d9cd6ba236b8f8a4e18430
+  sha256: 37c3f5d51a035177f81998c2dd6ea4552573f60224ad074d4881b1d5a787f2d1
   {% endif %}
 
 build:

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -12,7 +12,7 @@ source:
   {% else %}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-dashboard/#files
-  sha256: 3451d331d5d84850a7de98374b414acbee024b7256dfddc821d31e3a6bd6ed28
+  sha256: 968fa54c8ec685c7028b57375eadb9da7139b7885f77aaaab40b24cb1d74a190
   {% endif %}
 
 build:

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-dashboard" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.9.0" %}
+{% set version = "2.10.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/feedback/meta.yaml
+++ b/src/feedback/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-feedback" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.9.0" %}
+{% set version = "2.10.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/feedback/meta.yaml
+++ b/src/feedback/meta.yaml
@@ -12,7 +12,7 @@ source:
   {% else %}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-feedback/#files
-  sha256: db477eb2b187f6a609d82d8fb2afa927e083d00e46f2aef90fb260e0a7e18b2c
+  sha256: 5e14aadacfb73dfc3ccc9fc8d9180434eaa5dde2a5a8a6187ad3e5a5a351fb56
   {% endif %}
 
 build:

--- a/src/otel/semconv/meta.yaml
+++ b/src/otel/semconv/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-otel-semconv" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.9.0" %}
+{% set version = "2.10.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/otel/semconv/meta.yaml
+++ b/src/otel/semconv/meta.yaml
@@ -12,7 +12,7 @@ source:
   {% else %}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-otel-semconv/#files
-  sha256: 81c7182276ba0b63982d0d90b095a7f7ffdc9113edd06eec50e0242d68bf8641
+  sha256: 4fc21cd819867ecdf2a6f0b4e9632de01770f3166698bb6a1826001c44c249ef
   {% endif %}
 
 build:

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-providers-cortex" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.9.0" %}
+{% set version = "2.10.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -12,7 +12,7 @@ source:
   {% else %}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   # Get SHA256 from https://pypi.org/project/trulens-providers-cortex/#files
-  sha256: 290495ac1e38f96a3f70f09e15ac5dbbec5545375e73692dcb828166c60661f1
+  sha256: 332b8ca9aef26ef3fde39807bdea864213e1c8991e70a43b0f55d5c28c0e283c
   {% endif %}
 
 build:


### PR DESCRIPTION
Unblocks the `BuildCondaPackages` job on #2643.

## Problem

The 2.10.0 version bump updated every `pyproject.toml` but left the eight conda recipes at `2.9.0`. Each recipe's post-build test asserts that the installed package's `__version__` equals the recipe version, so the first package built fails:

```
+ python -c 'import trulens.otel.semconv; assert trulens.otel.semconv.__version__ == "2.9.0", ...'
AssertionError: Installed version does not match expected version
CondaBuildUserError: TESTS FAILED: trulens-otel-semconv-2.9.0-py_0.conda
```

## Fix

Bump `{% set version = ... %}` to `2.10.0` in all eight recipes:

- `src/core/meta.yaml`
- `src/feedback/meta.yaml`
- `src/dashboard/meta.yaml`
- `src/otel/semconv/meta.yaml`
- `src/apps/langchain/meta.yaml`
- `src/apps/langgraph/meta.yaml`
- `src/connectors/snowflake/meta.yaml`
- `src/providers/cortex/meta.yaml`

No other `2.9.0` references remain outside of lockfiles.

Also ran `make update-meta-yaml` (now that the 2.10.0 sdists are on PyPI) to refresh the `sha256:` values, which were still the 2.9.0 tarball digests. The CI conda job builds with `CONDA_SOURCE_USE_PATH=1` so it never hit them, but any build off the PyPI source URL would fail checksum verification. Each hash was verified against the sdist digest in the PyPI JSON API.

## Note

This only covers the conda failure. The remaining red checks on #2643 (pre-commit and the four `PRBranchProtect *-static` jobs) are pre-existing breakages inherited from `main` and are fixed separately in #2645.