### PR TITLE
fix(ci): repair Bedrock Nova tests, eval_gate formatting, and dangling docs link on main

### DIFF
--- a/docs/component_guides/evaluation/agentic_evaluations.md
+++ b/docs/component_guides/evaluation/agentic_evaluations.md
@@ -246,4 +246,3 @@ chosen but invoked incorrectly.
 
 - [Custom Feedback Functions](./feedback_implementations/custom_feedback_functions.ipynb)
 - [Feedback Selectors](./feedback_selectors/index.md)
-- [Agentic Evaluation Cookbook](../../../examples/cookbooks/agentic_evaluations.ipynb)

--- a/examples/cicd/circleci/eval_gate.py
+++ b/examples/cicd/circleci/eval_gate.py
@@ -14,12 +14,14 @@ Environment variables:
 from __future__ import annotations
 
 import os
+from pathlib import Path
 import sys
 import xml.etree.ElementTree as ET
-from pathlib import Path
 
 from trulens.apps.app import TruApp
-from trulens.core import Metric, Selector, TruSession
+from trulens.core import Metric
+from trulens.core import Selector
+from trulens.core import TruSession
 from trulens.core.otel.instrument import instrument
 from trulens.otel.semconv.trace import SpanAttributes
 
@@ -78,7 +80,9 @@ def build_feedbacks():
     """Configure RAG triad feedback functions using the OpenAI provider."""
     from trulens.providers.openai import OpenAI
 
-    provider = OpenAI(model_engine=os.environ.get("TRULENS_EVAL_MODEL", "gpt-4o-mini"))
+    provider = OpenAI(
+        model_engine=os.environ.get("TRULENS_EVAL_MODEL", "gpt-4o-mini")
+    )
 
     return [
         Metric(
@@ -108,7 +112,12 @@ def build_feedbacks():
     ]
 
 
-def write_junit(path: str, failures: list[tuple[str, float]], scores: dict[str, float], min_score: float) -> None:
+def write_junit(
+    path: str,
+    failures: list[tuple[str, float]],
+    scores: dict[str, float],
+    min_score: float,
+) -> None:
     suite = ET.Element(
         "testsuite",
         name="trulens-eval-gate",
@@ -117,9 +126,13 @@ def write_junit(path: str, failures: list[tuple[str, float]], scores: dict[str, 
     )
     failed = {name: score for name, score in failures}
     for name, score in scores.items():
-        case = ET.SubElement(suite, "testcase", classname="TruLensEvalGate", name=name)
+        case = ET.SubElement(
+            suite, "testcase", classname="TruLensEvalGate", name=name
+        )
         if name in failed:
-            failure = ET.SubElement(case, "failure", message=f"{name} below threshold")
+            failure = ET.SubElement(
+                case, "failure", message=f"{name} below threshold"
+            )
             failure.text = f"{name}: {score:.3f} < {min_score:.3f}"
 
     output = Path(path)
@@ -156,7 +169,8 @@ def main() -> int:
 
     ignore = {"latency", "total_cost", "total_tokens", "Latency", "Cost (USD)"}
     feedback_cols = [
-        col for col in leaderboard.columns
+        col
+        for col in leaderboard.columns
         if col not in ignore and leaderboard[col].dtype.kind in "fi"
     ]
 
@@ -175,7 +189,10 @@ def main() -> int:
         print(f"\nWrote JUnit report to {junit_path}")
 
     if failures:
-        print(f"\nEval gate FAILED: {len(failures)} metric(s) below {min_score}.", file=sys.stderr)
+        print(
+            f"\nEval gate FAILED: {len(failures)} metric(s) below {min_score}.",
+            file=sys.stderr,
+        )
         return 1
 
     print(f"\nEval gate PASSED: all metrics >= {min_score}.")

--- a/tests/unit/providers/test_bedrock_capabilities.py
+++ b/tests/unit/providers/test_bedrock_capabilities.py
@@ -52,6 +52,12 @@ def _make_provider(model_id: str, response_payload: Dict[str, Any]):
 _FAMILY_CASES = [
     (
         "amazon.nova-lite-v1:0",
+        {"output": {"message": {"content": [{"text": "nova-ok"}]}}},
+        "nova-ok",
+        "messages",
+    ),
+    (
+        "amazon.titan-text-express-v1",
         {"results": [{"outputText": "amazon-ok"}]},
         "amazon-ok",
         "inputText",
@@ -179,7 +185,7 @@ def test_requires_messages_or_prompt():
 def test_messages_are_concatenated_into_input_text():
     """Multiple messages are flattened to a single 'role: content' string."""
     provider = _make_provider(
-        "amazon.nova-lite-v1:0", {"results": [{"outputText": "ok"}]}
+        "amazon.titan-text-express-v1", {"results": [{"outputText": "ok"}]}
     )
     provider._create_chat_completion(
         messages=[


### PR DESCRIPTION
`main` is currently red on two independent, deterministic failures. Both surfaced on the 2.10.0 release PR (#2643), but neither was introduced by it — they are inherited from `main`.

## 1. Bedrock Nova tests (semantic merge conflict)

Fails on all four `PRBranchProtect *-static` jobs:

```
FAILED tests/unit/providers/test_bedrock_capabilities.py::test_model_family_request_and_response[amazon.nova-lite-v1:0-payload0-amazon-ok-inputText]
FAILED tests/unit/providers/test_bedrock_capabilities.py::test_messages_are_concatenated_into_input_text
```

Two PRs collided without a conflicting line between them:

- #2566 routed Amazon Nova to the [Messages API schema](https://docs.aws.amazon.com/nova/latest/userguide/using-invoke-api.html) — request uses `messages`/`schemaVersion`, response is parsed from `output.message.content[0].text`.
- #2536 added these capability tests, written against the pre-#2566 provider where every `amazon.*` model used the legacy Titan text-generation schema.

#2566 merged first, #2536 merged after without a rebase, so the Nova cases assert Titan shapes against a provider that no longer produces them — `KeyError: 'output'`.

Fixing the expectations, not the provider: the Nova routing is intentional and matches the AWS docs.

- family matrix: the Nova case now expects a `messages` request body and an `output.message.content[0].text` response
- added an explicit `amazon.titan-text-express-v1` case so the legacy Titan path keeps its coverage in the matrix
- `test_messages_are_concatenated_into_input_text` now targets Titan, the family that actually builds `inputText` (the behavior the test name describes)

## 2. eval_gate.py formatting

Fails the `Lint & format (pre-commit)` job. `examples/cicd/circleci/eval_gate.py` landed in #2593 without the hooks applied — ruff fixes one import-sorting error and ruff-format reformats the file. Formatting only, no behavior change.


## 3. Dangling docs link

Fails the `Docs (Check Documentation latest)` job. `docs/component_guides/evaluation/agentic_evaluations.md` linked `../../../examples/cookbooks/agentic_evaluations.ipynb` in its "Related" list, but that notebook was never added to the repo — dangling since #2460:

```
WARNING - Doc file '''component_guides/evaluation/agentic_evaluations.md''' contains a link
'''../../../examples/cookbooks/agentic_evaluations.ipynb''', but the target is not found
among documentation files.
make: *** [Makefile:169: docs-linkcheck-strict] Error 1
```

Dropped the bullet.

**Caveat:** this does not turn the `Docs` job green. That pipeline has been failing on every PR since May 2026 (see builds for #2611, #2612) on a backlog of unrelated warnings under `docs-linkcheck-strict` — griffe missing-annotation warnings in `src/benchmark/*`, `mkdocs_autorefs` failing to resolve `trulens.core.app.App.__init__`, and a `README.md`/`index.md` conflict. Cleaning those up is a separate effort and out of scope here.

`Docs` is not a required check — `PR Validation Eval` is the gate for merging into `main`. This PR only triggers `Docs` at all because it touches `docs/` and `examples/`; #2643 skipped it entirely.

## Verification

```
TEST_OPTIONAL=true pytest tests/unit/providers/test_bedrock_capabilities.py
13 passed

pre-commit run --all-files
all hooks Passed
```

Reproduced both failures locally before the fix (same 2 tests, same assertions as CI).

## Note

The third red check on #2643, `BuildCondaPackages`, is release-specific (recipes left at 2.9.0) and is fixed in #2644 against the RC branch.