### PR TITLE
fix(docs): make the strict docs build warning-clean so Docs CI can pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,19 +162,12 @@ docs-upload: clean env-docs $(shell find docs -type f) mkdocs.yml
 docs-linkcheck: site
 	lychee --offline --no-progress "site/**/*.html"
 
-# Check documentation for broken internal links using properdocs --strict.
-# Does not require lychee; fails if any warnings beyond the pre-existing
-# README.md/index.md conflict are found.
+# Check documentation for broken internal links and other build warnings using
+# properdocs --strict. Does not require lychee. The build is warning-clean, so
+# any new warning (broken link, unresolved cross-reference, missing annotation)
+# fails this target.
 docs-linkcheck-strict: env-docs
-	@OUTPUT=$$(poetry run properdocs build --clean --strict 2>&1); \
-	echo "$$OUTPUT"; \
-  BROKEN=$$(echo "$$OUTPUT" | grep "WARNING -" | grep -v "README.md" | grep -v "griffe:"); \
-	if [ -n "$$BROKEN" ]; then \
-	  echo ""; \
-	  echo "Broken links / documentation warnings found:"; \
-	  echo "$$BROKEN"; \
-	  exit 1; \
-	fi
+	poetry run properdocs build --clean --strict
 
 # Start the trubot slack app.
 trubot:

--- a/docs/component_guides/evaluation/agentic_evaluations.md
+++ b/docs/component_guides/evaluation/agentic_evaluations.md
@@ -246,4 +246,4 @@ chosen but invoked incorrectly.
 
 - [Custom Feedback Functions](./feedback_implementations/custom_feedback_functions.ipynb)
 - [Feedback Selectors](./feedback_selectors/index.md)
-- [Agentic Evaluation Cookbook](../../../examples/cookbooks/agentic_evaluations.ipynb)
+- [Agentic Evaluation Cookbook](../../cookbook/frameworks/openai_agent_sdk/openai_agents.ipynb)

--- a/examples/cicd/circleci/eval_gate.py
+++ b/examples/cicd/circleci/eval_gate.py
@@ -14,12 +14,14 @@ Environment variables:
 from __future__ import annotations
 
 import os
+from pathlib import Path
 import sys
 import xml.etree.ElementTree as ET
-from pathlib import Path
 
 from trulens.apps.app import TruApp
-from trulens.core import Metric, Selector, TruSession
+from trulens.core import Metric
+from trulens.core import Selector
+from trulens.core import TruSession
 from trulens.core.otel.instrument import instrument
 from trulens.otel.semconv.trace import SpanAttributes
 
@@ -78,7 +80,9 @@ def build_feedbacks():
     """Configure RAG triad feedback functions using the OpenAI provider."""
     from trulens.providers.openai import OpenAI
 
-    provider = OpenAI(model_engine=os.environ.get("TRULENS_EVAL_MODEL", "gpt-4o-mini"))
+    provider = OpenAI(
+        model_engine=os.environ.get("TRULENS_EVAL_MODEL", "gpt-4o-mini")
+    )
 
     return [
         Metric(
@@ -108,7 +112,12 @@ def build_feedbacks():
     ]
 
 
-def write_junit(path: str, failures: list[tuple[str, float]], scores: dict[str, float], min_score: float) -> None:
+def write_junit(
+    path: str,
+    failures: list[tuple[str, float]],
+    scores: dict[str, float],
+    min_score: float,
+) -> None:
     suite = ET.Element(
         "testsuite",
         name="trulens-eval-gate",
@@ -117,9 +126,13 @@ def write_junit(path: str, failures: list[tuple[str, float]], scores: dict[str, 
     )
     failed = {name: score for name, score in failures}
     for name, score in scores.items():
-        case = ET.SubElement(suite, "testcase", classname="TruLensEvalGate", name=name)
+        case = ET.SubElement(
+            suite, "testcase", classname="TruLensEvalGate", name=name
+        )
         if name in failed:
-            failure = ET.SubElement(case, "failure", message=f"{name} below threshold")
+            failure = ET.SubElement(
+                case, "failure", message=f"{name} below threshold"
+            )
             failure.text = f"{name}: {score:.3f} < {min_score:.3f}"
 
     output = Path(path)
@@ -156,7 +169,8 @@ def main() -> int:
 
     ignore = {"latency", "total_cost", "total_tokens", "Latency", "Cost (USD)"}
     feedback_cols = [
-        col for col in leaderboard.columns
+        col
+        for col in leaderboard.columns
         if col not in ignore and leaderboard[col].dtype.kind in "fi"
     ]
 
@@ -175,7 +189,10 @@ def main() -> int:
         print(f"\nWrote JUnit report to {junit_path}")
 
     if failures:
-        print(f"\nEval gate FAILED: {len(failures)} metric(s) below {min_score}.", file=sys.stderr)
+        print(
+            f"\nEval gate FAILED: {len(failures)} metric(s) below {min_score}.",
+            file=sys.stderr,
+        )
         return 1
 
     print(f"\nEval gate PASSED: all metrics >= {min_score}.")

--- a/src/benchmark/trulens/benchmark/cross_model_alignment.py
+++ b/src/benchmark/trulens/benchmark/cross_model_alignment.py
@@ -211,7 +211,9 @@ class CrossModelAlignmentReport:
             lines.append("No interchangeable judges or outliers detected.")
         print("\n".join(lines))
 
-    def plot_heatmap(self):  # pragma: no cover - needs matplotlib and a display
+    def plot_heatmap(
+        self,
+    ) -> Any:  # pragma: no cover - needs matplotlib and a display
         """Plot the pairwise Spearman matrix as a heatmap.
 
         Returns:

--- a/src/benchmark/trulens/benchmark/golden_set_generator.py
+++ b/src/benchmark/trulens/benchmark/golden_set_generator.py
@@ -149,7 +149,7 @@ class GoldenSetSample:
                 record["expected_score"] = None
         return records
 
-    def to_csv(self, path: str, **kwargs) -> None:
+    def to_csv(self, path: str, **kwargs: Any) -> None:
         """Write the sample to a CSV file for external annotation.
 
         Args:

--- a/src/benchmark/trulens/benchmark/score_distribution.py
+++ b/src/benchmark/trulens/benchmark/score_distribution.py
@@ -228,7 +228,7 @@ class ScoreDistributionReport:
             lines.append("No distribution pathologies detected.")
         print("\n".join(lines))
 
-    def plot(self):  # pragma: no cover - needs matplotlib and a display
+    def plot(self) -> Any:  # pragma: no cover - needs matplotlib and a display
         """Plot the score histogram and calibration curve with matplotlib.
 
         Returns:

--- a/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/connector.py
@@ -497,7 +497,7 @@ class SnowflakeConnector(DBConnector):
         """Populate Snowflake-specific fields on the App after it is
         constructed. Replaces the previous ``isinstance(connector,
         SnowflakeConnector)`` branch in
-        [App.__init__][trulens.core.app.App.__init__]."""
+        [App][trulens.core.app.App] construction."""
         app_name = kwargs.get("app_name")
         app_version = kwargs.get("app_version")
         if app_name is None:

--- a/src/core/trulens/core/database/connector/base.py
+++ b/src/core/trulens/core/database/connector/base.py
@@ -521,7 +521,7 @@ class DBConnector(ABC, text_utils.WithIdentString):
         return events[events.apply(row_matches_run, axis=1)]
 
     def augment_app(self, app: Any, **kwargs: Any) -> None:
-        """Hook called from [App.__init__][trulens.core.app.App.__init__]
+        """Hook called from [App][trulens.core.app.App] construction
         after the App is constructed. Connectors may override this to
         contribute connector-specific state (e.g. DAOs or external object
         identifiers) to the App. Default is a no-op."""


### PR DESCRIPTION
## Summary

The `DocsCheck` pipeline has been failing on every PR since May (e.g. #2611, #2612) on a backlog of warnings under `make docs-linkcheck-strict`. The target had grown `grep -v` filters for `README.md` and `griffe:` warnings, which hid part of the backlog without fixing it — and the remaining unresolved cross-references still failed the job.

This fixes the actual warnings so `properdocs build --clean --strict` exits 0 with **zero** warnings, then removes the grep filters so any new warning fails the job visibly.

- **README.md/index.md conflict** — `docs/README.md` was an empty (0-byte), unreferenced file shadowed by `docs/index.md`. Deleted.
- **Broken link** — `component_guides/evaluation/agentic_evaluations.md` linked to `examples/cookbooks/agentic_evaluations.ipynb`, which does not exist. Repointed at the OpenAI Agents SDK cookbook.
- **griffe missing annotations** (3, all in `src/benchmark/`) — annotated `ScoreDistributionAnalyzer.plot`, `CrossModelAlignment.plot_heatmap` and `GoldenSetSample.to_csv`'s `**kwargs`.
- **mkdocs_autorefs unresolved target** (6 warnings) — the two `augment_app` docstrings linked `[App.__init__][trulens.core.app.App.__init__]`, but `__init__` has no rendered anchor. They now link `[App][trulens.core.app.App]`.
- **Makefile** — `docs-linkcheck-strict` is now just `properdocs build --clean --strict`.

No behavior changes: annotations and docstring link text only.

## Test plan

- [x] `poetry run properdocs build --clean --strict` → exit 0, no `WARNING` lines (was: `Aborted with 11 warnings in strict mode!`)
- [x] `poetry run pre-commit run --files <changed files>` → all hooks pass
- [x] `DocsCheck` green on this PR