### PR TITLE
docs: set site_url so the sitemap and canonicals are actually emitted

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,18 @@
 site_name: 🦑 TruLens
-site_description: Evaluate and track LLM applications. Explain Deep Neural Nets.
+site_description: TruLens is an open source library for evaluating and tracing AI agents. Instrument with OpenTelemetry and score every step with benchmarked LLM judges.
+
+# MkDocs derives both the sitemap's <loc> entries and Material's rel="canonical"
+# from site_url. Without it the built sitemap.xml is an empty <urlset>, so no
+# page on the site is discoverable that way, and no page carries a canonical.
+site_url: https://www.trulens.org/
+
+# docs/overrides/ is the theme's custom_dir, but it also sits inside docs_dir, so
+# MkDocs copied the raw template out as a static file and the deployed site served
+# a second, near-identical copy of the home page at /overrides/home.html. The
+# theme loader reads custom_dir directly, so excluding the directory from the file
+# collector stops the duplicate without affecting the template.
+exclude_docs: |
+  overrides/
 
 repo_name: truera/trulens
 repo_url: https://github.com/truera/trulens


### PR DESCRIPTION
## Summary

`site_url` was never set in `mkdocs.yml`. MkDocs builds both the sitemap's `<loc>` entries and Material's `rel="canonical"` from it, so the deployed site has neither:

```
https://www.trulens.org/sitemap.xml   -> 200, 109 bytes, <urlset> with ZERO urls
canonical tags on /                   -> 0
canonical tags on /getting_started/   -> 0
```

Three changes, all in `mkdocs.yml`:

- **`site_url: https://www.trulens.org/`** — produces 337 sitemap URLs and canonicals on 348 of 351 built pages. The three without are `404.html`, a notebook frontend asset, and the home page, whose template is standalone and does not extend `base.html`.
- **`exclude_docs: overrides/`** — fixes a duplicate the missing canonicals were hiding. `docs/overrides/` is the theme's `custom_dir` but also sits under `docs_dir`, so MkDocs copied the raw template out as a static file and `https://www.trulens.org/overrides/home.html` served a second, near-identical copy of the home page (84,249 vs 84,214 bytes) with no canonical on either. The theme loader reads `custom_dir` directly, so the template still renders.
- **`site_description`** — the old value still advertised "Explain Deep Neural Nets", from the TruLens-Explain era. It is the fallback meta description on every page that does not set its own.

Found while reviewing the site's answer-engine optimisation. No content or theme changes.

## Test plan

- [x] `mkdocs build` exits 0
- [x] `sitemap.xml` contains 337 `<loc>` entries, up from 0
- [x] `rel="canonical"` present on 348/351 built HTML pages
- [x] `/overrides/` no longer published; built page count drops 352 -> 351
- [x] Home page still renders from the custom template after `exclude_docs`
- [x] New `site_description` appears as the `meta name="description"` fallback on docs pages

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)