### PR TITLE
fix(feedback): validate structured-JSON scores against the configured scale

### DIFF
--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -229,9 +229,9 @@ class LLMProvider(core_provider.Provider):
         """
 
         assert self.endpoint is not None, "Endpoint is not set."
-        assert max_score_val > min_score_val, (
-            "Max score must be greater than min score."
-        )
+        assert (
+            max_score_val > min_score_val
+        ), "Max score must be greater than min score."
 
         llm_messages = [{"role": "system", "content": system_prompt}]
         if user_prompt is not None:
@@ -342,9 +342,9 @@ class LLMProvider(core_provider.Provider):
                 reason metadata dictionary.
         """
         assert self.endpoint is not None, "Endpoint is not set."
-        assert max_score_val > min_score_val, (
-            "Max score must be greater than min score."
-        )
+        assert (
+            max_score_val > min_score_val
+        ), "Max score must be greater than min score."
 
         llm_messages = [{"role": "system", "content": system_prompt}]
         if user_prompt is not None:

--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -38,6 +38,27 @@ logger = logging.getLogger(__name__)
 
 REASONING_MODEL_PREFIXES = ("o1", "o3", "o4", "gpt-5", "deepseek-r1")
 
+
+def _validate_score_range(
+    rating: float, min_score_val: int, max_score_val: int
+) -> float:
+    """Check that a structured-output rating is within the configured scale.
+
+    Mirrors the range validation that `re_configured_rating` applies to plain
+    string responses, so structured JSON responses cannot silently normalize
+    to values outside [0, 1].
+
+    Raises:
+        ParseError: If the rating falls outside
+            [`min_score_val`, `max_score_val`].
+    """
+    if not (min_score_val <= rating <= max_score_val):
+        raise feedback_generated.ParseError(
+            f"{min_score_val}-{max_score_val} rating", str(rating)
+        )
+    return rating
+
+
 # --- Shared capability cache for LLM providers ---
 _capabilities_lock = threading.Lock()
 
@@ -208,9 +229,9 @@ class LLMProvider(core_provider.Provider):
         """
 
         assert self.endpoint is not None, "Endpoint is not set."
-        assert (
-            max_score_val > min_score_val
-        ), "Max score must be greater than min score."
+        assert max_score_val > min_score_val, (
+            "Max score must be greater than min score."
+        )
 
         llm_messages = [{"role": "system", "content": system_prompt}]
         if user_prompt is not None:
@@ -247,11 +268,13 @@ class LLMProvider(core_provider.Provider):
         if isinstance(parsed_json, dict) and "score" in parsed_json:
             try:
                 raw_score = float(parsed_json["score"])
+            except (TypeError, ValueError):
+                normalized_score = -1.0
+            else:
+                _validate_score_range(raw_score, min_score_val, max_score_val)
                 normalized_score = (raw_score - min_score_val) / (
                     max_score_val - min_score_val
                 )
-            except (TypeError, ValueError):
-                normalized_score = -1.0
 
             return normalized_score, {"reason": parsed_json}
 
@@ -261,9 +284,17 @@ class LLMProvider(core_provider.Provider):
             for item in parsed_json:
                 if isinstance(item, dict) and "score" in item:
                     try:
-                        scores.append(float(item["score"]))
+                        candidate = float(item["score"])
                     except (TypeError, ValueError):
-                        pass
+                        continue
+                    if min_score_val <= candidate <= max_score_val:
+                        scores.append(candidate)
+                    else:
+                        logger.warning(
+                            "Rating must be in [%s, %s].",
+                            min_score_val,
+                            max_score_val,
+                        )
             if scores:
                 avg_raw = sum(scores) / len(scores)
                 normalized_score = (avg_raw - min_score_val) / (
@@ -311,9 +342,9 @@ class LLMProvider(core_provider.Provider):
                 reason metadata dictionary.
         """
         assert self.endpoint is not None, "Endpoint is not set."
-        assert (
-            max_score_val > min_score_val
-        ), "Max score must be greater than min score."
+        assert max_score_val > min_score_val, (
+            "Max score must be greater than min score."
+        )
 
         llm_messages = [{"role": "system", "content": system_prompt}]
         if user_prompt is not None:
@@ -362,15 +393,19 @@ class LLMProvider(core_provider.Provider):
                     score_val = float(json_score)
                 except (TypeError, ValueError):
                     score_val = -1.0
+                else:
+                    _validate_score_range(
+                        score_val, min_score_val, max_score_val
+                    )
+                    score_val = (score_val - min_score_val) / (
+                        max_score_val - min_score_val
+                    )
                 reasons = {
                     "reason": (
                         f"{criteria_field}: {json_criteria}\n"
                         f"{supporting_evidence_field}: {json_evidence}"
                     )
                 }
-                score_val = (score_val - min_score_val) / (
-                    max_score_val - min_score_val
-                )
                 return score_val, reasons
 
         if isinstance(response, feedback_output_schemas.ChainOfThoughtResponse):

--- a/tests/integration/test_score_range_validation.py
+++ b/tests/integration/test_score_range_validation.py
@@ -1,0 +1,149 @@
+"""Integration tests for score range validation on structured-JSON paths.
+
+The string-response path already enforces the configured rating scale:
+``re_configured_rating`` warns on out-of-range matches and raises
+``ParseError`` when no in-range rating remains (see
+``test_generate_score_raises_parse_error[out_of_range]`` in
+``test_score_parsing_normalization.py``).
+
+The structured-JSON fast paths in ``generate_score`` and
+``generate_score_and_reasons`` previously skipped that validation, so an
+out-of-scale score (e.g. ``{"score": 42}`` on a 0-10 scale) was silently
+normalized to a value outside [0, 1], corrupting downstream aggregation.
+These tests pin the JSON paths to the same semantics as the string path.
+"""
+
+import math
+from typing import ClassVar
+
+import pytest
+from trulens.feedback import generated as feedback_generated
+from trulens.feedback import llm_provider
+from trulens.feedback import output_schemas as feedback_output_schemas
+
+_MIN, _MAX = 0, 10
+
+
+class _MockEndpoint:
+    def run_in_pace(self, func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+
+class MockLLMProvider(llm_provider.LLMProvider):
+    """Returns a canned completion through the real parser."""
+
+    model_config: ClassVar[dict[str, str]] = {"extra": "allow"}
+
+    def __init__(
+        self,
+        response: str | feedback_output_schemas.BaseFeedbackResponse,
+        **kwargs,
+    ):
+        super().__init__(endpoint=None, model_engine="mock-model", **kwargs)
+        object.__setattr__(self, "endpoint", _MockEndpoint())
+        object.__setattr__(self, "_response", response)
+
+    def _is_reasoning_model(self) -> bool:
+        return False
+
+    def _create_chat_completion(
+        self,
+        prompt: str | None = None,
+        messages: list | None = None,
+        response_format=None,
+        **kwargs,
+    ):
+        return self._response
+
+
+@pytest.mark.parametrize(
+    "response",
+    ['{"score": 42}', '{"score": -3}'],
+    ids=["above_max", "below_min"],
+)
+def test_generate_score_json_out_of_range_raises_parse_error(response):
+    """Regression: JSON scores outside the scale must raise ParseError like
+    the string path does, instead of normalizing past [0, 1]."""
+    with pytest.raises(feedback_generated.ParseError):
+        MockLLMProvider(response).generate_score(
+            system_prompt="System prompt.",
+            min_score_val=_MIN,
+            max_score_val=_MAX,
+        )
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        '{"criteria": "c", "supporting_evidence": "e", "score": 100}',
+        '{"criteria": "c", "supporting_evidence": "e", "score": -1}',
+    ],
+    ids=["above_max", "below_min"],
+)
+def test_generate_score_and_reasons_json_out_of_range_raises_parse_error(
+    response,
+):
+    with pytest.raises(feedback_generated.ParseError):
+        MockLLMProvider(response).generate_score_and_reasons(
+            system_prompt="System prompt.",
+            min_score_val=_MIN,
+            max_score_val=_MAX,
+        )
+
+
+def test_generate_score_json_in_range_still_normalizes():
+    """In-range JSON scores keep working after the validation was added."""
+    result = MockLLMProvider('{"score": 2}').generate_score(
+        system_prompt="System prompt.",
+        min_score_val=_MIN,
+        max_score_val=_MAX,
+    )
+
+    score = result[0] if isinstance(result, tuple) else result
+    assert score == pytest.approx(0.2)
+
+
+def test_generate_score_and_reasons_json_in_range_still_normalizes():
+    response = (
+        '{"criteria": "relevance", "supporting_evidence": "...", "score": 2}'
+    )
+
+    score, reasons = MockLLMProvider(response).generate_score_and_reasons(
+        system_prompt="System prompt.",
+        min_score_val=_MIN,
+        max_score_val=_MAX,
+    )
+
+    assert score == pytest.approx(0.2)
+    assert isinstance(reasons, dict)
+
+
+def test_generate_score_list_skips_out_of_range_items():
+    """List averaging must ignore out-of-scale items (mirroring the string
+    parser, which filters out-of-range matches) instead of folding them in."""
+    response = '[{"score": 2}, {"score": 42}]'
+
+    result = MockLLMProvider(response).generate_score(
+        system_prompt="System prompt.",
+        min_score_val=_MIN,
+        max_score_val=_MAX,
+    )
+
+    score = result[0] if isinstance(result, tuple) else result
+    # Only the in-range 2 contributes; 42 is skipped with a warning.
+    assert score == pytest.approx(0.2)
+
+
+def test_generate_score_and_reasons_unparseable_sentinel_not_normalized():
+    """Regression: the -1.0 failure sentinel was previously normalized to
+    -0.1 on a 0-10 scale; it must be returned raw, matching generate_score."""
+    response = '{"criteria": "c", "supporting_evidence": "e", "score": "abc"}'
+
+    score, _ = MockLLMProvider(response).generate_score_and_reasons(
+        system_prompt="System prompt.",
+        min_score_val=_MIN,
+        max_score_val=_MAX,
+    )
+
+    assert not math.isnan(score)
+    assert score == -1.0


### PR DESCRIPTION
## Root Cause

The structured-JSON fast paths in `LLMProvider.generate_score` and `generate_score_and_reasons` normalize `parsed_json["score"]` without validating it against the configured `[min_score_val, max_score_val]` scale. The plain-string path already enforces this via `re_configured_rating` (out-of-range → `ParseError` — pinned by `test_generate_score_raises_parse_error[out_of_range]`), so the two response shapes disagree:

| response (scale 0-10) | before | after |
|---|---|---|
| `"42"` (string) | `ParseError` | `ParseError` (unchanged) |
| `{"score": 42}` | **silently returns 4.2** | `ParseError` |
| CoT JSON `score=100` | **silently returns 10.0** | `ParseError` |
| `[{"score": 2}, {"score": 42}]` | mean folds in 42 → 2.2 | 42 skipped w/ warning → 0.2 |
| CoT JSON `score="abc"` | sentinel −1.0 normalized to **−0.1** | raw `-1.0` (matches `generate_score`) |

Out-of-scale scores escape the documented [0, 1] output range and silently corrupt downstream aggregation (leaderboard means, threshold checks). The `-1.0` failure sentinel was additionally being normalized only in `generate_score_and_reasons`, diverging from `generate_score`.

## Fix

- Add module-private `_validate_score_range` mirroring `re_configured_rating`'s range semantics; apply it on both scalar JSON paths.
- List-averaging path skips out-of-range items with the same warning the string parser logs, instead of folding them into the mean.
- Normalize only on successful parse in `generate_score_and_reasons`, so the `-1.0` sentinel is returned raw.

No public API surface change (helper is module-private).

## Test

- [x] New `tests/integration/test_score_range_validation.py` (7 tests): out-of-range scalar JSON raises on both methods (above/below), in-range still normalizes, list filtering, sentinel regression.
- [x] Existing `tests/integration/test_score_parsing_normalization.py` + `tests/unit/test_feedback_score_generation.py`: 34 passed, 1 xfailed (pre-existing strict xfail for #2496) — no regressions.
- [x] `ruff check` / `ruff format --check` clean on touched files.

## Diff scope

2 files, +197/−13 (fix is ~40 lines; the rest is tests).

## AI Disclosure

AI assistance was used for candidate-pattern scanning and test drafting; the root-cause analysis, fix design (mirroring the existing string-path semantics), and all verification (local repro of the 4 cases above + test runs) were human-reviewed. Happy to adjust anything.
