### PR TITLE
docs: refresh the stale download count on the home page

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -208,7 +208,14 @@
          already does the work of authenticating against Azure DevOps and
          aggregating pypistats, neither of which serves CORS headers directly --
          but they are fetched and drawn in our own chrome. The values baked into
-         the HTML below are the fallback when the fetch is blocked or slow. -->
+         the HTML below are the fallback when the fetch is blocked or slow.
+
+         The fallbacks drift, and the download count drifts fastest because it is
+         the only one that moves without a release. shields' pypi endpoint is also
+         the slowest of the five -- a cold cache there times out rather than
+         answering, so the fallback is what a fair number of visitors actually
+         see, which makes it worth refreshing rather than treating as a
+         never-rendered safety net. Checked against shields 2026-08-03. -->
     <div class="statstrip">
       <a class="stat" href="https://pypi.org/project/trulens/">
         <span class="k">Version</span>
@@ -224,7 +231,7 @@
       </a>
       <a class="stat" href="https://pypi.org/project/trulens-core/">
         <span class="k">Downloads</span>
-        <span class="v" data-badge="pypi/dm/trulens-core" data-ok="^[0-9.]+[kM]?/month$">104k/month</span>
+        <span class="v" data-badge="pypi/dm/trulens-core" data-ok="^[0-9.]+[kM]?/month$">122k/month</span>
       </a>
       <a class="stat" href="https://github.com/truera/trulens/blob/main/LICENSE">
         <span class="k">License</span>


### PR DESCRIPTION
## What

Refreshes the download count in the home page stats strip from `104k/month` to `122k/month`.

## Why

The strip reads all five values live from shields' `.json` badge siblings and bakes a fallback into the markup for when that fetch is blocked or slow. The download count was still the `104k/month` captured when the strip was written.

That particular fallback is the one worth maintaining:

- It is the only value that moves without a release. Version, license and build status change on our schedule; downloads drift continuously.
- shields' pypi endpoint is the slowest of the five. A cold cache there times out rather than answering — reproducible by requesting `pypi/dm/trulens-core.json` twice in a row, where the first call returns nothing and the second returns in under half a second. So the baked-in number is what a fair share of visitors actually see, not a never-rendered safety net.

The comment above the strip now says this, so the next person knows the fallback is expected to be refreshed rather than left alone.

## Verification

All five values checked against shields on 2026-08-03:

| Stat | shields | baked-in | action |
| --- | --- | --- | --- |
| Version | `v2.10.0` | `v2.10.0` | correct |
| E2E tests | `passing` | `passing` | correct |
| Stars | `3.5k` | `3.5k` | correct |
| Downloads | `122k/month` | `104k/month` | **updated** |
| License | `MIT` | `MIT` | correct |

## Not in this PR

The broken images on the deployed site are a separate problem with a separate fix. They are Git LFS pointer files that reached `gh-pages` because the deploy ran from a clone with LFS smudge disabled; the committed bytes are fine. That is being addressed by moving the docs deploy into CI with an LFS-aware checkout.
