### PR TITLE
Fix release version derivation

### DIFF
--- a/.azure_pipelines/README.md
+++ b/.azure_pipelines/README.md
@@ -36,9 +36,11 @@ github pipelines. There are differences between these systems.
 - `cd-release-prep.yaml` prepares a release. Run it **manually**, with the
   `releases/rc-trulens-<version>` branch selected. The exact version comes from
   the branch name: selecting `releases/rc-trulens-2.11.0` sets every package to
-  `2.11.0`. It refreshes the lockfile, commits, and pushes to that branch. You
-  then open the release PR from the "Compare & pull request" banner GitHub shows
-  after the push.
+  `2.11.0`. It also updates each conda recipe's version so local-source recipe
+  validation matches the package being built. The existing recipe hashes remain
+  unchanged until the packages exist on PyPI. It refreshes the lockfile, commits,
+  and pushes to that branch. You then open the release PR from the "Compare &
+  pull request" banner GitHub shows after the push.
 
   It exists so nobody has to sit and watch a dependency resolve, which was the
   tedious part of cutting a release. Validation remains on the release PR into

--- a/.azure_pipelines/README.md
+++ b/.azure_pipelines/README.md
@@ -34,23 +34,26 @@ github pipelines. There are differences between these systems.
   reference while a human can still retry it.
 
 - `cd-release-prep.yaml` prepares a release. Run it **manually**, with the
-  `releases/rc-trulens-<version>` branch selected and a `bumpType` of `patch`,
-  `minor` or `major`. It bumps the version across every package, refreshes the
-  lockfile, commits, and pushes to that branch. You then open the release PR from
-  the "Compare & pull request" banner GitHub shows after the push.
+  `releases/rc-trulens-<version>` branch selected. The exact version comes from
+  the branch name: selecting `releases/rc-trulens-2.11.0` sets every package to
+  `2.11.0`. It refreshes the lockfile, commits, and pushes to that branch. You
+  then open the release PR from the "Compare & pull request" banner GitHub shows
+  after the push.
 
   It exists so nobody has to sit and watch a dependency resolve, which was the
-  tedious part of cutting a release. It does not run the tests: the Snowflake
-  end-to-end suite stays a human gate, because a bad release there costs weeks.
+  tedious part of cutting a release. Validation remains on the release PR into
+  `main` rather than in this preparation job.
 
-  > Pushing to `releases/*` requires the Azure Pipelines GitHub App to be on the
-  > bypass list for that branch protection rule, configured from the [Branches
-  > settings](https://github.com/truera/trulens/settings/branches) panel. Without
-  > it every step succeeds and only the final push is rejected.
+  > Direct CI pushes to `releases/*` require the Azure Pipelines GitHub App on the
+  > pull-request bypass list and required status checks disabled for that branch
+  > protection rule. Keep pull requests required: the app bypasses that rule only
+  > for release preparation, while the release PR into `main` remains the human
+  > and validation gate.
 
-  > It refuses to run unless the selected branch is under `releases/`. The job
-  > commits and pushes, and the branch picker in the Run dialog makes running it
-  > against `main` an easy mistake.
+  > It refuses to run unless the selected branch matches
+  > `releases/rc-trulens-X.Y.Z`, or if that target is not greater than the current
+  > version. The branch picker in the Run dialog makes running against `main` an
+  > easy mistake, so these checks happen before any files are changed.
 
 - `cd-release-main.yaml` publishes the release. It triggers on every merge to
   `main`, which is the point at which a release is real — nothing can be published

--- a/.azure_pipelines/cd-release-prep.yaml
+++ b/.azure_pipelines/cd-release-prep.yaml
@@ -76,13 +76,14 @@ jobs:
           fi
 
           make "bump-version-$(targetVersion)"
+          make update-meta-yaml-versions
 
           NEW_VERSION=$(grep -m1 '^version' src/core/pyproject.toml | sed -E 's/^version *= *"(.*)"/\1/')
           if [[ "${NEW_VERSION}" != "$(targetVersion)" ]]; then
             echo "Version mismatch: expected $(targetVersion), got ${NEW_VERSION}."
             exit 1
           fi
-        displayName: "Set the version to $(targetVersion)"
+        displayName: "Set package and conda recipe versions to $(targetVersion)"
 
       # Plain `poetry lock`, which under 2.x keeps the pins already in the file and
       # resolves only what the bump actually changed. That is the point: a release

--- a/.azure_pipelines/cd-release-prep.yaml
+++ b/.azure_pipelines/cd-release-prep.yaml
@@ -1,9 +1,9 @@
 # This is a definition for azure pipelines, not github pipelines. There are
 # differences between these systems.
 #
-# Prepares a release: bumps the version across every package, refreshes the
-# lockfile, and pushes the result to the release branch. Run it manually from the
-# Azure DevOps UI with the release branch selected.
+# Prepares a release: sets every package to the version encoded in the release
+# branch name, refreshes the lockfile, and pushes the result to that branch. Run
+# it manually from the Azure DevOps UI with the release branch selected.
 #
 # This exists because the lock was the slow, tedious part of cutting a release and
 # there is no reason a person should sit and watch it. What it deliberately does
@@ -11,22 +11,9 @@
 # and it saves exactly one click on the "Compare & pull request" banner GitHub
 # shows after the push.
 #
-# It also does not run the tests. The Snowflake end-to-end suite stays a human
-# gate, because a bad release there costs weeks rather than minutes.
-#
 # Pushing to releases/* requires the Azure Pipelines GitHub App to be on the
-# bypass list for that branch protection rule. Without it the push is rejected and
-# every other step here will have succeeded.
-
-parameters:
-  - name: bumpType
-    displayName: "Version bump"
-    type: string
-    default: patch
-    values:
-      - patch
-      - minor
-      - major
+# pull-request bypass list and required status checks to be disabled for that
+# branch protection rule. The release PR into main remains the validation gate.
 
 trigger: none
 pr: none
@@ -45,24 +32,25 @@ jobs:
 
     steps:
       # First, and before the checkout, because it needs nothing from the
-      # repository and refusing early is the whole point. This job commits and
-      # pushes, so running it against main would push a version bump straight to
-      # main. The branch picker in the UI makes that a plausible mistake.
+      # repository and refusing early is the whole point. The branch name is the
+      # release version's source of truth; there is no separate bump selector that
+      # can disagree with it.
       - bash: |
           set -euo pipefail
           echo "Selected branch: ${BUILD_SOURCEBRANCH}"
-          case "${BUILD_SOURCEBRANCH}" in
-            refs/heads/releases/*)
-              echo "Release branch, proceeding."
-              ;;
-            *)
-              echo "Refusing to run: this pipeline commits and pushes, so it only"
-              echo "runs on a releases/* branch. Re-run it with the release branch"
-              echo "selected in the Run pipeline dialog."
-              exit 1
-              ;;
-          esac
-        displayName: "Refuse to run outside a release branch"
+          PREFIX="refs/heads/releases/rc-trulens-"
+          TARGET_VERSION="${BUILD_SOURCEBRANCH#"${PREFIX}"}"
+
+          if [[ "${TARGET_VERSION}" == "${BUILD_SOURCEBRANCH}" ]] ||
+             ! [[ "${TARGET_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Refusing to run: select a branch named"
+            echo "releases/rc-trulens-X.Y.Z in the Run pipeline dialog."
+            exit 1
+          fi
+
+          echo "Target version: ${TARGET_VERSION}"
+          echo "##vso[task.setvariable variable=targetVersion]${TARGET_VERSION}"
+        displayName: "Read the target version from the release branch"
 
       - template: templates/env-setup.yaml
         parameters:
@@ -72,8 +60,29 @@ jobs:
 
       - bash: |
           set -euo pipefail
-          make bump-version-${{ parameters.bumpType }}
-        displayName: "Bump the version (${{ parameters.bumpType }})"
+          CURRENT_VERSION=$(grep -m1 '^version' src/core/pyproject.toml | sed -E 's/^version *= *"(.*)"/\1/')
+
+          if ! python - "${CURRENT_VERSION}" "$(targetVersion)" <<'PY'
+          import sys
+
+          current = tuple(map(int, sys.argv[1].split(".")))
+          target = tuple(map(int, sys.argv[2].split(".")))
+          raise SystemExit(0 if target > current else 1)
+          PY
+          then
+            echo "Refusing to run: target version $(targetVersion) must be greater"
+            echo "than current version ${CURRENT_VERSION}."
+            exit 1
+          fi
+
+          make "bump-version-$(targetVersion)"
+
+          NEW_VERSION=$(grep -m1 '^version' src/core/pyproject.toml | sed -E 's/^version *= *"(.*)"/\1/')
+          if [[ "${NEW_VERSION}" != "$(targetVersion)" ]]; then
+            echo "Version mismatch: expected $(targetVersion), got ${NEW_VERSION}."
+            exit 1
+          fi
+        displayName: "Set the version to $(targetVersion)"
 
       # Plain `poetry lock`, which under 2.x keeps the pins already in the file and
       # resolves only what the bump actually changed. That is the point: a release

--- a/Makefile
+++ b/Makefile
@@ -384,7 +384,7 @@ zip-wheels:
 	poetry run ./zip_wheels.sh
 
 
-# Usage: make bump-version-patch
+# Usage: make bump-version-X.Y.Z
 bump-version-%: $(POETRY_DIRS)
 	for dir in $(POETRY_DIRS); do \
 		echo "Updating $$dir version"; \

--- a/Makefile
+++ b/Makefile
@@ -398,6 +398,9 @@ bump-version-%: $(POETRY_DIRS)
 update-meta-yaml:
 	poetry run python update_meta_yaml.py
 
+update-meta-yaml-versions:
+	poetry run python update_meta_yaml.py --version-only
+
 
 ## Step: Upload wheels to pypi
 # Usage: TOKEN=... make upload-trulens-instrument-langchain

--- a/update_meta_yaml.py
+++ b/update_meta_yaml.py
@@ -16,6 +16,7 @@ Usage:
     make update-meta-yaml
 """
 
+import argparse
 from pathlib import Path
 import re
 import sys
@@ -93,6 +94,21 @@ def fetch_sha256_from_pypi(package_name: str, version: str) -> str | None:
         return None
 
 
+def update_meta_yaml_version(meta_yaml_path: Path, version: str) -> bool:
+    """Update only the version in a meta.yaml file."""
+    content = meta_yaml_path.read_text()
+    updated = re.sub(
+        r'(\{%\s*set\s+version\s*=\s*")[^"]+("\s*%\})',
+        rf"\g<1>{version}\g<2>",
+        content,
+    )
+
+    if updated != content:
+        meta_yaml_path.write_text(updated)
+        return True
+    return False
+
+
 def update_meta_yaml(meta_yaml_path: Path, version: str, sha256: str) -> bool:
     """Update the meta.yaml file with new version and SHA256.
 
@@ -121,9 +137,20 @@ def update_meta_yaml(meta_yaml_path: Path, version: str, sha256: str) -> bool:
 
 def main():
     """Main function to update all meta.yaml files."""
-    print(
-        "Updating meta.yaml files with versions and SHA256 hashes from PyPI...\n"
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--version-only",
+        action="store_true",
+        help="Update recipe versions without fetching pre-release hashes.",
     )
+    args = parser.parse_args()
+
+    if args.version_only:
+        print("Updating meta.yaml versions from pyproject.toml files...\n")
+    else:
+        print(
+            "Updating meta.yaml files with versions and SHA256 hashes from PyPI...\n"
+        )
 
     meta_yaml_files = find_meta_yaml_files()
 
@@ -141,16 +168,6 @@ def main():
         relative_path = meta_yaml_path.relative_to(REPO_ROOT)
         print(f"Processing: {relative_path}")
 
-        # Extract package name
-        package_name = extract_package_name(meta_yaml_path)
-        if not package_name:
-            print(
-                f"  Error: Could not extract package name from {relative_path}"
-            )
-            error_count += 1
-            continue
-        print(f"  Package: {package_name}")
-
         # Find corresponding pyproject.toml
         pyproject_path = meta_yaml_path.parent / "pyproject.toml"
         version = extract_version_from_pyproject(pyproject_path)
@@ -161,6 +178,26 @@ def main():
             error_count += 1
             continue
         print(f"  Version: {version}")
+
+        if args.version_only:
+            if update_meta_yaml_version(meta_yaml_path, version):
+                print(f"  ✓ Updated {relative_path}")
+                success_count += 1
+            else:
+                print("  - No changes needed (already up to date)")
+                skip_count += 1
+            print()
+            continue
+
+        # Extract package name
+        package_name = extract_package_name(meta_yaml_path)
+        if not package_name:
+            print(
+                f"  Error: Could not extract package name from {relative_path}"
+            )
+            error_count += 1
+            continue
+        print(f"  Package: {package_name}")
 
         # Fetch SHA256 from PyPI
         sha256 = fetch_sha256_from_pypi(package_name, version)


### PR DESCRIPTION
## Summary
- remove the release bump selector and derive the exact target version from `releases/rc-trulens-X.Y.Z`
- reject malformed branch names and targets that do not advance the current version
- document the direct-push branch protection requirements

## Test plan
- [x] Parse the Azure Pipeline YAML
- [x] Run pre-commit on all changed files
- [x] Verify patch, minor, major, and arbitrary future release branches
- [x] Verify malformed and non-release branches are rejected

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)