### PR TITLE
Backport release version derivation

### DIFF
--- a/.azure_pipelines/README.md
+++ b/.azure_pipelines/README.md
@@ -34,23 +34,26 @@ github pipelines. There are differences between these systems.
   reference while a human can still retry it.
 
 - `cd-release-prep.yaml` prepares a release. Run it **manually**, with the
-  `releases/rc-trulens-<version>` branch selected and a `bumpType` of `patch`,
-  `minor` or `major`. It bumps the version across every package, refreshes the
-  lockfile, commits, and pushes to that branch. You then open the release PR from
-  the "Compare & pull request" banner GitHub shows after the push.
+  `releases/rc-trulens-<version>` branch selected. The exact version comes from
+  the branch name: selecting `releases/rc-trulens-2.11.0` sets every package to
+  `2.11.0`. It refreshes the lockfile, commits, and pushes to that branch. You
+  then open the release PR from the "Compare & pull request" banner GitHub shows
+  after the push.
 
   It exists so nobody has to sit and watch a dependency resolve, which was the
-  tedious part of cutting a release. It does not run the tests: the Snowflake
-  end-to-end suite stays a human gate, because a bad release there costs weeks.
+  tedious part of cutting a release. Validation remains on the release PR into
+  `main` rather than in this preparation job.
 
-  > Pushing to `releases/*` requires the Azure Pipelines GitHub App to be on the
-  > bypass list for that branch protection rule, configured from the [Branches
-  > settings](https://github.com/truera/trulens/settings/branches) panel. Without
-  > it every step succeeds and only the final push is rejected.
+  > Direct CI pushes to `releases/*` require the Azure Pipelines GitHub App on the
+  > pull-request bypass list and required status checks disabled for that branch
+  > protection rule. Keep pull requests required: the app bypasses that rule only
+  > for release preparation, while the release PR into `main` remains the human
+  > and validation gate.
 
-  > It refuses to run unless the selected branch is under `releases/`. The job
-  > commits and pushes, and the branch picker in the Run dialog makes running it
-  > against `main` an easy mistake.
+  > It refuses to run unless the selected branch matches
+  > `releases/rc-trulens-X.Y.Z`, or if that target is not greater than the current
+  > version. The branch picker in the Run dialog makes running against `main` an
+  > easy mistake, so these checks happen before any files are changed.
 
 - `cd-release-main.yaml` publishes the release. It triggers on every merge to
   `main`, which is the point at which a release is real — nothing can be published

--- a/.azure_pipelines/cd-release-prep.yaml
+++ b/.azure_pipelines/cd-release-prep.yaml
@@ -1,9 +1,9 @@
 # This is a definition for azure pipelines, not github pipelines. There are
 # differences between these systems.
 #
-# Prepares a release: bumps the version across every package, refreshes the
-# lockfile, and pushes the result to the release branch. Run it manually from the
-# Azure DevOps UI with the release branch selected.
+# Prepares a release: sets every package to the version encoded in the release
+# branch name, refreshes the lockfile, and pushes the result to that branch. Run
+# it manually from the Azure DevOps UI with the release branch selected.
 #
 # This exists because the lock was the slow, tedious part of cutting a release and
 # there is no reason a person should sit and watch it. What it deliberately does
@@ -11,22 +11,9 @@
 # and it saves exactly one click on the "Compare & pull request" banner GitHub
 # shows after the push.
 #
-# It also does not run the tests. The Snowflake end-to-end suite stays a human
-# gate, because a bad release there costs weeks rather than minutes.
-#
 # Pushing to releases/* requires the Azure Pipelines GitHub App to be on the
-# bypass list for that branch protection rule. Without it the push is rejected and
-# every other step here will have succeeded.
-
-parameters:
-  - name: bumpType
-    displayName: "Version bump"
-    type: string
-    default: patch
-    values:
-      - patch
-      - minor
-      - major
+# pull-request bypass list and required status checks to be disabled for that
+# branch protection rule. The release PR into main remains the validation gate.
 
 trigger: none
 pr: none
@@ -45,24 +32,25 @@ jobs:
 
     steps:
       # First, and before the checkout, because it needs nothing from the
-      # repository and refusing early is the whole point. This job commits and
-      # pushes, so running it against main would push a version bump straight to
-      # main. The branch picker in the UI makes that a plausible mistake.
+      # repository and refusing early is the whole point. The branch name is the
+      # release version's source of truth; there is no separate bump selector that
+      # can disagree with it.
       - bash: |
           set -euo pipefail
           echo "Selected branch: ${BUILD_SOURCEBRANCH}"
-          case "${BUILD_SOURCEBRANCH}" in
-            refs/heads/releases/*)
-              echo "Release branch, proceeding."
-              ;;
-            *)
-              echo "Refusing to run: this pipeline commits and pushes, so it only"
-              echo "runs on a releases/* branch. Re-run it with the release branch"
-              echo "selected in the Run pipeline dialog."
-              exit 1
-              ;;
-          esac
-        displayName: "Refuse to run outside a release branch"
+          PREFIX="refs/heads/releases/rc-trulens-"
+          TARGET_VERSION="${BUILD_SOURCEBRANCH#"${PREFIX}"}"
+
+          if [[ "${TARGET_VERSION}" == "${BUILD_SOURCEBRANCH}" ]] ||
+             ! [[ "${TARGET_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Refusing to run: select a branch named"
+            echo "releases/rc-trulens-X.Y.Z in the Run pipeline dialog."
+            exit 1
+          fi
+
+          echo "Target version: ${TARGET_VERSION}"
+          echo "##vso[task.setvariable variable=targetVersion]${TARGET_VERSION}"
+        displayName: "Read the target version from the release branch"
 
       - template: templates/env-setup.yaml
         parameters:
@@ -72,8 +60,29 @@ jobs:
 
       - bash: |
           set -euo pipefail
-          make bump-version-${{ parameters.bumpType }}
-        displayName: "Bump the version (${{ parameters.bumpType }})"
+          CURRENT_VERSION=$(grep -m1 '^version' src/core/pyproject.toml | sed -E 's/^version *= *"(.*)"/\1/')
+
+          if ! python - "${CURRENT_VERSION}" "$(targetVersion)" <<'PY'
+          import sys
+
+          current = tuple(map(int, sys.argv[1].split(".")))
+          target = tuple(map(int, sys.argv[2].split(".")))
+          raise SystemExit(0 if target > current else 1)
+          PY
+          then
+            echo "Refusing to run: target version $(targetVersion) must be greater"
+            echo "than current version ${CURRENT_VERSION}."
+            exit 1
+          fi
+
+          make "bump-version-$(targetVersion)"
+
+          NEW_VERSION=$(grep -m1 '^version' src/core/pyproject.toml | sed -E 's/^version *= *"(.*)"/\1/')
+          if [[ "${NEW_VERSION}" != "$(targetVersion)" ]]; then
+            echo "Version mismatch: expected $(targetVersion), got ${NEW_VERSION}."
+            exit 1
+          fi
+        displayName: "Set the version to $(targetVersion)"
 
       # Plain `poetry lock`, which under 2.x keeps the pins already in the file and
       # resolves only what the bump actually changed. That is the point: a release

--- a/Makefile
+++ b/Makefile
@@ -384,7 +384,7 @@ zip-wheels:
 	poetry run ./zip_wheels.sh
 
 
-# Usage: make bump-version-patch
+# Usage: make bump-version-X.Y.Z
 bump-version-%: $(POETRY_DIRS)
 	for dir in $(POETRY_DIRS); do \
 		echo "Updating $$dir version"; \


### PR DESCRIPTION
## Summary
Backport the Release Prep fix so the 2.11.0 release can exercise the corrected pipeline end to end before the same change merges to `main`.

The pipeline derives exact version `2.11.0` from `releases/rc-trulens-2.11.0`; there is no bump selector.

## Test plan
- [x] Azure Pipeline YAML parses
- [x] Focused pre-commit checks pass
- [x] Generic branch parsing accepts patch, minor, major, and future semantic versions
- [x] Malformed and non-release branches are rejected

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)