### PR TITLE
TruLens 2.11.0

### DIFF
--- a/.azure_pipelines/README.md
+++ b/.azure_pipelines/README.md
@@ -36,9 +36,11 @@ github pipelines. There are differences between these systems.
 - `cd-release-prep.yaml` prepares a release. Run it **manually**, with the
   `releases/rc-trulens-<version>` branch selected. The exact version comes from
   the branch name: selecting `releases/rc-trulens-2.11.0` sets every package to
-  `2.11.0`. It refreshes the lockfile, commits, and pushes to that branch. You
-  then open the release PR from the "Compare & pull request" banner GitHub shows
-  after the push.
+  `2.11.0`. It also updates each conda recipe's version so local-source recipe
+  validation matches the package being built. The existing recipe hashes remain
+  unchanged until the packages exist on PyPI. It refreshes the lockfile, commits,
+  and pushes to that branch. You then open the release PR from the "Compare &
+  pull request" banner GitHub shows after the push.
 
   It exists so nobody has to sit and watch a dependency resolve, which was the
   tedious part of cutting a release. Validation remains on the release PR into

--- a/.azure_pipelines/README.md
+++ b/.azure_pipelines/README.md
@@ -34,23 +34,26 @@ github pipelines. There are differences between these systems.
   reference while a human can still retry it.
 
 - `cd-release-prep.yaml` prepares a release. Run it **manually**, with the
-  `releases/rc-trulens-<version>` branch selected and a `bumpType` of `patch`,
-  `minor` or `major`. It bumps the version across every package, refreshes the
-  lockfile, commits, and pushes to that branch. You then open the release PR from
-  the "Compare & pull request" banner GitHub shows after the push.
+  `releases/rc-trulens-<version>` branch selected. The exact version comes from
+  the branch name: selecting `releases/rc-trulens-2.11.0` sets every package to
+  `2.11.0`. It refreshes the lockfile, commits, and pushes to that branch. You
+  then open the release PR from the "Compare & pull request" banner GitHub shows
+  after the push.
 
   It exists so nobody has to sit and watch a dependency resolve, which was the
-  tedious part of cutting a release. It does not run the tests: the Snowflake
-  end-to-end suite stays a human gate, because a bad release there costs weeks.
+  tedious part of cutting a release. Validation remains on the release PR into
+  `main` rather than in this preparation job.
 
-  > Pushing to `releases/*` requires the Azure Pipelines GitHub App to be on the
-  > bypass list for that branch protection rule, configured from the [Branches
-  > settings](https://github.com/truera/trulens/settings/branches) panel. Without
-  > it every step succeeds and only the final push is rejected.
+  > Direct CI pushes to `releases/*` require the Azure Pipelines GitHub App on the
+  > pull-request bypass list and required status checks disabled for that branch
+  > protection rule. Keep pull requests required: the app bypasses that rule only
+  > for release preparation, while the release PR into `main` remains the human
+  > and validation gate.
 
-  > It refuses to run unless the selected branch is under `releases/`. The job
-  > commits and pushes, and the branch picker in the Run dialog makes running it
-  > against `main` an easy mistake.
+  > It refuses to run unless the selected branch matches
+  > `releases/rc-trulens-X.Y.Z`, or if that target is not greater than the current
+  > version. The branch picker in the Run dialog makes running against `main` an
+  > easy mistake, so these checks happen before any files are changed.
 
 - `cd-release-main.yaml` publishes the release. It triggers on every merge to
   `main`, which is the point at which a release is real — nothing can be published

--- a/.azure_pipelines/cd-release-prep.yaml
+++ b/.azure_pipelines/cd-release-prep.yaml
@@ -76,13 +76,14 @@ jobs:
           fi
 
           make "bump-version-$(targetVersion)"
+          make update-meta-yaml-versions
 
           NEW_VERSION=$(grep -m1 '^version' src/core/pyproject.toml | sed -E 's/^version *= *"(.*)"/\1/')
           if [[ "${NEW_VERSION}" != "$(targetVersion)" ]]; then
             echo "Version mismatch: expected $(targetVersion), got ${NEW_VERSION}."
             exit 1
           fi
-        displayName: "Set the version to $(targetVersion)"
+        displayName: "Set package and conda recipe versions to $(targetVersion)"
 
       # Plain `poetry lock`, which under 2.x keeps the pins already in the file and
       # resolves only what the bump actually changed. That is the point: a release

--- a/.azure_pipelines/cd-release-prep.yaml
+++ b/.azure_pipelines/cd-release-prep.yaml
@@ -1,9 +1,9 @@
 # This is a definition for azure pipelines, not github pipelines. There are
 # differences between these systems.
 #
-# Prepares a release: bumps the version across every package, refreshes the
-# lockfile, and pushes the result to the release branch. Run it manually from the
-# Azure DevOps UI with the release branch selected.
+# Prepares a release: sets every package to the version encoded in the release
+# branch name, refreshes the lockfile, and pushes the result to that branch. Run
+# it manually from the Azure DevOps UI with the release branch selected.
 #
 # This exists because the lock was the slow, tedious part of cutting a release and
 # there is no reason a person should sit and watch it. What it deliberately does
@@ -11,22 +11,9 @@
 # and it saves exactly one click on the "Compare & pull request" banner GitHub
 # shows after the push.
 #
-# It also does not run the tests. The Snowflake end-to-end suite stays a human
-# gate, because a bad release there costs weeks rather than minutes.
-#
 # Pushing to releases/* requires the Azure Pipelines GitHub App to be on the
-# bypass list for that branch protection rule. Without it the push is rejected and
-# every other step here will have succeeded.
-
-parameters:
-  - name: bumpType
-    displayName: "Version bump"
-    type: string
-    default: patch
-    values:
-      - patch
-      - minor
-      - major
+# pull-request bypass list and required status checks to be disabled for that
+# branch protection rule. The release PR into main remains the validation gate.
 
 trigger: none
 pr: none
@@ -45,24 +32,25 @@ jobs:
 
     steps:
       # First, and before the checkout, because it needs nothing from the
-      # repository and refusing early is the whole point. This job commits and
-      # pushes, so running it against main would push a version bump straight to
-      # main. The branch picker in the UI makes that a plausible mistake.
+      # repository and refusing early is the whole point. The branch name is the
+      # release version's source of truth; there is no separate bump selector that
+      # can disagree with it.
       - bash: |
           set -euo pipefail
           echo "Selected branch: ${BUILD_SOURCEBRANCH}"
-          case "${BUILD_SOURCEBRANCH}" in
-            refs/heads/releases/*)
-              echo "Release branch, proceeding."
-              ;;
-            *)
-              echo "Refusing to run: this pipeline commits and pushes, so it only"
-              echo "runs on a releases/* branch. Re-run it with the release branch"
-              echo "selected in the Run pipeline dialog."
-              exit 1
-              ;;
-          esac
-        displayName: "Refuse to run outside a release branch"
+          PREFIX="refs/heads/releases/rc-trulens-"
+          TARGET_VERSION="${BUILD_SOURCEBRANCH#"${PREFIX}"}"
+
+          if [[ "${TARGET_VERSION}" == "${BUILD_SOURCEBRANCH}" ]] ||
+             ! [[ "${TARGET_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Refusing to run: select a branch named"
+            echo "releases/rc-trulens-X.Y.Z in the Run pipeline dialog."
+            exit 1
+          fi
+
+          echo "Target version: ${TARGET_VERSION}"
+          echo "##vso[task.setvariable variable=targetVersion]${TARGET_VERSION}"
+        displayName: "Read the target version from the release branch"
 
       - template: templates/env-setup.yaml
         parameters:
@@ -72,8 +60,29 @@ jobs:
 
       - bash: |
           set -euo pipefail
-          make bump-version-${{ parameters.bumpType }}
-        displayName: "Bump the version (${{ parameters.bumpType }})"
+          CURRENT_VERSION=$(grep -m1 '^version' src/core/pyproject.toml | sed -E 's/^version *= *"(.*)"/\1/')
+
+          if ! python - "${CURRENT_VERSION}" "$(targetVersion)" <<'PY'
+          import sys
+
+          current = tuple(map(int, sys.argv[1].split(".")))
+          target = tuple(map(int, sys.argv[2].split(".")))
+          raise SystemExit(0 if target > current else 1)
+          PY
+          then
+            echo "Refusing to run: target version $(targetVersion) must be greater"
+            echo "than current version ${CURRENT_VERSION}."
+            exit 1
+          fi
+
+          make "bump-version-$(targetVersion)"
+
+          NEW_VERSION=$(grep -m1 '^version' src/core/pyproject.toml | sed -E 's/^version *= *"(.*)"/\1/')
+          if [[ "${NEW_VERSION}" != "$(targetVersion)" ]]; then
+            echo "Version mismatch: expected $(targetVersion), got ${NEW_VERSION}."
+            exit 1
+          fi
+        displayName: "Set the version to $(targetVersion)"
 
       # Plain `poetry lock`, which under 2.x keeps the pins already in the file and
       # resolves only what the bump actually changed. That is the point: a release

--- a/Makefile
+++ b/Makefile
@@ -384,7 +384,7 @@ zip-wheels:
 	poetry run ./zip_wheels.sh
 
 
-# Usage: make bump-version-patch
+# Usage: make bump-version-X.Y.Z
 bump-version-%: $(POETRY_DIRS)
 	for dir in $(POETRY_DIRS); do \
 		echo "Updating $$dir version"; \

--- a/Makefile
+++ b/Makefile
@@ -398,6 +398,9 @@ bump-version-%: $(POETRY_DIRS)
 update-meta-yaml:
 	poetry run python update_meta_yaml.py
 
+update-meta-yaml-versions:
+	poetry run python update_meta_yaml.py --version-only
+
 
 ## Step: Upload wheels to pypi
 # Usage: TOKEN=... make upload-trulens-instrument-langchain

--- a/poetry.lock
+++ b/poetry.lock
@@ -10347,7 +10347,7 @@ reference = "pypi-public"
 
 [[package]]
 name = "trulens-apps-gepa"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10364,7 +10364,7 @@ url = "src/apps/gepa"
 
 [[package]]
 name = "trulens-apps-langchain"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10385,7 +10385,7 @@ url = "src/apps/langchain"
 
 [[package]]
 name = "trulens-apps-langgraph"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LangGraph based applications."
 optional = false
 python-versions = "^3.9"
@@ -10411,7 +10411,7 @@ url = "src/apps/langgraph"
 
 [[package]]
 name = "trulens-apps-llamaindex"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10435,7 +10435,7 @@ url = "src/apps/llamaindex"
 
 [[package]]
 name = "trulens-benchmark"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10453,7 +10453,7 @@ url = "src/benchmark"
 
 [[package]]
 name = "trulens-connectors-snowflake"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9,<3.14"
@@ -10473,7 +10473,7 @@ url = "src/connectors/snowflake"
 
 [[package]]
 name = "trulens-core"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10509,7 +10509,7 @@ url = "src/core"
 
 [[package]]
 name = "trulens-dashboard"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9,!=3.9.7"
@@ -10539,7 +10539,7 @@ url = "src/dashboard"
 
 [[package]]
 name = "trulens-eval"
-version = "2.10.0"
+version = "2.11.0"
 description = "Backwards-compatibility package for API of trulens_eval<1.0.0 using API of trulens-*>=1.0.0."
 optional = false
 python-versions = "^3.9,!=3.9.7"
@@ -10558,7 +10558,7 @@ url = "src/trulens_eval"
 
 [[package]]
 name = "trulens-feedback"
-version = "2.10.0"
+version = "2.11.0"
 description = "A TruLens extension package implementing feedback functions for LLM App evaluation."
 optional = false
 python-versions = "^3.9"
@@ -10581,7 +10581,7 @@ url = "src/feedback"
 
 [[package]]
 name = "trulens-hotspots"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library and command-line tool to list features lowering your evaluation score."
 optional = false
 python-versions = "^3.9"
@@ -10601,7 +10601,7 @@ url = "src/hotspots"
 
 [[package]]
 name = "trulens-otel-semconv"
-version = "2.10.0"
+version = "2.11.0"
 description = "Semantic conventions for spans produced by TruLens."
 optional = false
 python-versions = "^3.9"
@@ -10619,7 +10619,7 @@ url = "src/otel/semconv"
 
 [[package]]
 name = "trulens-providers-anthropic"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10639,7 +10639,7 @@ url = "src/providers/anthropic"
 
 [[package]]
 name = "trulens-providers-bedrock"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10659,7 +10659,7 @@ url = "src/providers/bedrock"
 
 [[package]]
 name = "trulens-providers-cortex"
-version = "2.10.0"
+version = "2.11.0"
 description = "A TruLens extension package adding Snowflake Cortex support for LLM App evaluation."
 optional = false
 python-versions = "^3.9,<3.14"
@@ -10682,7 +10682,7 @@ url = "src/providers/cortex"
 
 [[package]]
 name = "trulens-providers-google"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10702,7 +10702,7 @@ url = "src/providers/google"
 
 [[package]]
 name = "trulens-providers-huggingface"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10725,7 +10725,7 @@ url = "src/providers/huggingface"
 
 [[package]]
 name = "trulens-providers-langchain"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10744,7 +10744,7 @@ url = "src/providers/langchain"
 
 [[package]]
 name = "trulens-providers-litellm"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -10763,7 +10763,7 @@ url = "src/providers/litellm"
 
 [[package]]
 name = "trulens-providers-openai"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires = [
 # early with a clear message rather than letting either surprise happen.
 requires-poetry = ">=2.0"
 name = "trulens"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/gepa/pyproject.toml
+++ b/src/apps/gepa/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-gepa"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/langchain/meta.yaml
+++ b/src/apps/langchain/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-apps-langchain" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.10.0" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/apps/langchain/pyproject.toml
+++ b/src/apps/langchain/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-langchain"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/langgraph/meta.yaml
+++ b/src/apps/langgraph/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-apps-langgraph" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.10.0" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/apps/langgraph/pyproject.toml
+++ b/src/apps/langgraph/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-langgraph"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LangGraph based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/llamaindex/pyproject.toml
+++ b/src/apps/llamaindex/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-llamaindex"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/nemo/pyproject.toml
+++ b/src/apps/nemo/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-nemo"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/benchmark/pyproject.toml
+++ b/src/benchmark/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-benchmark"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/connectors/snowflake/meta.yaml
+++ b/src/connectors/snowflake/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-connectors-snowflake" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.10.0" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/connectors/snowflake/pyproject.toml
+++ b/src/connectors/snowflake/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-connectors-snowflake"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-core" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.10.0" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-core"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-dashboard" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.10.0" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/dashboard/pyproject.toml
+++ b/src/dashboard/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-dashboard"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/feedback/meta.yaml
+++ b/src/feedback/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-feedback" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.10.0" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/feedback/pyproject.toml
+++ b/src/feedback/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-feedback"
-version = "2.10.0"
+version = "2.11.0"
 description = "A TruLens extension package implementing feedback functions for LLM App evaluation."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/hotspots/pyproject.toml
+++ b/src/hotspots/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-hotspots"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library and command-line tool to list features lowering your evaluation score."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/otel/semconv/meta.yaml
+++ b/src/otel/semconv/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-otel-semconv" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.10.0" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/otel/semconv/pyproject.toml
+++ b/src/otel/semconv/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-otel-semconv"
-version = "2.10.0"
+version = "2.11.0"
 description = "Semantic conventions for spans produced by TruLens."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/anthropic/pyproject.toml
+++ b/src/providers/anthropic/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-anthropic"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/bedrock/pyproject.toml
+++ b/src/providers/bedrock/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-bedrock"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-providers-cortex" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.10.0" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/providers/cortex/pyproject.toml
+++ b/src/providers/cortex/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-cortex"
-version = "2.10.0"
+version = "2.11.0"
 description = "A TruLens extension package adding Snowflake Cortex support for LLM App evaluation."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/google/pyproject.toml
+++ b/src/providers/google/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-google"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/huggingface/pyproject.toml
+++ b/src/providers/huggingface/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-huggingface"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/langchain/pyproject.toml
+++ b/src/providers/langchain/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-langchain"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/litellm/pyproject.toml
+++ b/src/providers/litellm/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-litellm"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/openai/pyproject.toml
+++ b/src/providers/openai/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-openai"
-version = "2.10.0"
+version = "2.11.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/trulens_eval/pyproject.toml
+++ b/src/trulens_eval/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens_eval"
-version = "2.10.0"
+version = "2.11.0"
 description = "Backwards-compatibility package for API of trulens_eval<1.0.0 using API of trulens-*>=1.0.0."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/update_meta_yaml.py
+++ b/update_meta_yaml.py
@@ -16,6 +16,7 @@ Usage:
     make update-meta-yaml
 """
 
+import argparse
 from pathlib import Path
 import re
 import sys
@@ -93,6 +94,21 @@ def fetch_sha256_from_pypi(package_name: str, version: str) -> str | None:
         return None
 
 
+def update_meta_yaml_version(meta_yaml_path: Path, version: str) -> bool:
+    """Update only the version in a meta.yaml file."""
+    content = meta_yaml_path.read_text()
+    updated = re.sub(
+        r'(\{%\s*set\s+version\s*=\s*")[^"]+("\s*%\})',
+        rf"\g<1>{version}\g<2>",
+        content,
+    )
+
+    if updated != content:
+        meta_yaml_path.write_text(updated)
+        return True
+    return False
+
+
 def update_meta_yaml(meta_yaml_path: Path, version: str, sha256: str) -> bool:
     """Update the meta.yaml file with new version and SHA256.
 
@@ -121,9 +137,20 @@ def update_meta_yaml(meta_yaml_path: Path, version: str, sha256: str) -> bool:
 
 def main():
     """Main function to update all meta.yaml files."""
-    print(
-        "Updating meta.yaml files with versions and SHA256 hashes from PyPI...\n"
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--version-only",
+        action="store_true",
+        help="Update recipe versions without fetching pre-release hashes.",
     )
+    args = parser.parse_args()
+
+    if args.version_only:
+        print("Updating meta.yaml versions from pyproject.toml files...\n")
+    else:
+        print(
+            "Updating meta.yaml files with versions and SHA256 hashes from PyPI...\n"
+        )
 
     meta_yaml_files = find_meta_yaml_files()
 
@@ -141,16 +168,6 @@ def main():
         relative_path = meta_yaml_path.relative_to(REPO_ROOT)
         print(f"Processing: {relative_path}")
 
-        # Extract package name
-        package_name = extract_package_name(meta_yaml_path)
-        if not package_name:
-            print(
-                f"  Error: Could not extract package name from {relative_path}"
-            )
-            error_count += 1
-            continue
-        print(f"  Package: {package_name}")
-
         # Find corresponding pyproject.toml
         pyproject_path = meta_yaml_path.parent / "pyproject.toml"
         version = extract_version_from_pyproject(pyproject_path)
@@ -161,6 +178,26 @@ def main():
             error_count += 1
             continue
         print(f"  Version: {version}")
+
+        if args.version_only:
+            if update_meta_yaml_version(meta_yaml_path, version):
+                print(f"  ✓ Updated {relative_path}")
+                success_count += 1
+            else:
+                print("  - No changes needed (already up to date)")
+                skip_count += 1
+            print()
+            continue
+
+        # Extract package name
+        package_name = extract_package_name(meta_yaml_path)
+        if not package_name:
+            print(
+                f"  Error: Could not extract package name from {relative_path}"
+            )
+            error_count += 1
+            continue
+        print(f"  Package: {package_name}")
 
         # Fetch SHA256 from PyPI
         sha256 = fetch_sha256_from_pypi(package_name, version)


### PR DESCRIPTION

# TruLens 2.11.0

Two features land in 2.11.0 that push the boundary of how you can observe your agents.

We added a direct path for Anthropic models in the new anthropic providers package. **Anthropic becomes a first-class provider** — Claude models are now usable as judges through a native `trulens-providers-anthropic` package with real cost tracking, rather than via a LiteLLM hop. 

And **online evaluation gets sampling controls**, so you can turn on automatic post-ingest evals on a high-traffic app without evaluating (and paying for) every single record.

Alongside those, MCP tool calls get an end-to-end cookbook showing how to trace and evaluate them.

Three new contributors shipped every feature in this release.

## New Features

### Anthropic provider for Claude models

**`trulens-providers-anthropic`** ([#2532](https://github.com/truera/trulens/pull/2532) — @Oxygen56)

A new installable provider package for native Anthropic/Claude support, following the same pattern as the OpenAI and Google providers. Defaults to `claude-sonnet-4-6`, reads `ANTHROPIC_API_KEY` from the environment, and tracks cost per-model across the Opus 4, Sonnet 4, and Haiku 4.5 families.

Notable implementation details: OpenAI-style message lists are translated to Anthropic's format (system messages hoisted to the top-level `system` param, `tool` messages converted to `tool_result` blocks, consecutive same-role messages merged to satisfy Anthropic's alternating requirement). Structured output uses Anthropic's native `tool_use` with the Pydantic JSON Schema passed as a tool definition, falling back to text extraction on parse failure.

Closes [#2404](https://github.com/truera/trulens/issues/2404).

```bash
pip install trulens-providers-anthropic
```

```python
from trulens.providers.anthropic import Anthropic

provider = Anthropic()  # or Anthropic(model_engine="claude-opus-4-1")

score, reasons = provider.relevance_with_cot_reasons(
    "What is the capital of France?",
    "Paris is the capital of France.",
)
```

### Sampling for online evaluation

**`TruSession.configure_online_eval()`** ([#2649](https://github.com/truera/trulens/pull/2649) — @Payal2000)

Controls how much of your ingested traffic gets automatically evaluated. Three independent levers: `sample_rate` (global, or a per-app dict), `throttle` (max evals per minute), and `cost_budget` (daily USD cap).

Sampling is deterministic — a SHA-256 hash of `record_id` salted with `app_name` — so decisions are idempotent across retries and replays. Only the ingest path is gated: explicit `compute_metrics()` / `compute_now()` still evaluate everything, and batch backfills don't charge against the daily cost budget.

For records in scope, an `EVAL_DECISION` span is emitted whether or not the record was evaluated, so `get_records_and_feedback()` surfaces `sampled`, `sample_rate`, and `eval_decision_reason` columns and you can measure your actual eval coverage. Apps not covered by a config evaluate normally with no span overhead.

Also adds a `reports_costs` property to the `Provider` base (default `False`, overridden to `True` on OpenAI, LiteLLM, Google, and Cortex) so the cost budget knows which providers it can actually account for.

Refs [#2630](https://github.com/truera/trulens/issues/2630).

```python
from trulens.core import TruSession

session = TruSession()

session.configure_online_eval(
    sample_rate={"prod-rag": 0.05, "staging-rag": 1.0},
    throttle=60,           # max evals/min
    cost_budget=25.00,     # daily USD cap
    feedbacks=[f_groundedness, f_context_relevance],
)
```

Dashboard coverage visibility and cost-warning display are follow-up work, as is alerting integration ([#2619](https://github.com/truera/trulens/issues/2619)).

## Examples

### MCP tool instrumentation cookbook

**MCP tracing and evaluation walkthrough** ([#2638](https://github.com/truera/trulens/pull/2638) — @bhargavikalicheti)

A self-contained cookbook for tracing and evaluating Model Context Protocol tool calls. It starts a deterministic local MCP server over stdio using the official MCP Python SDK, discovers its tools through `ClientSession`, and invokes them from a LangGraph agent — capturing MCP span attributes (server name, tool name, arguments, output, error status, execution time) along the way, then running Tool Selection and Tool Calling evaluations on the result.

The bundled weather/temperature-conversion server needs no network access or external credentials; OpenAI is used only by the agent and the LLM-based metrics. Ships with integration test coverage.

Closes [#2415](https://github.com/truera/trulens/issues/2415).

## Docs
- **Rebuilt trulens.org home page** ([#2647](https://github.com/truera/trulens/pull/2647) — @joshreini1) — closes [#2413](https://github.com/truera/trulens/issues/2413).
- **Feedback providers page, plus a custom `base_url` guide** ([#2602](https://github.com/truera/trulens/pull/2602) — @seven7763) — documents pointing the OpenAI provider at any OpenAI-compatible Chat Completions endpoint (vLLM, Ollama shims, OpenRouter, Together, Fireworks, DaoXE, reverse proxies) via `base_url`, with the equivalent LiteLLM route. Also surfaces the previously-unlinked Feedback Providers page in the docs nav.
- **Stop baking stat values into the home page markup** ([#2659](https://github.com/truera/trulens/pull/2659) — @joshreini1) — homepage numbers no longer go stale silently.
- **Strict docs build is now warning-clean** ([#2646](https://github.com/truera/trulens/pull/2646) — @joshreini1) — Docs CI can pass without grep-filtering expected warnings out of the log.

## Bug Fixes
- **Repair Bedrock Nova tests, eval_gate formatting, and a dangling docs link** (#2654 — @joshreini1)

## New Contributors (3)

[@seven7763](https://github.com/seven7763), [@bhargavikalicheti](https://github.com/bhargavikalicheti), [@Oxygen56](https://github.com/Oxygen56) — every feature in this release came from a first-time contributor.

One-line takeaway: 2.11.0 makes Claude a native judge (`trulens-providers-anthropic`) and makes always-on evaluation affordable (`configure_online_eval()` with sampling, throttling, and a daily cost budget).

**Full Changelog**: https://github.com/truera/trulens/compare/trulens-2.10.0...trulens-2.11.0
