### PR TITLE
Fix conda validation for TruLens 2.11.0

### DIFF
--- a/.azure_pipelines/README.md
+++ b/.azure_pipelines/README.md
@@ -36,9 +36,11 @@ github pipelines. There are differences between these systems.
 - `cd-release-prep.yaml` prepares a release. Run it **manually**, with the
   `releases/rc-trulens-<version>` branch selected. The exact version comes from
   the branch name: selecting `releases/rc-trulens-2.11.0` sets every package to
-  `2.11.0`. It refreshes the lockfile, commits, and pushes to that branch. You
-  then open the release PR from the "Compare & pull request" banner GitHub shows
-  after the push.
+  `2.11.0`. It also updates each conda recipe's version so local-source recipe
+  validation matches the package being built. The existing recipe hashes remain
+  unchanged until the packages exist on PyPI. It refreshes the lockfile, commits,
+  and pushes to that branch. You then open the release PR from the "Compare &
+  pull request" banner GitHub shows after the push.
 
   It exists so nobody has to sit and watch a dependency resolve, which was the
   tedious part of cutting a release. Validation remains on the release PR into

--- a/.azure_pipelines/cd-release-prep.yaml
+++ b/.azure_pipelines/cd-release-prep.yaml
@@ -76,13 +76,14 @@ jobs:
           fi
 
           make "bump-version-$(targetVersion)"
+          make update-meta-yaml-versions
 
           NEW_VERSION=$(grep -m1 '^version' src/core/pyproject.toml | sed -E 's/^version *= *"(.*)"/\1/')
           if [[ "${NEW_VERSION}" != "$(targetVersion)" ]]; then
             echo "Version mismatch: expected $(targetVersion), got ${NEW_VERSION}."
             exit 1
           fi
-        displayName: "Set the version to $(targetVersion)"
+        displayName: "Set package and conda recipe versions to $(targetVersion)"
 
       # Plain `poetry lock`, which under 2.x keeps the pins already in the file and
       # resolves only what the bump actually changed. That is the point: a release

--- a/Makefile
+++ b/Makefile
@@ -398,6 +398,9 @@ bump-version-%: $(POETRY_DIRS)
 update-meta-yaml:
 	poetry run python update_meta_yaml.py
 
+update-meta-yaml-versions:
+	poetry run python update_meta_yaml.py --version-only
+
 
 ## Step: Upload wheels to pypi
 # Usage: TOKEN=... make upload-trulens-instrument-langchain

--- a/src/apps/langchain/meta.yaml
+++ b/src/apps/langchain/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-apps-langchain" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.10.0" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/apps/langgraph/meta.yaml
+++ b/src/apps/langgraph/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-apps-langgraph" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.10.0" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/connectors/snowflake/meta.yaml
+++ b/src/connectors/snowflake/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-connectors-snowflake" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.10.0" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-core" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.10.0" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-dashboard" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.10.0" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/feedback/meta.yaml
+++ b/src/feedback/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-feedback" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.10.0" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/otel/semconv/meta.yaml
+++ b/src/otel/semconv/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-otel-semconv" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.10.0" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-providers-cortex" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.10.0" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name|lower }}

--- a/update_meta_yaml.py
+++ b/update_meta_yaml.py
@@ -16,6 +16,7 @@ Usage:
     make update-meta-yaml
 """
 
+import argparse
 from pathlib import Path
 import re
 import sys
@@ -93,6 +94,21 @@ def fetch_sha256_from_pypi(package_name: str, version: str) -> str | None:
         return None
 
 
+def update_meta_yaml_version(meta_yaml_path: Path, version: str) -> bool:
+    """Update only the version in a meta.yaml file."""
+    content = meta_yaml_path.read_text()
+    updated = re.sub(
+        r'(\{%\s*set\s+version\s*=\s*")[^"]+("\s*%\})',
+        rf"\g<1>{version}\g<2>",
+        content,
+    )
+
+    if updated != content:
+        meta_yaml_path.write_text(updated)
+        return True
+    return False
+
+
 def update_meta_yaml(meta_yaml_path: Path, version: str, sha256: str) -> bool:
     """Update the meta.yaml file with new version and SHA256.
 
@@ -121,9 +137,20 @@ def update_meta_yaml(meta_yaml_path: Path, version: str, sha256: str) -> bool:
 
 def main():
     """Main function to update all meta.yaml files."""
-    print(
-        "Updating meta.yaml files with versions and SHA256 hashes from PyPI...\n"
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--version-only",
+        action="store_true",
+        help="Update recipe versions without fetching pre-release hashes.",
     )
+    args = parser.parse_args()
+
+    if args.version_only:
+        print("Updating meta.yaml versions from pyproject.toml files...\n")
+    else:
+        print(
+            "Updating meta.yaml files with versions and SHA256 hashes from PyPI...\n"
+        )
 
     meta_yaml_files = find_meta_yaml_files()
 
@@ -141,16 +168,6 @@ def main():
         relative_path = meta_yaml_path.relative_to(REPO_ROOT)
         print(f"Processing: {relative_path}")
 
-        # Extract package name
-        package_name = extract_package_name(meta_yaml_path)
-        if not package_name:
-            print(
-                f"  Error: Could not extract package name from {relative_path}"
-            )
-            error_count += 1
-            continue
-        print(f"  Package: {package_name}")
-
         # Find corresponding pyproject.toml
         pyproject_path = meta_yaml_path.parent / "pyproject.toml"
         version = extract_version_from_pyproject(pyproject_path)
@@ -161,6 +178,26 @@ def main():
             error_count += 1
             continue
         print(f"  Version: {version}")
+
+        if args.version_only:
+            if update_meta_yaml_version(meta_yaml_path, version):
+                print(f"  ✓ Updated {relative_path}")
+                success_count += 1
+            else:
+                print("  - No changes needed (already up to date)")
+                skip_count += 1
+            print()
+            continue
+
+        # Extract package name
+        package_name = extract_package_name(meta_yaml_path)
+        if not package_name:
+            print(
+                f"  Error: Could not extract package name from {relative_path}"
+            )
+            error_count += 1
+            continue
+        print(f"  Package: {package_name}")
 
         # Fetch SHA256 from PyPI
         sha256 = fetch_sha256_from_pypi(package_name, version)


### PR DESCRIPTION
## Summary
- update all eight conda recipe versions to `2.11.0` while preserving their existing pre-release hashes
- teach Release Prep to update recipe versions before PR validation
- keep the post-PyPI stage responsible for replacing hashes from the uploaded sdists

## Why
Conda CI builds from local source, so stale hashes are harmless before publication. Recipe versions are not: the recipes packaged the 2.11.0 source as 2.10.0 and failed their installed-version assertions.

## Test plan
- [x] Verify all eight recipe versions match their corresponding `pyproject.toml`
- [x] Verify all eight recipe SHA256 values are unchanged
- [x] Verify version-only updates are idempotent and preserve hashes
- [x] Run focused pre-commit checks

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)