### PR TITLE
feat(docs+examples): end-to-end conversation evaluation example (#2626)

### DIFF
--- a/docs/component_guides/instrumentation/conversation_evaluation.md
+++ b/docs/component_guides/instrumentation/conversation_evaluation.md
@@ -1,0 +1,154 @@
+# Conversation Evaluation
+
+This guide explains how to evaluate multi-turn conversations end-to-end with TruLens:
+how `conversation_id` flows from your app into TruLens, how to wire per-turn metrics,
+the difference between record-level and conversation-level scores, and how to explore
+results in the dashboard's conversation view.
+
+!!! tip "Quickstart notebook"
+    The concepts on this page are demonstrated end-to-end in the
+    [Conversation Evaluation Quickstart](../../../examples/quickstart/conversation_evaluation.ipynb)
+    notebook.
+
+## How `conversation_id` flows
+
+When you pass `conversation_id` to the recording context manager, TruLens propagates
+the value through [OpenTelemetry Baggage](https://opentelemetry.io/docs/concepts/signals/baggage/)
+so every span produced during that invocation carries the attribute
+`ai.observability.conversation_id`.  Each invocation (a single turn) becomes one TruLens
+**record**.  Records that share a `conversation_id` are logically grouped into a
+**conversation**.
+
+```
+Turn 1  →  with tru_app(conversation_id="conv-42") as recording:  →  Record A  ┐
+Turn 2  →  with tru_app(conversation_id="conv-42") as recording:  →  Record B  ├─ Conversation "conv-42"
+Turn 3  →  with tru_app(conversation_id="conv-42") as recording:  →  Record C  ┘
+```
+
+See [Conversation ID — Grouping Multi-Turn Traces](conversation_id.md) for the
+full API reference and propagation details.
+
+## Wiring conversation metrics
+
+Feedback metrics are defined and attached to the `TruApp` wrapper exactly as for
+single-turn apps.  Each metric is evaluated **per turn** (per record) by default.
+
+```python
+from trulens.core import Metric, Selector, TruSession
+from trulens.apps.langchain import TruChain
+from trulens.providers.openai import OpenAI
+
+session = TruSession()
+provider = OpenAI(model_engine="gpt-4o-mini")
+
+# Per-turn answer relevance
+f_answer_relevance = Metric(
+    implementation=provider.relevance_with_cot_reasons,
+    name="Answer Relevance",
+    selectors={
+        "prompt": Selector.select_record_input(),
+        "response": Selector.select_record_output(),
+    },
+)
+
+# Per-turn coherence
+f_coherence = Metric(
+    implementation=provider.coherence_with_cot_reasons,
+    name="Coherence",
+    selectors={
+        "text": Selector.select_record_output(),
+    },
+)
+
+tru_chatbot = TruChain(
+    chatbot,
+    app_name="Chatbot",
+    app_version="v1",
+    feedbacks=[f_answer_relevance, f_coherence],
+)
+```
+
+## Recording multi-turn conversations
+
+Pass the same `conversation_id` string to every turn of the same conversation.
+Use a different ID for each independent conversation.
+
+```python
+CONV_ID = "conv-climate-001"
+
+turns = [
+    "What is the greenhouse effect?",
+    "How does it relate to global warming?",
+    "What are the most effective ways to reduce carbon emissions?",
+]
+
+for turn in turns:
+    with tru_chatbot(conversation_id=CONV_ID) as recording:
+        chatbot.invoke(
+            {"input": turn},
+            config={"configurable": {"session_id": CONV_ID}},
+        )
+```
+
+Each `with` block produces one record.  All three records share the same
+`conversation_id`, so TruLens groups them as a single conversation thread.
+
+## Per-record vs conversation-level scores
+
+| Level | What it measures | How to get it |
+|---|---|---|
+| **Per-record (turn-level)** | Quality of a single response — relevance, coherence, groundedness | `Metric` evaluated inside each recording context; visible per row in `get_records_and_feedback()` |
+| **Conversation-level** | Quality across the whole thread — e.g., average score, worst-turn detection | Aggregate per-turn scores by `conversation_id` in post-processing (see below) |
+
+### Retrieving turn-level scores
+
+```python
+records, feedback = session.get_records_and_feedback(app_ids=["Chatbot"])
+
+# All turns for one conversation
+conv_records = records[records["conversation_id"] == "conv-climate-001"]
+conv_records[["input", "output", "Answer Relevance", "Coherence"]]
+```
+
+### Aggregating to conversation-level scores
+
+```python
+summary = (
+    records
+    .groupby("conversation_id")[["Answer Relevance", "Coherence"]]
+    .mean()
+    .round(3)
+)
+```
+
+This gives one row per conversation with the mean score across all its turns —
+useful for comparing conversations or detecting which thread had the most trouble.
+
+## Dashboard conversation view
+
+Launch the dashboard to explore conversations visually:
+
+```python
+from trulens.dashboard import run_dashboard
+
+run_dashboard(session)
+```
+
+In the dashboard:
+
+- The **Records** tab shows all turns. Filter by `conversation_id` to see only
+  the turns belonging to one conversation.
+- Each turn's feedback scores are displayed inline so you can spot the exact
+  turn where quality dropped.
+- The **Leaderboard** tab summarises aggregate metrics across all conversations
+  for quick comparison.
+
+## See also
+
+- [Conversation ID — Grouping Multi-Turn Traces](conversation_id.md) — propagation
+  mechanics and API reference
+- [Span Groups](span_groups.md) — localize metrics to specific segments within a
+  single turn
+- [Feedback Selectors](../evaluation/feedback_selectors/index.md) — choosing what
+  to evaluate in each turn
+- [Conversation Evaluation Quickstart notebook](../../../examples/quickstart/conversation_evaluation.ipynb)

--- a/docs/component_guides/instrumentation/conversation_id.md
+++ b/docs/component_guides/instrumentation/conversation_id.md
@@ -83,3 +83,11 @@ with tru_app as recording:
   creating and managing conversation identifiers in your application.
 * The value is stored in OTEL Baggage during the context-manager lifetime and
   therefore does not leak across concurrent invocations that use different IDs.
+
+## Next steps
+
+Once conversations are tagged, see [Conversation Evaluation](conversation_evaluation.md)
+for a complete guide on wiring per-turn metrics, aggregating scores by conversation,
+and exploring results in the dashboard.  The
+[Conversation Evaluation Quickstart](../../../examples/quickstart/conversation_evaluation.ipynb)
+notebook walks through this end-to-end.

--- a/examples/quickstart/conversation_evaluation.ipynb
+++ b/examples/quickstart/conversation_evaluation.ipynb
@@ -1,0 +1,357 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-0",
+   "metadata": {},
+   "source": [
+    "# 🗣️ Conversation Evaluation Quickstart\n",
+    "\n",
+    "This notebook shows the full loop for evaluating **multi-turn conversations** with TruLens:\n",
+    "\n",
+    "1. Build a memory-enabled LangChain chatbot\n",
+    "2. Record 2–3 conversations, each tagged with a `conversation_id`\n",
+    "3. Run per-turn feedback metrics\n",
+    "4. Filter and compare results by conversation\n",
+    "5. Visualise in the TruLens dashboard\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/truera/trulens/blob/main/examples/quickstart/conversation_evaluation.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install trulens trulens-apps-langchain trulens-providers-openai langchain langchain-openai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if \"OPENAI_API_KEY\" not in os.environ:\n",
+    "    os.environ[\"OPENAI_API_KEY\"] = \"sk-proj-...\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-3",
+   "metadata": {},
+   "source": [
+    "## Build the chatbot\n",
+    "\n",
+    "We use LangChain's `RunnableWithMessageHistory` to maintain per-conversation history.\n",
+    "Each conversation is keyed by a **session ID** — the same value we will pass as `conversation_id` to TruLens."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_community.chat_message_histories import ChatMessageHistory\n",
+    "from langchain_core.output_parsers import StrOutputParser\n",
+    "from langchain_core.prompts import ChatPromptTemplate\n",
+    "from langchain_core.prompts import MessagesPlaceholder\n",
+    "from langchain_core.runnables.history import RunnableWithMessageHistory\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "\n",
+    "llm = ChatOpenAI(model=\"gpt-4o-mini\", temperature=0)\n",
+    "\n",
+    "prompt = ChatPromptTemplate.from_messages([\n",
+    "    (\n",
+    "        \"system\",\n",
+    "        \"You are a knowledgeable assistant. Answer concisely in 2–3 sentences.\",\n",
+    "    ),\n",
+    "    MessagesPlaceholder(variable_name=\"history\"),\n",
+    "    (\"human\", \"{input}\"),\n",
+    "])\n",
+    "\n",
+    "# In-memory store keyed by session / conversation ID\n",
+    "store: dict = {}\n",
+    "\n",
+    "\n",
+    "def get_session_history(session_id: str) -> ChatMessageHistory:\n",
+    "    if session_id not in store:\n",
+    "        store[session_id] = ChatMessageHistory()\n",
+    "    return store[session_id]\n",
+    "\n",
+    "\n",
+    "chatbot = RunnableWithMessageHistory(\n",
+    "    prompt | llm | StrOutputParser(),\n",
+    "    get_session_history,\n",
+    "    input_messages_key=\"input\",\n",
+    "    history_messages_key=\"history\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-5",
+   "metadata": {},
+   "source": [
+    "## Set up TruSession and feedback functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.core import TruSession\n",
+    "\n",
+    "session = TruSession()\n",
+    "session.reset_database()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.core import Metric\n",
+    "from trulens.core import Selector\n",
+    "from trulens.providers.openai import OpenAI\n",
+    "\n",
+    "provider = OpenAI(model_engine=\"gpt-4o-mini\")\n",
+    "\n",
+    "# How well does the assistant's answer address the user's question?\n",
+    "f_answer_relevance = Metric(\n",
+    "    implementation=provider.relevance_with_cot_reasons,\n",
+    "    name=\"Answer Relevance\",\n",
+    "    selectors={\n",
+    "        \"prompt\": Selector.select_record_input(),\n",
+    "        \"response\": Selector.select_record_output(),\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "# Does the assistant's answer avoid introducing contradictions or hallucinations?\n",
+    "f_coherence = Metric(\n",
+    "    implementation=provider.coherence_with_cot_reasons,\n",
+    "    name=\"Coherence\",\n",
+    "    selectors={\n",
+    "        \"text\": Selector.select_record_output(),\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-8",
+   "metadata": {},
+   "source": [
+    "## Wrap the chatbot with TruChain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.apps.langchain import TruChain\n",
+    "\n",
+    "tru_chatbot = TruChain(\n",
+    "    chatbot,\n",
+    "    app_name=\"Chatbot\",\n",
+    "    app_version=\"v1\",\n",
+    "    feedbacks=[f_answer_relevance, f_coherence],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-10",
+   "metadata": {},
+   "source": [
+    "## Run conversations\n",
+    "\n",
+    "Each conversation gets a unique `conversation_id`.  \n",
+    "Every turn in the same conversation shares that ID so TruLens can group them together.\n",
+    "\n",
+    "We run two independent conversations:\n",
+    "- **conv-climate-001** — a 3-turn discussion about climate change\n",
+    "- **conv-python-002** — a 3-turn discussion about Python programming"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── Conversation A: climate change ──────────────────────────────────────────\n",
+    "CONV_A = \"conv-climate-001\"\n",
+    "\n",
+    "turns_a = [\n",
+    "    \"What is the greenhouse effect?\",\n",
+    "    \"How does it relate to global warming?\",\n",
+    "    \"What are the most effective ways to reduce carbon emissions?\",\n",
+    "]\n",
+    "\n",
+    "for turn in turns_a:\n",
+    "    with tru_chatbot(conversation_id=CONV_A) as recording:\n",
+    "        chatbot.invoke(\n",
+    "            {\"input\": turn},\n",
+    "            config={\"configurable\": {\"session_id\": CONV_A}},\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── Conversation B: Python programming ──────────────────────────────────────\n",
+    "CONV_B = \"conv-python-002\"\n",
+    "\n",
+    "turns_b = [\n",
+    "    \"What makes Python a good language for beginners?\",\n",
+    "    \"Can you explain list comprehensions with a simple example?\",\n",
+    "    \"When should I use a generator instead of a list?\",\n",
+    "]\n",
+    "\n",
+    "for turn in turns_b:\n",
+    "    with tru_chatbot(conversation_id=CONV_B) as recording:\n",
+    "        chatbot.invoke(\n",
+    "            {\"input\": turn},\n",
+    "            config={\"configurable\": {\"session_id\": CONV_B}},\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-13",
+   "metadata": {},
+   "source": [
+    "## View results\n",
+    "\n",
+    "### Overall leaderboard"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session.get_leaderboard()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-15",
+   "metadata": {},
+   "source": [
+    "### Filter records by conversation\n",
+    "\n",
+    "Use `conversation_id` to retrieve all turns for a single conversation and compare metrics turn-by-turn."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "records, feedback = session.get_records_and_feedback(app_ids=[\"Chatbot\"])\n",
+    "\n",
+    "# All turns for Conversation A\n",
+    "conv_a_records = records[records[\"conversation_id\"] == CONV_A]\n",
+    "print(f\"Conversation A — {len(conv_a_records)} turns\")\n",
+    "conv_a_records[[\"input\", \"output\", \"Answer Relevance\", \"Coherence\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# All turns for Conversation B\n",
+    "conv_b_records = records[records[\"conversation_id\"] == CONV_B]\n",
+    "print(f\"Conversation B — {len(conv_b_records)} turns\")\n",
+    "conv_b_records[[\"input\", \"output\", \"Answer Relevance\", \"Coherence\"]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-18",
+   "metadata": {},
+   "source": [
+    "### Per-conversation aggregate scores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summary = (\n",
+    "    records.groupby(\"conversation_id\")[[\"Answer Relevance\", \"Coherence\"]]\n",
+    "    .mean()\n",
+    "    .round(3)\n",
+    ")\n",
+    "summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-20",
+   "metadata": {},
+   "source": [
+    "## Launch the TruLens dashboard\n",
+    "\n",
+    "The dashboard's **Conversation** view lets you explore all turns of a conversation thread together,\n",
+    "inspect per-turn scores, and compare conversations side by side."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.dashboard import run_dashboard\n",
+    "\n",
+    "run_dashboard(session)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -258,6 +258,8 @@ nav:
         - component_guides/instrumentation/llama_index.md
         - MCP: component_guides/instrumentation/mcp.md
         - Span Groups: component_guides/instrumentation/span_groups.md
+        - Conversation ID: component_guides/instrumentation/conversation_id.md
+        - Conversation Evaluation: component_guides/instrumentation/conversation_evaluation.md
     - Logging:
         - component_guides/logging/where_to_log/index.md
         - Postgres: component_guides/logging/where_to_log/log_in_postgres.md


### PR DESCRIPTION
## Summary

Closes #2626.

- **`examples/quickstart/conversation_evaluation.ipynb`** — new quickstart notebook: builds a memory-enabled LangChain chatbot (`RunnableWithMessageHistory`), records two 3-turn conversations each tagged with a `conversation_id`, runs Answer Relevance + Coherence metrics per turn, filters/aggregates records by `conversation_id`, and launches the dashboard.
- **`docs/component_guides/instrumentation/conversation_evaluation.md`** — new docs page covering the full loop: how `conversation_id` flows into spans, wiring per-turn metrics, per-record vs conversation-level scores (with groupby pattern), and the dashboard conversation view.
- **`docs/component_guides/instrumentation/conversation_id.md`** — added "Next steps" section cross-linking to the new guide and notebook.
- **`mkdocs.yml`** — added both new pages to the nav under Instrumentation.

## Files changed

| File | Change |
|---|---|
| `examples/quickstart/conversation_evaluation.ipynb` | New |
| `docs/component_guides/instrumentation/conversation_evaluation.md` | New |
| `docs/component_guides/instrumentation/conversation_id.md` | Cross-link added |
| `mkdocs.yml` | Nav entries added |

## Test plan

- [ ] Notebook runs top-to-bottom with a valid `OPENAI_API_KEY` and `TEST_OPTIONAL=1`
- [ ] Both conversations produce 3 records each; `records["conversation_id"]` filters correctly
- [ ] Leaderboard and per-conversation aggregate table render without error
- [ ] Dashboard launches and shows conversation threads grouped by `conversation_id`
- [ ] Doc page renders in `mkdocs serve` with no broken links
- [ ] Cross-link from `conversation_id.md` resolves correctly