### PR TITLE
fix(groundedness): fence statement and stop instructing judge to copy it verbatim

### DIFF
--- a/src/feedback/trulens/feedback/templates/rag.py
+++ b/src/feedback/trulens/feedback/templates/rag.py
@@ -66,10 +66,10 @@ class Groundedness(Semantics, WithPrompt, CriteriaOutputSpaceMixin):
     user_prompt: ClassVar[str] = cleandoc(
         """SOURCE: {premise}
 
-        STATEMENT: {hypothesis}
+        <statement>{hypothesis}</statement>
 
         Respond ONLY with a single-line JSON object having exactly these keys:
-          "criteria"             – copy of the STATEMENT verbatim
+          "criteria"             – a short label for the statement (do NOT copy it)
           "supporting_evidence"  – sentence(s) from SOURCE that support the STATEMENT, or the string NOTHING FOUND or ABSTENTION
           "score"                – an integer 0, 1, 2, or 3
 


### PR DESCRIPTION
## Summary

The Groundedness user_prompt template (`templates/rag.py:66`) instructs the judge to set the `criteria` key to a verbatim copy of the STATEMENT. Since `STATEMENT: {hypothesis}` is the model-under-test output interpolated via `str.format`, the judge is guaranteed to reproduce attacker-controlled text in its JSON output. Combined with the JSON `score` key being trusted directly, a crafted answer can influence its own groundedness score.

## Fix (2 lines changed)

1. Wrap the hypothesis in `<statement>...</statement>` tags so the judge treats it as data.
2. Change `criteria: copy of the STATEMENT verbatim` to `criteria: a short label for the statement (do NOT copy it)`.

## Verification

- `ruff check`: all checks passed
- 1 file changed, 2 insertions, 2 deletions