### PR TITLE
fix(feedback): unwrap generate_score tuple in float-returning feedbacks

### DIFF
--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -206,7 +206,7 @@ class LLMProvider(core_provider.Provider):
         min_score_val: int = 0,
         max_score_val: int = 10,
         temperature: float = 0.0,
-    ) -> float | tuple[float, dict]:
+    ) -> float:
         """
         Base method to generate a score normalized to 0 to 1, used for evaluation.
 
@@ -218,15 +218,8 @@ class LLMProvider(core_provider.Provider):
             temperature (float): The temperature for the LLM response.
 
         Returns:
-            float | tuple[float, dict]: The normalized score on a 0-1 scale.
-            When the LLM returns a structured JSON response containing a ``score``
-            key, returns a ``(score, reason_dict)`` tuple where ``reason_dict``
-            contains the raw parsed JSON under a ``"reason"`` key. When the
-            response is a plain string, returns a bare ``float``. Callers should
-            handle both forms, e.g.::
-
-                result = provider.generate_score(system_prompt="...")
-                score = result[0] if isinstance(result, tuple) else result
+            float: The normalized score on a 0-1 scale. If reasons are needed,
+            use :meth:`generate_score_and_reasons` instead.
         """
 
         assert self.endpoint is not None, "Endpoint is not set."
@@ -277,7 +270,7 @@ class LLMProvider(core_provider.Provider):
                     max_score_val - min_score_val
                 )
 
-            return normalized_score, {"reason": parsed_json}
+            return normalized_score
 
         if isinstance(parsed_json, list):
             # If a list is returned, average the scores where possible.
@@ -303,7 +296,7 @@ class LLMProvider(core_provider.Provider):
                 )
             else:
                 normalized_score = -1.0
-            return normalized_score, {"reason": parsed_json}
+            return normalized_score
 
         if isinstance(response, feedback_output_schemas.BaseFeedbackResponse):
             score = response.score
@@ -3610,10 +3603,6 @@ class LLMProvider(core_provider.Provider):
                     min_score_val=0,
                     max_score_val=1,
                 )
-                # generate_score returns (score, reason) when the judge
-                # responds with structured JSON; compare on the score alone.
-                if isinstance(score, tuple):
-                    score = score[0]
             except Exception:
                 score = 0  # assume not abstention if abstention scoring fails
             return score
@@ -3630,10 +3619,6 @@ class LLMProvider(core_provider.Provider):
                 min_score_val=0,
                 max_score_val=1,
             )
-            # generate_score returns (score, reason) when the judge
-            # responds with structured JSON; compare on the score alone.
-            if isinstance(score, tuple):
-                score = score[0]
             return score
 
         if filter_trivial_statements:

--- a/tests/integration/test_score_parsing_normalization.py
+++ b/tests/integration/test_score_parsing_normalization.py
@@ -235,15 +235,6 @@ def test_context_relevance_pipeline_accepts_decimal_rating():
     assert 0.0 <= score <= 1.0
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "generate_score returns a (score, reason) tuple for structured-JSON "
-        "responses instead of a normalized float, inconsistent with its "
-        "`-> float` annotation, with generate_score_and_reasons, and with "
-        "every other response shape (truera/trulens#2496)."
-    ),
-)
 def test_generate_score_structured_json_returns_float():
     response = (
         '{"criteria": "relevance", "supporting_evidence": "...", "score": 2}'

--- a/tests/integration/test_score_parsing_pipeline.py
+++ b/tests/integration/test_score_parsing_pipeline.py
@@ -82,17 +82,16 @@ MALFORMED_JSON_FALLTHROUGH_CASES = [
 @pytest.mark.parametrize("response,expected", JSON_CASES)
 def test_generate_score_json_branch(provider, response, expected):
     """generate_score should parse a JSON dict/list response directly,
-    without going through the regex fallback at all. Note: the JSON
-    branch returns a (score, reason_dict) tuple, unlike the plain-string
-    branch which returns a bare float."""
+    without going through the regex fallback at all. It returns a bare
+    float on every path; reasons are available via
+    generate_score_and_reasons."""
     provider.canned_response = response
-    score, reason = provider.generate_score(
+    score = provider.generate_score(
         system_prompt="irrelevant for this test",
         min_score_val=0,
         max_score_val=10,
     )
     assert score == pytest.approx(expected)
-    assert "reason" in reason
 
 
 @pytest.mark.parametrize("response,expected", PLAIN_STRING_CASES)

--- a/tests/unit/providers/test_openai_capabilities.py
+++ b/tests/unit/providers/test_openai_capabilities.py
@@ -502,14 +502,9 @@ def test_generate_score_end_to_end_via_cfg_tool_call(monkeypatch):
         min_score_val=0,
         max_score_val=3,
     )
-    # generate_score returns (score, reason) when it parses structured
-    # JSON (see tests/integration/test_score_parsing_pipeline.py); the
-    # payload {"score": 2} on a 0-3 scale normalizes to 2/3. A mid-scale
-    # value is used so the assertion cannot pass by coinciding with a
-    # scale endpoint.
-    assert isinstance(result, tuple)
-    score, reason = result
-    assert score == pytest.approx(2 / 3)
-    assert reason == {"reason": {"score": 2}}
+    # generate_score returns a bare float; the payload {"score": 2} on a
+    # 0-3 scale normalizes to 2/3. A mid-scale value is used so the
+    # assertion cannot pass by coinciding with a scale endpoint.
+    assert result == pytest.approx(2 / 3)
     # Pin the route: the CFG create path produced the value.
     assert provider.endpoint.client.responses.create_calls == 1


### PR DESCRIPTION
### what

`generate_score` returns `float | tuple[float, dict]`: a `(score, reason)` tuple when the judge answers with structured json, a bare float otherwise. its docstring already tells callers to unwrap:

```python
score = result[0] if isinstance(result, tuple) else result
```

`evaluate_abstention` and `evaluate_answerability` do this. seven methods annotated `-> float` don't, so they return the raw tuple whenever a structured-output provider is used (the default `_create_chat_completion` path returns json text):

- `context_relevance`
- `citation_accuracy`
- `relevance`
- `sentiment`
- `stereotypes`
- `citation_attribution`
- `_langchain_evaluate` (backs the langchain criteria family: conciseness, correctness, coherence, harmfulness, ...)

so those feedbacks hand back `(0.8, {...})` where a float is expected, which breaks downstream aggregation/thresholding.

### repro

with `generate_score` returning a structured-json tuple, on current main:

```
citation_attribution(...)  ->  (1.0, {'reason': 'cited'})   # tuple
```

after this change:

```
citation_attribution(...)  ->  1.0                          # float
```

### fix

small `_extract_score` staticmethod, all nine call sites routed through it (the two existing inline guards folded in too). regression test added in `test_citation_attribution`. pinned ruff (0.5.5) format/check and the touched unit tests pass locally.

note: #2655 adds a few more `return self.generate_score(...)` methods with the same shape that would want the same wrap. the root cause is the dual return on `generate_score`; happy to instead make it always return a bare float and drop the tuple contract if you prefer that direction.
