### PR TITLE
Fix release prep dependency installation

### DIFF
--- a/.azure_pipelines/cd-release-prep.yaml
+++ b/.azure_pipelines/cd-release-prep.yaml
@@ -58,6 +58,12 @@ jobs:
           # LFS stays off: nothing here reads an image.
           persistCredentials: true
 
+      # update_meta_yaml.py needs requests, which the dev group provides.
+      - bash: |
+          set -euo pipefail
+          poetry sync --only dev
+        displayName: "Install the dev group"
+
       - bash: |
           set -euo pipefail
           CURRENT_VERSION=$(grep -m1 '^version' src/core/pyproject.toml | sed -E 's/^version *= *"(.*)"/\1/')


### PR DESCRIPTION
## Summary
- install the locked dev dependency group before release prep updates conda recipes
- make `requests` available to `update_meta_yaml.py`, matching the release-main pipeline
- fix the failure observed in Azure build 16119

## Why 2.11 differed
The 2.11 prep run completed before `make update-meta-yaml-versions` was added to the release-prep pipeline. That command was introduced later as part of the 2.11 conda validation fix, making 2.12 the first clean release-prep run to execute the `requests`-dependent script.

## Test plan
- [x] Parse `.azure_pipelines/cd-release-prep.yaml` with PyYAML
- [x] Verify `requests` imports in the Poetry environment
- [x] Run pre-commit hooks for the pipeline change
- [ ] Merge and rerun the Release Prep pipeline on `releases/rc-trulens-2.12.0`

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)