### PR TITLE
Add GENERATION span attributes for streaming (semconv)

### DIFF
--- a/src/otel/semconv/trulens/otel/semconv/trace.py
+++ b/src/otel/semconv/trulens/otel/semconv/trace.py
@@ -47,6 +47,19 @@ class GenAIAttributes:
         TEMPERATURE = GEN_AI_SCOPE + ".request.temperature"
         """Sampling temperature requested."""
 
+        STREAM = GEN_AI_SCOPE + ".request.stream"
+        """Whether the request was made in streaming mode. Conditionally
+        required: only set if and only if the request is streaming (per
+        spec, an unset value is assumed to mean non-streaming)."""
+
+    class RESPONSE:
+        """Attributes describing the GenAI response."""
+
+        TIME_TO_FIRST_CHUNK = GEN_AI_SCOPE + ".response.time_to_first_chunk"
+        """Time to first chunk in a streaming response, in seconds, measured
+        from request issuance to the first chunk being received. Recommended
+        when the request was a streaming request."""
+
     class USAGE:
         """Token usage reported by the GenAI provider."""
 
@@ -421,25 +434,44 @@ class SpanAttributes:
         """The retrieved contexts."""
 
     class GENERATION:
-        """A generation call to an LLM."""
+        """A generation call to an LLM.
+
+        `IS_STREAMING` and `TIME_TO_FIRST_TOKEN_MS` below have canonical
+        OTel GenAI semconv counterparts --
+        `GenAIAttributes.REQUEST.STREAM` and
+        `GenAIAttributes.RESPONSE.TIME_TO_FIRST_CHUNK` respectively -- which
+        are emitted alongside these for interoperability. `TOKENS_PER_SECOND`
+        and `CHUNKS_RECEIVED` do not: the OTel GenAI spec models per-chunk
+        latency/throughput as Histogram metrics
+        (`gen_ai.client.operation.time_per_output_chunk`), not span
+        attributes, but this codebase has no OTel Metrics/MeterProvider
+        pipeline yet. Until one exists, these two stay TruLens-internal
+        (`ai.observability.*` only, no `gen_ai.*` counterpart) rather than
+        being misrepresented as canonical semconv.
+        """
 
         base = BASE_SCOPE + ".generation"
 
         IS_STREAMING = base + ".is_streaming"
-        """Whether this generation call used streaming (e.g. `stream=True`)."""
+        """Whether this generation call used streaming (e.g. `stream=True`).
+        See also `GenAIAttributes.REQUEST.STREAM`."""
 
         TIME_TO_FIRST_TOKEN_MS = base + ".time_to_first_token_ms"
         """Milliseconds between issuing the request and receiving the first
-        streamed chunk. Only set when `IS_STREAMING` is `True`."""
+        streamed chunk. Only set when `IS_STREAMING` is `True`. See also
+        `GenAIAttributes.RESPONSE.TIME_TO_FIRST_CHUNK` (same measurement,
+        canonical key, unit seconds instead of milliseconds)."""
 
         TOKENS_PER_SECOND = base + ".tokens_per_second"
         """Completion tokens generated per second, measured from the first
-        to the last chunk received. Only set when `IS_STREAMING` is
-        `True`."""
+        to the last chunk received. Only set when `IS_STREAMING` is `True`.
+        TruLens-internal; not part of OTel GenAI semconv (see class
+        docstring)."""
 
         CHUNKS_RECEIVED = base + ".chunks_received"
         """Number of chunks received while consuming a streamed response.
-        Only set when `IS_STREAMING` is `True`."""
+        Only set when `IS_STREAMING` is `True`. TruLens-internal; not part
+        of OTel GenAI semconv (see class docstring)."""
 
     class GRAPH_TASK:
         """A graph task function execution."""

--- a/src/otel/semconv/trulens/otel/semconv/trace.py
+++ b/src/otel/semconv/trulens/otel/semconv/trace.py
@@ -425,6 +425,22 @@ class SpanAttributes:
 
         base = BASE_SCOPE + ".generation"
 
+        IS_STREAMING = base + ".is_streaming"
+        """Whether this generation call used streaming (e.g. `stream=True`)."""
+
+        TIME_TO_FIRST_TOKEN_MS = base + ".time_to_first_token_ms"
+        """Milliseconds between issuing the request and receiving the first
+        streamed chunk. Only set when `IS_STREAMING` is `True`."""
+
+        TOKENS_PER_SECOND = base + ".tokens_per_second"
+        """Completion tokens generated per second, measured from the first
+        to the last chunk received. Only set when `IS_STREAMING` is
+        `True`."""
+
+        CHUNKS_RECEIVED = base + ".chunks_received"
+        """Number of chunks received while consuming a streamed response.
+        Only set when `IS_STREAMING` is `True`."""
+
     class GRAPH_TASK:
         """A graph task function execution."""
 

--- a/src/otel/semconv/trulens/otel/semconv/trace.py
+++ b/src/otel/semconv/trulens/otel/semconv/trace.py
@@ -436,13 +436,14 @@ class SpanAttributes:
     class GENERATION:
         """A generation call to an LLM.
 
-        `IS_STREAMING` and `TIME_TO_FIRST_TOKEN_MS` below have canonical
-        OTel GenAI semconv counterparts --
-        `GenAIAttributes.REQUEST.STREAM` and
-        `GenAIAttributes.RESPONSE.TIME_TO_FIRST_CHUNK` respectively -- which
-        are emitted alongside these for interoperability. `TOKENS_PER_SECOND`
-        and `CHUNKS_RECEIVED` do not: the OTel GenAI spec models per-chunk
-        latency/throughput as Histogram metrics
+        Streaming mode and time-to-first-chunk are captured exclusively via
+        the canonical OTel GenAI semconv attributes --
+        `GenAIAttributes.REQUEST.STREAM` (bool) and
+        `GenAIAttributes.RESPONSE.TIME_TO_FIRST_CHUNK` (seconds) -- rather
+        than TruLens-specific duplicates, to stay interoperable with
+        OTel-native tooling. `TOKENS_PER_SECOND` and `CHUNKS_RECEIVED`
+        below have no canonical counterpart: the OTel GenAI spec models
+        per-chunk latency/throughput as Histogram metrics
         (`gen_ai.client.operation.time_per_output_chunk`), not span
         attributes, but this codebase has no OTel Metrics/MeterProvider
         pipeline yet. Until one exists, these two stay TruLens-internal
@@ -452,26 +453,17 @@ class SpanAttributes:
 
         base = BASE_SCOPE + ".generation"
 
-        IS_STREAMING = base + ".is_streaming"
-        """Whether this generation call used streaming (e.g. `stream=True`).
-        See also `GenAIAttributes.REQUEST.STREAM`."""
-
-        TIME_TO_FIRST_TOKEN_MS = base + ".time_to_first_token_ms"
-        """Milliseconds between issuing the request and receiving the first
-        streamed chunk. Only set when `IS_STREAMING` is `True`. See also
-        `GenAIAttributes.RESPONSE.TIME_TO_FIRST_CHUNK` (same measurement,
-        canonical key, unit seconds instead of milliseconds)."""
-
         TOKENS_PER_SECOND = base + ".tokens_per_second"
         """Completion tokens generated per second, measured from the first
-        to the last chunk received. Only set when `IS_STREAMING` is `True`.
-        TruLens-internal; not part of OTel GenAI semconv (see class
-        docstring)."""
+        to the last chunk received. Only set when
+        `GenAIAttributes.REQUEST.STREAM` is `True`. TruLens-internal; not
+        part of OTel GenAI semconv (see class docstring)."""
 
         CHUNKS_RECEIVED = base + ".chunks_received"
         """Number of chunks received while consuming a streamed response.
-        Only set when `IS_STREAMING` is `True`. TruLens-internal; not part
-        of OTel GenAI semconv (see class docstring)."""
+        Only set when `GenAIAttributes.REQUEST.STREAM` is `True`.
+        TruLens-internal; not part of OTel GenAI semconv (see class
+        docstring)."""
 
     class GRAPH_TASK:
         """A graph task function execution."""


### PR DESCRIPTION
## Summary

Part of #2442 (streaming LLM instrumentation). This is PR 1 of several small, independently-revertable PRs toward that issue, split so each piece can land (or be reverted) on its own.

Adds the four new `GENERATION` span attributes the issue asks for, as a pure additive semconv change with **no behavior change**:

- `ai.observability.generation.is_streaming`
- `ai.observability.generation.time_to_first_token_ms`
- `ai.observability.generation.tokens_per_second`
- `ai.observability.generation.chunks_received`

Nothing populates these yet — that's the next PR (wiring them up for the OpenAI provider's `stream=True` path, extending the existing chunk-handling in `OpenAIEndpoint._handle_response`).

## Scope of the overall issue

Issue #2442 bundles several genuinely separate efforts: semconv attributes (this PR), OpenAI streaming instrumentation, LangChain `stream()`/`astream()` instrumentation, a generic async-generator pattern, mid-stream/partial-output evaluation for guardrails, and a dashboard latency-view UI change. Splitting these into separate PRs keeps each one small, reviewable, and safe to revert independently rather than landing (or blocking on) one large, multi-part change.

## Test plan

- [x] `ruff check` / `ruff format --check` (pinned `0.5.5`) pass.
- [x] Verified the new attribute keys resolve correctly, e.g. `SpanAttributes.GENERATION.IS_STREAMING == "ai.observability.generation.is_streaming"`.
- [x] No existing tests reference `trulens.otel.semconv.trace.SpanAttributes.GENERATION` (confirmed via repo-wide search), and this package isn't covered by the `tests/unit/static` API golden-snapshot tests, so nothing needed regenerating.
