### PR TITLE
Instrument the generic streaming pattern (covers LangChain too)

### DIFF
--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from contextvars import ContextVar
 import inspect
 import logging
+import time
 import types
 from types import TracebackType
 from typing import (
@@ -285,6 +286,40 @@ def _set_span_attributes(
         )
 
 
+def _record_generic_streaming_attributes(
+    span: Span,
+    span_type: SpanAttributes.SpanType,
+    chunk_count: int,
+    request_started_at: float,
+    first_chunk_at: float | None,
+) -> None:
+    """Record IS_STREAMING/TIME_TO_FIRST_TOKEN_MS/CHUNKS_RECEIVED for any
+    GENERATION-typed `@instrument`-decorated function that returns a
+    generator or async generator -- the "generic async generator pattern",
+    as opposed to provider-specific instrumentation (e.g. the OpenAI
+    endpoint's) which knows enough about chunk contents to also compute
+    TOKENS_PER_SECOND from real token counts. No token count is fabricated
+    here since a generic chunk's contents aren't known to be token-shaped.
+    """
+    if span_type != SpanAttributes.SpanType.GENERATION or chunk_count == 0:
+        return
+    try:
+        span.set_attribute(SpanAttributes.GENERATION.IS_STREAMING, True)
+        span.set_attribute(
+            SpanAttributes.GENERATION.CHUNKS_RECEIVED, chunk_count
+        )
+        if first_chunk_at is not None:
+            span.set_attribute(
+                SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS,
+                (first_chunk_at - request_started_at) * 1000,
+            )
+    except Exception:
+        logger.debug(
+            "Could not record generic streaming span attributes.",
+            exc_info=True,
+        )
+
+
 def _finalize_span(
     span: Span,
     span_type: SpanAttributes.SpanType,
@@ -422,13 +457,21 @@ class instrument:
             ) as span:
                 ret = None
                 func_exception: Exception | None = None
+                was_generator = False
+                chunk_count = 0
+                request_started_at = time.monotonic()
+                first_chunk_at: float | None = None
                 # Run function.
                 try:
                     result = func(*args, **kwargs)
                     if isinstance(result, types.GeneratorType):
+                        was_generator = True
                         yield "is_generator"
                         ret = []
                         for curr in result:
+                            chunk_count += 1
+                            if first_chunk_at is None:
+                                first_chunk_at = time.monotonic()
                             ret.append(curr)
                             yield curr
                     else:
@@ -441,6 +484,14 @@ class instrument:
                     # None as a return value.
                     func_exception = e
                 finally:
+                    if was_generator:
+                        _record_generic_streaming_attributes(
+                            span,
+                            self.span_type,
+                            chunk_count,
+                            request_started_at,
+                            first_chunk_at,
+                        )
                     _finalize_span(
                         span,
                         self.span_type,
@@ -531,11 +582,17 @@ class instrument:
             ) as span:
                 ret = None
                 func_exception: Exception | None = None
+                chunk_count = 0
+                request_started_at = time.monotonic()
+                first_chunk_at: float | None = None
                 # Run function.
                 try:
                     result = func(*args, **kwargs)
                     ret = []
                     async for curr in result:
+                        chunk_count += 1
+                        if first_chunk_at is None:
+                            first_chunk_at = time.monotonic()
                         ret.append(curr)
                         yield curr
                 except Exception as e:
@@ -544,6 +601,13 @@ class instrument:
                     # None as a return value.
                     func_exception = e
                 finally:
+                    _record_generic_streaming_attributes(
+                        span,
+                        self.span_type,
+                        chunk_count,
+                        request_started_at,
+                        first_chunk_at,
+                    )
                     _finalize_span(
                         span,
                         self.span_type,

--- a/src/otel/semconv/trulens/otel/semconv/trace.py
+++ b/src/otel/semconv/trulens/otel/semconv/trace.py
@@ -425,6 +425,22 @@ class SpanAttributes:
 
         base = BASE_SCOPE + ".generation"
 
+        IS_STREAMING = base + ".is_streaming"
+        """Whether this generation call used streaming (e.g. `stream=True`)."""
+
+        TIME_TO_FIRST_TOKEN_MS = base + ".time_to_first_token_ms"
+        """Milliseconds between issuing the request and receiving the first
+        streamed chunk. Only set when `IS_STREAMING` is `True`."""
+
+        TOKENS_PER_SECOND = base + ".tokens_per_second"
+        """Completion tokens generated per second, measured from the first
+        to the last chunk received. Only set when `IS_STREAMING` is
+        `True`."""
+
+        CHUNKS_RECEIVED = base + ".chunks_received"
+        """Number of chunks received while consuming a streamed response.
+        Only set when `IS_STREAMING` is `True`."""
+
     class GRAPH_TASK:
         """A graph task function execution."""
 

--- a/tests/unit/test_otel_instrument.py
+++ b/tests/unit/test_otel_instrument.py
@@ -587,6 +587,7 @@ class TestOtelInstrument(unittest.TestCase):
         self.assertGreaterEqual(
             attrs[SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS], 0
         )
+        self.assertNotIn(SpanAttributes.GENERATION.TOKENS_PER_SECOND, attrs)
 
     def test_non_generation_generator_has_no_streaming_attributes(
         self,

--- a/tests/unit/test_otel_instrument.py
+++ b/tests/unit/test_otel_instrument.py
@@ -537,3 +537,102 @@ class TestOtelInstrument(unittest.TestCase):
         self.assertEqual(len(spans), 1)
         proto = convert_readable_span_to_proto(spans[0])
         self.assertEqual(proto.kind, SpanProto.SpanKind.SPAN_KIND_CLIENT)
+
+    def test_sync_generation_generator_records_streaming_attributes(
+        self,
+    ) -> None:
+        """A GENERATION-typed sync generator function should get
+        IS_STREAMING/TIME_TO_FIRST_TOKEN_MS/CHUNKS_RECEIVED recorded
+        generically, with no fabricated TOKENS_PER_SECOND."""
+
+        @instrument(span_type=SpanAttributes.SpanType.GENERATION)
+        def stream_llm(prompt: str):
+            yield "Hello"
+            yield " world"
+
+        for _ in stream_llm("hi"):
+            pass
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        attrs = spans[0].attributes
+        self.assertTrue(attrs[SpanAttributes.GENERATION.IS_STREAMING])
+        self.assertEqual(attrs[SpanAttributes.GENERATION.CHUNKS_RECEIVED], 2)
+        self.assertGreaterEqual(
+            attrs[SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS], 0
+        )
+        self.assertNotIn(SpanAttributes.GENERATION.TOKENS_PER_SECOND, attrs)
+
+    def test_async_generation_generator_records_streaming_attributes(
+        self,
+    ) -> None:
+        """Same as the sync case, but for an async generator function."""
+
+        @instrument(span_type=SpanAttributes.SpanType.GENERATION)
+        async def stream_llm(prompt: str):
+            yield "Hello"
+            yield " world"
+
+        async def consume():
+            async for _ in stream_llm("hi"):
+                pass
+
+        asyncio.run(consume())
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        attrs = spans[0].attributes
+        self.assertTrue(attrs[SpanAttributes.GENERATION.IS_STREAMING])
+        self.assertEqual(attrs[SpanAttributes.GENERATION.CHUNKS_RECEIVED], 2)
+        self.assertGreaterEqual(
+            attrs[SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS], 0
+        )
+
+    def test_non_generation_generator_has_no_streaming_attributes(
+        self,
+    ) -> None:
+        """Streaming attributes are GENERATION-specific; a generator
+        function with a different (or no) span_type shouldn't get them."""
+
+        @instrument()
+        def stream_something(prompt: str):
+            yield "Hello"
+            yield " world"
+
+        for _ in stream_something("hi"):
+            pass
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        attrs = spans[0].attributes
+        self.assertNotIn(SpanAttributes.GENERATION.IS_STREAMING, attrs)
+        self.assertNotIn(SpanAttributes.GENERATION.CHUNKS_RECEIVED, attrs)
+        self.assertNotIn(
+            SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS, attrs
+        )
+
+    def test_generation_generator_partial_consumption_records_partial_count(
+        self,
+    ) -> None:
+        """If a caller only partially consumes a streamed generator before
+        it's garbage-collected, CHUNKS_RECEIVED should reflect only what was
+        actually consumed, not the full underlying sequence."""
+
+        @instrument(span_type=SpanAttributes.SpanType.GENERATION)
+        def stream_llm(prompt: str):
+            yield "Kojikun"
+            yield "Nolan"
+            yield "Sachiboy"
+
+        gen = stream_llm("hi")
+        for i, _ in enumerate(gen):
+            if i == 1:
+                break
+        del gen
+        gc.collect()
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(
+            spans[0].attributes[SpanAttributes.GENERATION.CHUNKS_RECEIVED], 2
+        )

--- a/tests/unit/test_otel_tru_chain.py
+++ b/tests/unit/test_otel_tru_chain.py
@@ -10,6 +10,7 @@ import pytest
 from trulens.core.otel.instrument import instrument
 from trulens.otel.semconv.trace import SpanAttributes
 
+import tests.util.otel_test_case
 import tests.util.otel_tru_app_test_case
 from tests.utils import enable_otel_backwards_compatibility
 
@@ -20,6 +21,10 @@ try:
     from langchain_community.embeddings import DeterministicFakeEmbedding
     from langchain_community.llms import FakeListLLM
     from langchain_community.vectorstores import FAISS
+    from langchain_core.language_models.fake_chat_models import (
+        GenericFakeChatModel,
+    )
+    from langchain_core.messages import AIMessage
     from langchain_core.output_parsers import StrOutputParser
     from langchain_core.runnables import RunnablePassthrough
     from langchain_text_splitters import RecursiveCharacterTextSplitter
@@ -140,3 +145,68 @@ class TestOtelTruChain(tests.util.otel_tru_app_test_case.OtelTruAppTestCase):
         self._compare_record_attributes_to_golden_dataframe(
             "tests/unit/static/golden/test_otel_tru_chain__test_smoke.csv"
         )
+
+
+@pytest.mark.optional
+class TestOtelTruChainStreaming(tests.util.otel_test_case.OtelTestCase):
+    """LangChain's `BaseChatModel.stream`/`.astream` are registered with
+    span_type=GENERATION in this app's METHODS() (see
+    trulens.apps.langchain.tru_chain), and route through the same generic
+    generator-wrapping in trulens.core.otel.instrument that any other
+    @instrument(span_type=GENERATION) generator function does. So no
+    LangChain-specific streaming instrumentation code is needed -- these
+    tests exist to prove that's actually true, not to add new behavior.
+    """
+
+    def test_sync_stream_records_streaming_attributes(self) -> None:
+        model = GenericFakeChatModel(
+            messages=iter([AIMessage(content="Hello world")])
+        )
+        tru_chain = TruChain(model, app_name="test_app", app_version="v1")
+
+        with tru_chain:
+            chunks = list(model.stream("say hello"))
+        self.assertEqual(len(chunks), 3)  # "Hello", " ", "world"
+
+        events = self._get_events()
+        found = False
+        for attrs in events["record_attributes"]:
+            if SpanAttributes.GENERATION.IS_STREAMING in attrs:
+                found = True
+                self.assertTrue(attrs[SpanAttributes.GENERATION.IS_STREAMING])
+                self.assertEqual(
+                    attrs[SpanAttributes.GENERATION.CHUNKS_RECEIVED], 3
+                )
+                self.assertGreaterEqual(
+                    attrs[SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS], 0
+                )
+        self.assertTrue(found, "No span with IS_STREAMING found")
+
+    def test_async_stream_records_streaming_attributes(self) -> None:
+        import asyncio
+
+        model = GenericFakeChatModel(
+            messages=iter([AIMessage(content="Hello world")])
+        )
+        tru_chain = TruChain(model, app_name="test_app", app_version="v1")
+
+        async def run():
+            chunks = []
+            with tru_chain:
+                async for chunk in model.astream("say hello"):
+                    chunks.append(chunk)
+            return chunks
+
+        chunks = asyncio.run(run())
+        self.assertEqual(len(chunks), 3)
+
+        events = self._get_events()
+        found = False
+        for attrs in events["record_attributes"]:
+            if SpanAttributes.GENERATION.IS_STREAMING in attrs:
+                found = True
+                self.assertTrue(attrs[SpanAttributes.GENERATION.IS_STREAMING])
+                self.assertEqual(
+                    attrs[SpanAttributes.GENERATION.CHUNKS_RECEIVED], 3
+                )
+        self.assertTrue(found, "No span with IS_STREAMING found")


### PR DESCRIPTION
## Summary

Part of #2442 (streaming LLM instrumentation). **Stacked on #2689** (adds the semconv attributes; that commit is included in the diff until it merges). Independent of #2690/#2691 -- this is the "generic async generator pattern" item from the issue, not OpenAI-specific.

Any `@instrument(span_type=SpanAttributes.SpanType.GENERATION)`-decorated function that returns a sync or async generator now gets `IS_STREAMING`, `TIME_TO_FIRST_TOKEN_MS`, and `CHUNKS_RECEIVED` recorded automatically -- useful for custom LLM integrations that aren't OpenAI or LangChain (e.g. a raw SSE call to some other provider's API).

### Why this didn't need the deferred-span-write trick from #2690

The OpenAI provider's raw `Stream` object is usually handed back to application code that consumes it *after* the instrumentation hook that fires on `create()` returning -- the span is often already closed by then, which is why #2690 has to capture the span and write to it later, best-effort.

Here it's simpler: the existing (pre-dating this change) generator handling in `convert_to_generator`/`async_generator_wrapper` already keeps the span open for the generator's *entire* lifetime and only finalizes it once exhausted (verified this holds even under partial consumption + GC, via `test_generation_generator_partial_consumption_records_partial_count`). So the new attributes are just computed inline in the same `finally` block that already runs after consumption -- no deferred-write mechanism needed.

### Bonus: this also turned out to cover LangChain's `stream()`/`astream()` for free

`trulens.apps.langchain.tru_chain` already registers `BaseLanguageModel`/`BaseChatModel`'s `stream`/`astream` with `span_type=GENERATION`, and that routes through this exact same generic mechanism -- LangChain's `stream`/`astream` are literally a sync generator function and an async generator function, no different from any other instrumented streaming function. I verified this live (real `TruChain` + `langchain_core`'s `GenericFakeChatModel`, not a stub) before adding `TestOtelTruChainStreaming` in `tests/unit/test_otel_tru_chain.py` to pin it down. **No LangChain-specific instrumentation code was needed or added** -- this closes that item from the issue's "Instrument common streaming patterns" list as a side effect of the generic design, not a separate implementation.

### Deliberately not included

No `TOKENS_PER_SECOND` here, unlike the OpenAI-specific work -- a generic chunk's contents aren't known to be token-shaped, so there's no honest way to compute a token rate without provider-specific knowledge of the response (see #2690 for how that's done when the provider tells you the real completion-token count).

## Test plan

- [x] 4 new tests in `tests/unit/test_otel_instrument.py`: sync generator, async generator, a non-GENERATION generator correctly getting *no* streaming attributes (confirms the gating), and partial consumption + GC recording only the partial chunk count.
- [x] 2 new tests in `tests/unit/test_otel_tru_chain.py` (`TestOtelTruChainStreaming`): real `TruChain` + `GenericFakeChatModel`, sync `.stream()` and async `.astream()`, confirming `IS_STREAMING`/`TIME_TO_FIRST_TOKEN_MS`/`CHUNKS_RECEIVED` on real exported spans.
- [x] Full existing suite (`tests/unit/test_otel_instrument.py`, 23 tests) passes -- no regression to the pre-existing generator/span-lifecycle behavior this builds on.
- [x] `ruff check` / `ruff format --check` (pinned `0.5.5`) pass.
