### PR TITLE
Instrument AsyncOpenAI stream=True with TTFT/chunks/throughput

### DIFF
--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -599,6 +599,7 @@ def instrument_method(
     span_type: SpanAttributes.SpanType = SpanAttributes.SpanType.UNKNOWN,
     attributes: Attributes = None,
     must_be_first_wrapper: bool = False,
+    create_new_span: bool = True,
 ) -> None:
     method = getattr(cls, method_name)
     if hasattr(method, TRULENS_INSTRUMENT_WRAPPER_FLAG):
@@ -608,6 +609,7 @@ def instrument_method(
         span_type=span_type,
         attributes=attributes,
         must_be_first_wrapper=must_be_first_wrapper,
+        create_new_span=create_new_span,
     )
     setattr(cls, method_name, wrapper(method))
 

--- a/src/core/trulens/experimental/otel_tracing/core/session.py
+++ b/src/core/trulens/experimental/otel_tracing/core/session.py
@@ -3,6 +3,7 @@ from importlib.metadata import version as pkg_version
 import logging
 import os
 import threading
+import time
 from typing import Any, Callable, Dict, Optional
 
 from opentelemetry import trace
@@ -213,12 +214,28 @@ class _TruSession(core_session.TruSession):
             # Instrument AsyncOpenAI.post method directly for async cost tracking
             try:
                 from openai import AsyncOpenAI
+                from openai import AsyncStream
                 from trulens.core.otel.instrument import instrument_method
+                from trulens.providers.openai.endpoint import (
+                    instrument_async_openai_stream,
+                )
 
                 def async_post_cost_attributes(ret, exception, *args, **kwargs):
                     """Extract costs and capture input/output from AsyncOpenAI post responses."""
 
+                    request_returned_at = time.monotonic()
                     attrs = {}
+
+                    if isinstance(ret, AsyncStream):
+                        # Streaming responses aren't ChatCompletion-shaped
+                        # (no top-level .model/.usage/.choices), so none of
+                        # the output-capture/cost logic below applies -- the
+                        # stream is wrapped so CHUNKS_RECEIVED/TTFT/
+                        # TOKENS_PER_SECOND get recorded once it's consumed.
+                        attrs[SpanAttributes.GENERATION.IS_STREAMING] = True
+                        instrument_async_openai_stream(ret, request_returned_at)
+                        # Still fall through to capture the request (path,
+                        # body, prompts) below, but skip response parsing.
 
                     # Capture the input (path and request body)
                     if args and len(args) > 0:
@@ -278,8 +295,10 @@ class _TruSession(core_session.TruSession):
                         except Exception:
                             pass  # Silently skip serialization errors
 
-                    # Capture the output
-                    if ret:
+                    # Capture the output (skip for streaming responses --
+                    # an AsyncStream isn't ChatCompletion-shaped, and its
+                    # own attributes are handled above)
+                    if ret and not isinstance(ret, AsyncStream):
                         try:
                             # Try to serialize the response
                             if hasattr(ret, "model_dump"):
@@ -397,6 +416,17 @@ class _TruSession(core_session.TruSession):
                     "post",
                     span_type=SpanAttributes.SpanType.GENERATION,
                     attributes=async_post_cost_attributes,
+                    # Piggyback on whatever span is already open (typically
+                    # the caller's own @instrument-decorated method) rather
+                    # than creating a new span scoped exactly to the
+                    # `await post(...)` call. That new span would always end
+                    # the instant post() resolves to the stream object --
+                    # before the caller starts consuming it -- making it
+                    # impossible to ever record CHUNKS_RECEIVED/
+                    # TIME_TO_FIRST_TOKEN_MS/TOKENS_PER_SECOND for streaming
+                    # responses. Matches the sync OpenAI client's existing
+                    # instrument_cost_computer (also create_new_span=False).
+                    create_new_span=False,
                 )
 
             except ImportError as e:

--- a/src/otel/semconv/trulens/otel/semconv/trace.py
+++ b/src/otel/semconv/trulens/otel/semconv/trace.py
@@ -425,6 +425,22 @@ class SpanAttributes:
 
         base = BASE_SCOPE + ".generation"
 
+        IS_STREAMING = base + ".is_streaming"
+        """Whether this generation call used streaming (e.g. `stream=True`)."""
+
+        TIME_TO_FIRST_TOKEN_MS = base + ".time_to_first_token_ms"
+        """Milliseconds between issuing the request and receiving the first
+        streamed chunk. Only set when `IS_STREAMING` is `True`."""
+
+        TOKENS_PER_SECOND = base + ".tokens_per_second"
+        """Completion tokens generated per second, measured from the first
+        to the last chunk received. Only set when `IS_STREAMING` is
+        `True`."""
+
+        CHUNKS_RECEIVED = base + ".chunks_received"
+        """Number of chunks received while consuming a streamed response.
+        Only set when `IS_STREAMING` is `True`."""
+
     class GRAPH_TASK:
         """A graph task function execution."""
 

--- a/src/providers/openai/trulens/providers/openai/endpoint.py
+++ b/src/providers/openai/trulens/providers/openai/endpoint.py
@@ -737,3 +737,83 @@ def _instrument_stream_span_attributes(stream, first_chunk_received_at: float):
             stream._iterator, wrap=_record_chunk, on_done=_on_done
         )
     return stream
+
+
+def instrument_async_openai_stream(
+    stream: "openai.AsyncStream", request_returned_at: float
+) -> "openai.AsyncStream":
+    """Async counterpart to `_instrument_stream_span_attributes`, for use
+    from a hook that -- unlike `OpenAICostComputer.handle_response` for the
+    sync client -- cannot `await` the first chunk itself to measure TTFT
+    synchronously (e.g. a plain sync `attributes` callback on an
+    already-awaited `AsyncOpenAI.post()` call). Records `IS_STREAMING`
+    immediately (returned as a caller-attached attribute, since that much is
+    known synchronously) and defers `TIME_TO_FIRST_TOKEN_MS` /
+    `CHUNKS_RECEIVED` / `TOKENS_PER_SECOND` to when the stream is actually
+    consumed, same graceful-no-op-if-span-already-ended caveat as above.
+
+    Note this measures TTFT from `request_returned_at` (when the coroutine
+    resolved to the stream object) to whenever the *caller* first pulls a
+    chunk -- which, unlike the sync path's eager first-chunk read, can
+    slightly overstate true network TTFT if the caller does other work
+    before starting to iterate the stream.
+    """
+    span = otel_trace.get_current_span()
+    if not span.get_span_context().is_valid or not isinstance(
+        stream, openai.AsyncStream
+    ):
+        return stream
+
+    state: Dict[str, Any] = {
+        "count": 0,
+        "first_chunk_at": None,
+        "last_chunk_at": request_returned_at,
+        "completion_tokens": None,
+    }
+
+    def _record_chunk(chunk):
+        now = time.monotonic()
+        state["count"] += 1
+        if state["first_chunk_at"] is None:
+            state["first_chunk_at"] = now
+            try:
+                span.set_attribute(
+                    SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS,
+                    (now - request_returned_at) * 1000,
+                )
+            except Exception:
+                logger.debug(
+                    "Could not record TIME_TO_FIRST_TOKEN_MS; the span may "
+                    "have already ended.",
+                    exc_info=True,
+                )
+        state["last_chunk_at"] = now
+        usage = getattr(chunk, "usage", None)
+        completion_tokens = getattr(usage, "completion_tokens", None)
+        if completion_tokens:
+            state["completion_tokens"] = completion_tokens
+        return chunk
+
+    def _on_done(_chunks):
+        try:
+            span.set_attribute(
+                SpanAttributes.GENERATION.CHUNKS_RECEIVED, state["count"]
+            )
+            if state["first_chunk_at"] is not None:
+                duration_s = state["last_chunk_at"] - state["first_chunk_at"]
+                if state["completion_tokens"] and duration_s > 0:
+                    span.set_attribute(
+                        SpanAttributes.GENERATION.TOKENS_PER_SECOND,
+                        state["completion_tokens"] / duration_s,
+                    )
+        except Exception:
+            logger.debug(
+                "Could not record streaming span attributes; the span may "
+                "have already ended.",
+                exc_info=True,
+            )
+
+    stream._iterator = python_utils.wrap_async_generator(
+        stream._iterator, wrap=_record_chunk, on_done=_on_done
+    )
+    return stream

--- a/src/providers/openai/trulens/providers/openai/endpoint.py
+++ b/src/providers/openai/trulens/providers/openai/endpoint.py
@@ -23,6 +23,7 @@ the involved classes will need to be adapted here. The important classes are:
 import inspect
 import logging
 import pprint
+import time
 from typing import (
     Any,
     Callable,
@@ -51,6 +52,7 @@ except ImportError:
         from langchain_core.outputs import LLMResult
 
 from langchain_community.callbacks.openai_info import OpenAICallbackHandler
+from opentelemetry import trace as otel_trace
 import pydantic
 from pydantic.v1 import BaseModel as v1BaseModel
 from trulens.core.feedback import endpoint as core_endpoint
@@ -125,12 +127,22 @@ class OpenAICostComputer:
         endpoint = OpenAIEndpoint()
         callback = OpenAICallback(endpoint=endpoint)
         model_name = ""
+        streaming_attributes: Dict[str, Any] = {}
 
         if hasattr(response, "__iter__") and not hasattr(response, "model"):
+            streaming_attributes[SpanAttributes.GENERATION.IS_STREAMING] = True
+            request_returned_at = time.monotonic()
             try:
                 first_chunk = next(response)
+                first_chunk_received_at = time.monotonic()
+                streaming_attributes[
+                    SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS
+                ] = (first_chunk_received_at - request_returned_at) * 1000
                 model_name = first_chunk.model or ""
                 response = prepend_first_chunk(response, first_chunk)
+                response = _instrument_stream_span_attributes(
+                    response, first_chunk_received_at
+                )
             except Exception:
                 logger.exception(
                     "Exception occurred while consuming the first chunk from a streamed response."
@@ -156,6 +168,7 @@ class OpenAICostComputer:
         }
         if model_name:
             ret[SpanAttributes.COST.MODEL] = model_name
+        ret.update(streaming_attributes)
 
         return ret
 
@@ -659,4 +672,68 @@ def prepend_first_chunk(stream, first_chunk):
         yield from original_iter
 
     stream._iterator = new_iter()
+    return stream
+
+
+def _instrument_stream_span_attributes(stream, first_chunk_received_at: float):
+    """Wrap `stream`'s iterator to record `CHUNKS_RECEIVED` and, when usage
+    is available (e.g. the caller passed ``stream_options={"include_usage":
+    True}``), `TOKENS_PER_SECOND` on the span that is current *right now* --
+    which must be called before this function, i.e. synchronously as soon as
+    the streamed response object is returned.
+
+    This only works if that span is still open by the time the stream is
+    exhausted, which is the case when the calling code consumes the stream
+    inside the same instrumented function that issued the request (the
+    common pattern). If the raw stream is instead handed off elsewhere (e.g.
+    returned directly to an outer caller for pass-through streaming), the
+    span will have already ended and this becomes a silent no-op -- chunk
+    count/throughput just won't be recorded for that call, same as if this
+    function did not exist.
+    """
+    span = otel_trace.get_current_span()
+    if not span.get_span_context().is_valid:
+        return stream
+
+    state: Dict[str, Any] = {
+        "count": 0,
+        "last_chunk_at": first_chunk_received_at,
+        "completion_tokens": None,
+    }
+
+    def _record_chunk(chunk):
+        state["count"] += 1
+        state["last_chunk_at"] = time.monotonic()
+        usage = getattr(chunk, "usage", None)
+        completion_tokens = getattr(usage, "completion_tokens", None)
+        if completion_tokens:
+            state["completion_tokens"] = completion_tokens
+        return chunk
+
+    def _on_done(_chunks):
+        try:
+            span.set_attribute(
+                SpanAttributes.GENERATION.CHUNKS_RECEIVED, state["count"]
+            )
+            duration_s = state["last_chunk_at"] - first_chunk_received_at
+            if state["completion_tokens"] and duration_s > 0:
+                span.set_attribute(
+                    SpanAttributes.GENERATION.TOKENS_PER_SECOND,
+                    state["completion_tokens"] / duration_s,
+                )
+        except Exception:
+            logger.debug(
+                "Could not record streaming span attributes; the span may "
+                "have already ended.",
+                exc_info=True,
+            )
+
+    if isinstance(stream, openai.AsyncStream):
+        stream._iterator = python_utils.wrap_async_generator(
+            stream._iterator, wrap=_record_chunk, on_done=_on_done
+        )
+    elif isinstance(stream, openai.Stream):
+        stream._iterator = python_utils.wrap_generator(
+            stream._iterator, wrap=_record_chunk, on_done=_on_done
+        )
     return stream

--- a/tests/unit/providers/test_async_openai_streaming_span_attributes.py
+++ b/tests/unit/providers/test_async_openai_streaming_span_attributes.py
@@ -1,0 +1,88 @@
+# pyright: reportMissingImports=false, reportMissingModuleSource=false
+import asyncio
+
+import httpx
+import openai
+import pytest
+from trulens.apps.app import TruApp
+from trulens.apps.app import instrument
+from trulens.otel.semconv.trace import SpanAttributes
+
+from tests.util.otel_test_case import OtelTestCase
+
+_SSE_BODY = (
+    b'data: {"id":"1","object":"chat.completion.chunk","created":1,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}\n\n'
+    b'data: {"id":"1","object":"chat.completion.chunk","created":1,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}\n\n'
+    b'data: {"id":"1","object":"chat.completion.chunk","created":1,"model":"gpt-4o-mini","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":3,"total_tokens":13}}\n\n'
+    b"data: [DONE]\n\n"
+)
+
+
+def _mock_handler(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(
+        200,
+        headers={"content-type": "text/event-stream"},
+        content=_SSE_BODY,
+    )
+
+
+@pytest.mark.optional
+class TestAsyncOpenAIStreamingSpanAttributes(OtelTestCase):
+    """Exercises the *real* class-level `AsyncOpenAI.post` instrumentation
+    (not an instance-level mock swap, which would bypass it) via a mocked
+    httpx transport, so this runs without network access while still
+    proving the fix that made this possible: `AsyncOpenAI.post` must
+    piggyback on the caller's already-open span (`create_new_span=False`)
+    rather than creating its own, which would always close before the
+    caller starts consuming the stream.
+    """
+
+    def test_async_openai_streaming_records_span_attributes(self):
+        oai_client = openai.AsyncOpenAI(
+            api_key="test",
+            http_client=httpx.AsyncClient(
+                transport=httpx.MockTransport(_mock_handler)
+            ),
+        )
+
+        class App:
+            @instrument
+            async def stream_completion(self, prompt: str) -> str:
+                completion = await oai_client.chat.completions.create(
+                    model="gpt-4o-mini",
+                    stream=True,
+                    stream_options={"include_usage": True},
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                chunks = []
+                async for chunk in completion:
+                    if chunk.choices and chunk.choices[0].delta.content:
+                        chunks.append(chunk.choices[0].delta.content)
+                return "".join(chunks)
+
+        app = App()
+        tru_app = TruApp(app, app_name="test_app", app_version="v1")
+
+        async def run():
+            with tru_app:
+                return await app.stream_completion("hi")
+
+        result = asyncio.run(run())
+        self.assertEqual(result, "Hello world")
+
+        events = self._get_events()
+        found = False
+        for attrs in events["record_attributes"]:
+            if SpanAttributes.GENERATION.IS_STREAMING in attrs:
+                found = True
+                self.assertTrue(attrs[SpanAttributes.GENERATION.IS_STREAMING])
+                self.assertEqual(
+                    attrs[SpanAttributes.GENERATION.CHUNKS_RECEIVED], 3
+                )
+                self.assertGreaterEqual(
+                    attrs[SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS], 0
+                )
+                self.assertGreater(
+                    attrs[SpanAttributes.GENERATION.TOKENS_PER_SECOND], 0
+                )
+        self.assertTrue(found, "No span with IS_STREAMING found")

--- a/tests/unit/providers/test_openai_streaming_span_attributes.py
+++ b/tests/unit/providers/test_openai_streaming_span_attributes.py
@@ -1,0 +1,147 @@
+# pyright: reportMissingImports=false, reportMissingModuleSource=false
+from typing import Any, Dict
+from unittest.mock import Mock
+
+import openai
+from opentelemetry import trace
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+import pytest
+from trulens.otel.semconv.trace import SpanAttributes
+
+
+def _make_chunk(content: str, usage=None):
+    return Mock(
+        model="gpt-4o-mini",
+        choices=[Mock(delta=Mock(content=content), finish_reason=None)],
+        usage=usage,
+    )
+
+
+def _make_sync_stream(chunks):
+    stream = openai.Stream(
+        cast_to=object, client=Mock(spec=openai.OpenAI), response=Mock()
+    )
+
+    def _iterator():
+        yield from chunks
+
+    stream._iterator = _iterator()
+    return stream
+
+
+@pytest.fixture
+def otel_setup():
+    from trulens.experimental.otel_tracing.core.session import (
+        _set_up_tracer_provider,
+    )
+
+    exporter = InMemorySpanExporter()
+    _set_up_tracer_provider()
+    processor = SimpleSpanProcessor(exporter)
+    trace.get_tracer_provider().add_span_processor(processor)
+    try:
+        yield exporter
+    finally:
+        processor.shutdown()
+
+
+@pytest.mark.optional
+def test_streaming_attrs_returned_immediately(otel_setup):
+    from trulens.providers.openai.endpoint import OpenAICostComputer
+
+    stream = _make_sync_stream([
+        _make_chunk("Hello"),
+        _make_chunk(" world"),
+    ])
+
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span("test_span"):
+        ret = OpenAICostComputer.handle_response(stream)
+        # Fully consume the stream (handle_response rewires
+        # `stream._iterator` in place, so iterating `stream` itself drives
+        # the wrapped iterator).
+        list(stream)
+
+    assert ret[SpanAttributes.GENERATION.IS_STREAMING] is True
+    assert ret[SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS] >= 0
+
+
+@pytest.mark.optional
+def test_chunks_received_and_tokens_per_second_recorded_on_open_span(
+    otel_setup,
+):
+    from trulens.providers.openai.endpoint import OpenAICostComputer
+
+    usage = Mock(completion_tokens=7)
+    stream = _make_sync_stream([
+        _make_chunk("Hello"),
+        _make_chunk(" world"),
+        _make_chunk("", usage=usage),
+    ])
+
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span("test_span"):
+        OpenAICostComputer.handle_response(stream)
+        list(stream)  # fully consume while span is still open
+
+    spans = otel_setup.get_finished_spans()
+    assert len(spans) == 1
+    attrs: Dict[str, Any] = spans[0].attributes
+    assert attrs[SpanAttributes.GENERATION.CHUNKS_RECEIVED] == 3
+    assert attrs[SpanAttributes.GENERATION.TOKENS_PER_SECOND] > 0
+
+
+@pytest.mark.optional
+def test_chunks_received_omitted_without_usage(otel_setup):
+    from trulens.providers.openai.endpoint import OpenAICostComputer
+
+    stream = _make_sync_stream([_make_chunk("Hello"), _make_chunk(" world")])
+
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span("test_span"):
+        OpenAICostComputer.handle_response(stream)
+        list(stream)
+
+    attrs = otel_setup.get_finished_spans()[0].attributes
+    assert attrs[SpanAttributes.GENERATION.CHUNKS_RECEIVED] == 2
+    assert SpanAttributes.GENERATION.TOKENS_PER_SECOND not in attrs
+
+
+@pytest.mark.optional
+def test_stream_completion_after_span_ended_is_a_safe_noop(otel_setup):
+    from trulens.providers.openai.endpoint import OpenAICostComputer
+
+    stream = _make_sync_stream([_make_chunk("Hello"), _make_chunk(" world")])
+
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span("test_span"):
+        OpenAICostComputer.handle_response(stream)
+    # Span has ended -- consuming the rest of the stream now must not raise.
+    list(stream)
+
+    attrs = otel_setup.get_finished_spans()[0].attributes
+    assert SpanAttributes.GENERATION.CHUNKS_RECEIVED not in attrs
+
+
+class _FakeChatCompletion:
+    """Minimal stand-in for a non-streaming `ChatCompletion`: has `.model`
+    like the real thing, and supports `in` (pydantic models iterate as
+    key/value pairs) the same way `_handle_response`'s generic response
+    handling expects."""
+
+    model = "gpt-4o-mini"
+    usage = None
+
+    def __contains__(self, _key):
+        return False
+
+
+@pytest.mark.optional
+def test_non_streaming_response_unaffected():
+    from trulens.providers.openai.endpoint import OpenAICostComputer
+
+    ret = OpenAICostComputer.handle_response(_FakeChatCompletion())
+    assert SpanAttributes.GENERATION.IS_STREAMING not in ret


### PR DESCRIPTION
## Summary

Part of #2442 (streaming LLM instrumentation). **Stacked on #2690** (sync OpenAI streaming; that commit and #2689's are included in the diff until they merge). Covers a gap flagged when overall issue coverage was last reviewed: the sync-only OpenAI work didn't touch `AsyncOpenAI`, which goes through a separate instrumentation path.

### The bug this actually is

`AsyncOpenAI.post` is registered via `instrument_method(..., span_type=GENERATION)`, which defaults to `create_new_span=True`. That creates a span scoped exactly to the `await post(...)` call -- which always ends the instant `post()` resolves to the stream object, *before* the caller ever starts consuming it. This isn't a "sometimes it doesn't work" edge case like the sync provider's pass-through-streaming caveat -- it's structural: that span can never still be open by the time chunks are consumed, no matter what the calling code does.

Confirmed by testing against a live Ollama server before the fix: `IS_STREAMING` recorded correctly (it's known synchronously), but `TIME_TO_FIRST_TOKEN_MS`/`CHUNKS_RECEIVED`/`TOKENS_PER_SECOND` all came back `None` every time.

### The fix

- Added a `create_new_span` parameter to `instrument_method` (defaults to `True`, so every other caller is unaffected), and pass `create_new_span=False` for `AsyncOpenAI.post` so it piggybacks on the caller's already-open span instead -- the same pattern the sync client already uses successfully (`instrument_cost_computer`, also `create_new_span=False`).
- Added `instrument_async_openai_stream` in the OpenAI endpoint, which wraps the `AsyncStream`'s iterator and defers `TIME_TO_FIRST_TOKEN_MS`/`CHUNKS_RECEIVED`/`TOKENS_PER_SECOND` until the stream is actually consumed. It can't use the sync path's eager-first-chunk-read trick to measure TTFT (that needs `await`, and this fires from a plain sync `attributes` callback), so TTFT here is measured from "request resolved" to "caller pulled the first chunk" -- documented in the docstring as slightly less precise than the sync measurement if the caller does other work before starting to iterate.

Re-verified live after the fix: all four attributes populate correctly.

## Test plan

- [x] New `tests/unit/providers/test_async_openai_streaming_span_attributes.py`, using a **mocked httpx transport** (no network) that still exercises the *real* class-level `AsyncOpenAI.post` monkeypatch -- deliberately not an instance-level mock swap (`client.post = AsyncMock(...)`), since that would bypass the exact instrumentation this PR changes and wouldn't have caught the bug described above.
- [x] Verified live end-to-end against a real Ollama server (before and after the fix, to confirm the fix actually mattered).
- [x] Existing `test_otel_instrument.py` (23 tests), `test_tru_llama_workflow.py`, `test_openai_capabilities.py`, `test_async_openai_capabilities.py`, `test_openai_streaming_span_attributes.py` all still pass -- no regression from the `instrument_method` signature change or the `AsyncOpenAI.post` registration change.
- [x] `ruff check` / `ruff format --check` (pinned `0.5.5`) pass.
