### PR TITLE
Fix streaming cost accumulation to use real token usage

### DIFF
--- a/src/otel/semconv/trulens/otel/semconv/trace.py
+++ b/src/otel/semconv/trulens/otel/semconv/trace.py
@@ -425,6 +425,22 @@ class SpanAttributes:
 
         base = BASE_SCOPE + ".generation"
 
+        IS_STREAMING = base + ".is_streaming"
+        """Whether this generation call used streaming (e.g. `stream=True`)."""
+
+        TIME_TO_FIRST_TOKEN_MS = base + ".time_to_first_token_ms"
+        """Milliseconds between issuing the request and receiving the first
+        streamed chunk. Only set when `IS_STREAMING` is `True`."""
+
+        TOKENS_PER_SECOND = base + ".tokens_per_second"
+        """Completion tokens generated per second, measured from the first
+        to the last chunk received. Only set when `IS_STREAMING` is
+        `True`."""
+
+        CHUNKS_RECEIVED = base + ".chunks_received"
+        """Number of chunks received while consuming a streamed response.
+        Only set when `IS_STREAMING` is `True`."""
+
     class GRAPH_TASK:
         """A graph task function execution."""
 

--- a/src/providers/openai/trulens/providers/openai/endpoint.py
+++ b/src/providers/openai/trulens/providers/openai/endpoint.py
@@ -23,6 +23,7 @@ the involved classes will need to be adapted here. The important classes are:
 import inspect
 import logging
 import pprint
+import time
 from typing import (
     Any,
     Callable,
@@ -51,6 +52,7 @@ except ImportError:
         from langchain_core.outputs import LLMResult
 
 from langchain_community.callbacks.openai_info import OpenAICallbackHandler
+from opentelemetry import trace as otel_trace
 import pydantic
 from pydantic.v1 import BaseModel as v1BaseModel
 from trulens.core.feedback import endpoint as core_endpoint
@@ -125,12 +127,22 @@ class OpenAICostComputer:
         endpoint = OpenAIEndpoint()
         callback = OpenAICallback(endpoint=endpoint)
         model_name = ""
+        streaming_attributes: Dict[str, Any] = {}
 
         if hasattr(response, "__iter__") and not hasattr(response, "model"):
+            streaming_attributes[SpanAttributes.GENERATION.IS_STREAMING] = True
+            request_returned_at = time.monotonic()
             try:
                 first_chunk = next(response)
+                first_chunk_received_at = time.monotonic()
+                streaming_attributes[
+                    SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS
+                ] = (first_chunk_received_at - request_returned_at) * 1000
                 model_name = first_chunk.model or ""
                 response = prepend_first_chunk(response, first_chunk)
+                response = _instrument_stream_span_attributes(
+                    response, first_chunk_received_at
+                )
             except Exception:
                 logger.exception(
                     "Exception occurred while consuming the first chunk from a streamed response."
@@ -156,6 +168,7 @@ class OpenAICostComputer:
         }
         if model_name:
             ret[SpanAttributes.COST.MODEL] = model_name
+        ret.update(streaming_attributes)
 
         return ret
 
@@ -659,4 +672,68 @@ def prepend_first_chunk(stream, first_chunk):
         yield from original_iter
 
     stream._iterator = new_iter()
+    return stream
+
+
+def _instrument_stream_span_attributes(stream, first_chunk_received_at: float):
+    """Wrap `stream`'s iterator to record `CHUNKS_RECEIVED` and, when usage
+    is available (e.g. the caller passed ``stream_options={"include_usage":
+    True}``), `TOKENS_PER_SECOND` on the span that is current *right now* --
+    which must be called before this function, i.e. synchronously as soon as
+    the streamed response object is returned.
+
+    This only works if that span is still open by the time the stream is
+    exhausted, which is the case when the calling code consumes the stream
+    inside the same instrumented function that issued the request (the
+    common pattern). If the raw stream is instead handed off elsewhere (e.g.
+    returned directly to an outer caller for pass-through streaming), the
+    span will have already ended and this becomes a silent no-op -- chunk
+    count/throughput just won't be recorded for that call, same as if this
+    function did not exist.
+    """
+    span = otel_trace.get_current_span()
+    if not span.get_span_context().is_valid:
+        return stream
+
+    state: Dict[str, Any] = {
+        "count": 0,
+        "last_chunk_at": first_chunk_received_at,
+        "completion_tokens": None,
+    }
+
+    def _record_chunk(chunk):
+        state["count"] += 1
+        state["last_chunk_at"] = time.monotonic()
+        usage = getattr(chunk, "usage", None)
+        completion_tokens = getattr(usage, "completion_tokens", None)
+        if completion_tokens:
+            state["completion_tokens"] = completion_tokens
+        return chunk
+
+    def _on_done(_chunks):
+        try:
+            span.set_attribute(
+                SpanAttributes.GENERATION.CHUNKS_RECEIVED, state["count"]
+            )
+            duration_s = state["last_chunk_at"] - first_chunk_received_at
+            if state["completion_tokens"] and duration_s > 0:
+                span.set_attribute(
+                    SpanAttributes.GENERATION.TOKENS_PER_SECOND,
+                    state["completion_tokens"] / duration_s,
+                )
+        except Exception:
+            logger.debug(
+                "Could not record streaming span attributes; the span may "
+                "have already ended.",
+                exc_info=True,
+            )
+
+    if isinstance(stream, openai.AsyncStream):
+        stream._iterator = python_utils.wrap_async_generator(
+            stream._iterator, wrap=_record_chunk, on_done=_on_done
+        )
+    elif isinstance(stream, openai.Stream):
+        stream._iterator = python_utils.wrap_generator(
+            stream._iterator, wrap=_record_chunk, on_done=_on_done
+        )
     return stream

--- a/src/providers/openai/trulens/providers/openai/endpoint.py
+++ b/src/providers/openai/trulens/providers/openai/endpoint.py
@@ -323,6 +323,11 @@ class OpenAICallback(core_endpoint.EndpointCallback):
         exclude=True,
     )
 
+    _stream_usage: Optional[Dict[str, int]] = pydantic.PrivateAttr(default=None)
+    """Token usage captured from a streamed response's trailing usage-only
+    chunk (sent when the caller passes `stream_options={"include_usage":
+    True}`), held until `finalize_stream` is called."""
+
     _FIELDS_MAP: ClassVar[List[Tuple[str, str]]] = [
         ("cost", "total_cost"),
         ("n_tokens", "total_tokens"),
@@ -338,25 +343,51 @@ class OpenAICallback(core_endpoint.EndpointCallback):
 
         try:
             if hasattr(response, "choices"):
-                choices = response.choices
+                for choice in response.choices:
+                    if (
+                        choice.finish_reason != "stop"
+                        and hasattr(choice, "delta")
+                        and choice.delta.content
+                    ):
+                        self.chunks.append({"text": choice.delta.content})
 
-                for choice in choices:
-                    if choice.finish_reason == "stop":
-                        llm_result = LLMResult(
-                            llm_output=dict(
-                                token_usage={},
-                                model_name=response.model or "",
-                            ),
-                            generations=[self.chunks],
-                        )
-                        self.chunks = []
-                        self.handle_generation(response=llm_result)
-                    else:
-                        if hasattr(choice, "delta"):
-                            self.chunks.append({"text": choice.delta.content})
-
+            # Real token usage, when present, arrives on a *separate*
+            # trailing chunk with empty `choices` (only sent when the
+            # caller passes `stream_options={"include_usage": True}`), not
+            # on the same chunk as `finish_reason == "stop"` -- so it can't
+            # be read in the branch above. Held here and applied once the
+            # stream is fully consumed, in `finalize_stream`.
+            usage = getattr(response, "usage", None)
+            if usage is not None:
+                self._stream_usage = {
+                    "prompt_tokens": getattr(usage, "prompt_tokens", 0) or 0,
+                    "completion_tokens": getattr(usage, "completion_tokens", 0)
+                    or 0,
+                    "total_tokens": getattr(usage, "total_tokens", 0) or 0,
+                }
         finally:
             return response
+
+    def finalize_stream(self, model_name: str = "") -> None:
+        """Flush accumulated streamed chunks into a cost/generation record.
+        Must be called once the stream's iterator is exhausted (not on
+        `finish_reason == "stop"`, since real usage -- when requested --
+        arrives in a later chunk than that; see `handle_generation_chunk`).
+        A no-op if nothing was accumulated (e.g. a non-streaming response,
+        which never calls `handle_generation_chunk` in the first place).
+        """
+        if not self.chunks and self._stream_usage is None:
+            return
+        llm_result = LLMResult(
+            llm_output=dict(
+                token_usage=self._stream_usage or {},
+                model_name=model_name,
+            ),
+            generations=[self.chunks],
+        )
+        self.chunks = []
+        self._stream_usage = None
+        self.handle_generation(response=llm_result)
 
     def handle_generation(self, response: LLMResult) -> None:
         super().handle_generation(response)
@@ -519,10 +550,18 @@ class OpenAIEndpoint(core_endpoint.Endpoint):
 
                     return chunk
 
+            def handle_stream_done(_chunks) -> None:
+                with python_utils.with_context(context_vars):
+                    for callback in callbacks:
+                        finalize = getattr(callback, "finalize_stream", None)
+                        if finalize is not None:
+                            finalize(model_name=model_name)
+
             if isinstance(response, openai.AsyncStream):
                 response._iterator = python_utils.wrap_async_generator(
                     response._iterator,
                     wrap=handle_chunk,
+                    on_done=handle_stream_done,
                     context_vars=context_vars,
                 )
                 return response
@@ -531,6 +570,7 @@ class OpenAIEndpoint(core_endpoint.Endpoint):
                 response._iterator = python_utils.wrap_generator(
                     response._iterator,
                     wrap=handle_chunk,
+                    on_done=handle_stream_done,
                     context_vars=context_vars,
                 )
                 return response
@@ -678,9 +718,11 @@ def prepend_first_chunk(stream, first_chunk):
 def _instrument_stream_span_attributes(stream, first_chunk_received_at: float):
     """Wrap `stream`'s iterator to record `CHUNKS_RECEIVED` and, when usage
     is available (e.g. the caller passed ``stream_options={"include_usage":
-    True}``), `TOKENS_PER_SECOND` on the span that is current *right now* --
-    which must be called before this function, i.e. synchronously as soon as
-    the streamed response object is returned.
+    True}``), `TOKENS_PER_SECOND` and real `COST.NUM_*_TOKENS` (in place of
+    the zeros/absence they'd otherwise have for a streamed call) on the span
+    that is current *right now* -- which must be called before this
+    function, i.e. synchronously as soon as the streamed response object is
+    returned.
 
     This only works if that span is still open by the time the stream is
     exhausted, which is the case when the calling code consumes the stream
@@ -688,8 +730,8 @@ def _instrument_stream_span_attributes(stream, first_chunk_received_at: float):
     common pattern). If the raw stream is instead handed off elsewhere (e.g.
     returned directly to an outer caller for pass-through streaming), the
     span will have already ended and this becomes a silent no-op -- chunk
-    count/throughput just won't be recorded for that call, same as if this
-    function did not exist.
+    count/throughput/tokens just won't be recorded for that call, same as if
+    this function did not exist.
     """
     span = otel_trace.get_current_span()
     if not span.get_span_context().is_valid:
@@ -698,16 +740,15 @@ def _instrument_stream_span_attributes(stream, first_chunk_received_at: float):
     state: Dict[str, Any] = {
         "count": 0,
         "last_chunk_at": first_chunk_received_at,
-        "completion_tokens": None,
+        "usage": None,
     }
 
     def _record_chunk(chunk):
         state["count"] += 1
         state["last_chunk_at"] = time.monotonic()
         usage = getattr(chunk, "usage", None)
-        completion_tokens = getattr(usage, "completion_tokens", None)
-        if completion_tokens:
-            state["completion_tokens"] = completion_tokens
+        if usage is not None:
+            state["usage"] = usage
         return chunk
 
     def _on_done(_chunks):
@@ -715,12 +756,29 @@ def _instrument_stream_span_attributes(stream, first_chunk_received_at: float):
             span.set_attribute(
                 SpanAttributes.GENERATION.CHUNKS_RECEIVED, state["count"]
             )
+            usage = state["usage"]
+            completion_tokens = getattr(usage, "completion_tokens", None)
             duration_s = state["last_chunk_at"] - first_chunk_received_at
-            if state["completion_tokens"] and duration_s > 0:
+            if completion_tokens and duration_s > 0:
                 span.set_attribute(
                     SpanAttributes.GENERATION.TOKENS_PER_SECOND,
-                    state["completion_tokens"] / duration_s,
+                    completion_tokens / duration_s,
                 )
+            if usage is not None:
+                # The synchronous OpenAICostComputer.handle_response call
+                # that set up this wrap already flushed COST.* onto this
+                # span *before* any chunk was consumed, so it's stuck at
+                # zero/absent -- overwrite it now that real numbers exist.
+                prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
+                total_tokens = getattr(usage, "total_tokens", 0) or 0
+                span.set_attribute(
+                    SpanAttributes.COST.NUM_PROMPT_TOKENS, prompt_tokens
+                )
+                span.set_attribute(
+                    SpanAttributes.COST.NUM_COMPLETION_TOKENS,
+                    completion_tokens or 0,
+                )
+                span.set_attribute(SpanAttributes.COST.NUM_TOKENS, total_tokens)
         except Exception:
             logger.debug(
                 "Could not record streaming span attributes; the span may "

--- a/tests/unit/providers/test_openai_streaming_cost_accumulation.py
+++ b/tests/unit/providers/test_openai_streaming_cost_accumulation.py
@@ -1,0 +1,128 @@
+# pyright: reportMissingImports=false, reportMissingModuleSource=false
+from unittest.mock import Mock
+
+import pytest
+
+
+def _make_chunk(
+    content=None, finish_reason=None, usage=None, model="gpt-4o-mini"
+):
+    return Mock(
+        model=model,
+        choices=[Mock(delta=Mock(content=content), finish_reason=finish_reason)]
+        if content is not None or finish_reason is not None
+        else [],
+        usage=usage,
+    )
+
+
+@pytest.mark.optional
+def test_finalize_stream_uses_real_usage_from_trailing_chunk():
+    """The bug this fixes: token_usage was hard-coded to `{}` on the
+    finish_reason=="stop" chunk, so streamed calls never got real cost
+    tracked even when the caller requested
+    stream_options={"include_usage": True} -- the real usage arrives on a
+    *separate* trailing chunk with empty choices, which finish_reason=="stop"
+    handling never even looked at."""
+    from trulens.providers.openai.endpoint import OpenAICallback
+    from trulens.providers.openai.endpoint import OpenAIEndpoint
+
+    callback = OpenAICallback(endpoint=OpenAIEndpoint(api_key="test"))
+
+    callback.handle_generation_chunk(_make_chunk(content="Hello"))
+    callback.handle_generation_chunk(_make_chunk(content=" world"))
+    callback.handle_generation_chunk(_make_chunk(finish_reason="stop"))
+    # Nothing should be finalized yet -- real usage hasn't arrived, and we
+    # don't yet know whether it's coming.
+    assert callback.cost.n_successful_requests == 0
+
+    usage = Mock(
+        spec=["prompt_tokens", "completion_tokens", "total_tokens"],
+        prompt_tokens=10,
+        completion_tokens=5,
+        total_tokens=15,
+    )
+    callback.handle_generation_chunk(_make_chunk(usage=usage))
+    # Still not finalized -- that only happens when the stream is actually
+    # exhausted (finalize_stream), not on any particular chunk pattern.
+    assert callback.cost.n_successful_requests == 0
+
+    callback.finalize_stream(model_name="gpt-4o-mini")
+
+    assert callback.cost.n_successful_requests == 1
+    assert callback.cost.n_prompt_tokens == 10
+    assert callback.cost.n_completion_tokens == 5
+    assert callback.cost.n_tokens == 15
+    assert callback.cost.cost > 0  # gpt-4o-mini has known per-token pricing
+
+
+@pytest.mark.optional
+def test_finalize_stream_without_usage_still_records_request():
+    """When the caller doesn't request stream_options={"include_usage":
+    True}, no usage chunk ever arrives -- finalize_stream should still flush
+    the accumulated text (same as the old behavior), just with unknown
+    (zero) cost, not silently drop the request."""
+    from trulens.providers.openai.endpoint import OpenAICallback
+    from trulens.providers.openai.endpoint import OpenAIEndpoint
+
+    callback = OpenAICallback(endpoint=OpenAIEndpoint(api_key="test"))
+
+    callback.handle_generation_chunk(_make_chunk(content="Hello"))
+    callback.handle_generation_chunk(_make_chunk(finish_reason="stop"))
+    callback.finalize_stream(model_name="gpt-4o-mini")
+
+    assert callback.cost.n_successful_requests == 1
+    assert callback.cost.cost == 0
+
+
+@pytest.mark.optional
+def test_finalize_stream_is_a_noop_with_nothing_accumulated():
+    from trulens.providers.openai.endpoint import OpenAICallback
+    from trulens.providers.openai.endpoint import OpenAIEndpoint
+
+    callback = OpenAICallback(endpoint=OpenAIEndpoint(api_key="test"))
+    callback.finalize_stream(model_name="gpt-4o-mini")
+    assert callback.cost.n_successful_requests == 0
+
+
+@pytest.mark.optional
+def test_handle_response_stream_accumulates_real_cost_end_to_end():
+    """Full path: OpenAICostComputer.handle_response wraps the stream, the
+    caller consumes it exactly like real application code would, and the
+    *same* callback object's cost (reachable via the endpoint actually used
+    by the app, e.g. provider.endpoint.global_callback in a real provider)
+    ends up with real, non-zero cost -- not just $0 like before this fix."""
+    import openai
+    from trulens.providers.openai.endpoint import OpenAIEndpoint
+
+    endpoint = OpenAIEndpoint(api_key="test")
+
+    usage = Mock(
+        spec=["prompt_tokens", "completion_tokens", "total_tokens"],
+        prompt_tokens=8,
+        completion_tokens=4,
+        total_tokens=12,
+    )
+    stream = openai.Stream(
+        cast_to=object, client=Mock(spec=openai.OpenAI), response=Mock()
+    )
+
+    def _iterator():
+        yield _make_chunk(content="Hi")
+        yield _make_chunk(finish_reason="stop")
+        yield _make_chunk(usage=usage)
+
+    stream._iterator = _iterator()
+
+    from trulens.providers.openai.endpoint import OpenAICallback
+
+    callback = OpenAICallback(endpoint=endpoint)
+    wrapped = OpenAIEndpoint._handle_response(
+        model_name="gpt-4o-mini", response=stream, callbacks=[callback]
+    )
+    list(wrapped)  # simulate the app consuming the stream
+
+    assert callback.cost.n_successful_requests == 1
+    assert callback.cost.n_prompt_tokens == 8
+    assert callback.cost.n_completion_tokens == 4
+    assert callback.cost.cost > 0

--- a/tests/unit/providers/test_openai_streaming_span_attributes.py
+++ b/tests/unit/providers/test_openai_streaming_span_attributes.py
@@ -1,0 +1,147 @@
+# pyright: reportMissingImports=false, reportMissingModuleSource=false
+from typing import Any, Dict
+from unittest.mock import Mock
+
+import openai
+from opentelemetry import trace
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+import pytest
+from trulens.otel.semconv.trace import SpanAttributes
+
+
+def _make_chunk(content: str, usage=None):
+    return Mock(
+        model="gpt-4o-mini",
+        choices=[Mock(delta=Mock(content=content), finish_reason=None)],
+        usage=usage,
+    )
+
+
+def _make_sync_stream(chunks):
+    stream = openai.Stream(
+        cast_to=object, client=Mock(spec=openai.OpenAI), response=Mock()
+    )
+
+    def _iterator():
+        yield from chunks
+
+    stream._iterator = _iterator()
+    return stream
+
+
+@pytest.fixture
+def otel_setup():
+    from trulens.experimental.otel_tracing.core.session import (
+        _set_up_tracer_provider,
+    )
+
+    exporter = InMemorySpanExporter()
+    _set_up_tracer_provider()
+    processor = SimpleSpanProcessor(exporter)
+    trace.get_tracer_provider().add_span_processor(processor)
+    try:
+        yield exporter
+    finally:
+        processor.shutdown()
+
+
+@pytest.mark.optional
+def test_streaming_attrs_returned_immediately(otel_setup):
+    from trulens.providers.openai.endpoint import OpenAICostComputer
+
+    stream = _make_sync_stream([
+        _make_chunk("Hello"),
+        _make_chunk(" world"),
+    ])
+
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span("test_span"):
+        ret = OpenAICostComputer.handle_response(stream)
+        # Fully consume the stream (handle_response rewires
+        # `stream._iterator` in place, so iterating `stream` itself drives
+        # the wrapped iterator).
+        list(stream)
+
+    assert ret[SpanAttributes.GENERATION.IS_STREAMING] is True
+    assert ret[SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS] >= 0
+
+
+@pytest.mark.optional
+def test_chunks_received_and_tokens_per_second_recorded_on_open_span(
+    otel_setup,
+):
+    from trulens.providers.openai.endpoint import OpenAICostComputer
+
+    usage = Mock(completion_tokens=7)
+    stream = _make_sync_stream([
+        _make_chunk("Hello"),
+        _make_chunk(" world"),
+        _make_chunk("", usage=usage),
+    ])
+
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span("test_span"):
+        OpenAICostComputer.handle_response(stream)
+        list(stream)  # fully consume while span is still open
+
+    spans = otel_setup.get_finished_spans()
+    assert len(spans) == 1
+    attrs: Dict[str, Any] = spans[0].attributes
+    assert attrs[SpanAttributes.GENERATION.CHUNKS_RECEIVED] == 3
+    assert attrs[SpanAttributes.GENERATION.TOKENS_PER_SECOND] > 0
+
+
+@pytest.mark.optional
+def test_chunks_received_omitted_without_usage(otel_setup):
+    from trulens.providers.openai.endpoint import OpenAICostComputer
+
+    stream = _make_sync_stream([_make_chunk("Hello"), _make_chunk(" world")])
+
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span("test_span"):
+        OpenAICostComputer.handle_response(stream)
+        list(stream)
+
+    attrs = otel_setup.get_finished_spans()[0].attributes
+    assert attrs[SpanAttributes.GENERATION.CHUNKS_RECEIVED] == 2
+    assert SpanAttributes.GENERATION.TOKENS_PER_SECOND not in attrs
+
+
+@pytest.mark.optional
+def test_stream_completion_after_span_ended_is_a_safe_noop(otel_setup):
+    from trulens.providers.openai.endpoint import OpenAICostComputer
+
+    stream = _make_sync_stream([_make_chunk("Hello"), _make_chunk(" world")])
+
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span("test_span"):
+        OpenAICostComputer.handle_response(stream)
+    # Span has ended -- consuming the rest of the stream now must not raise.
+    list(stream)
+
+    attrs = otel_setup.get_finished_spans()[0].attributes
+    assert SpanAttributes.GENERATION.CHUNKS_RECEIVED not in attrs
+
+
+class _FakeChatCompletion:
+    """Minimal stand-in for a non-streaming `ChatCompletion`: has `.model`
+    like the real thing, and supports `in` (pydantic models iterate as
+    key/value pairs) the same way `_handle_response`'s generic response
+    handling expects."""
+
+    model = "gpt-4o-mini"
+    usage = None
+
+    def __contains__(self, _key):
+        return False
+
+
+@pytest.mark.optional
+def test_non_streaming_response_unaffected():
+    from trulens.providers.openai.endpoint import OpenAICostComputer
+
+    ret = OpenAICostComputer.handle_response(_FakeChatCompletion())
+    assert SpanAttributes.GENERATION.IS_STREAMING not in ret

--- a/tests/unit/providers/test_openai_streaming_span_attributes.py
+++ b/tests/unit/providers/test_openai_streaming_span_attributes.py
@@ -75,7 +75,12 @@ def test_chunks_received_and_tokens_per_second_recorded_on_open_span(
 ):
     from trulens.providers.openai.endpoint import OpenAICostComputer
 
-    usage = Mock(completion_tokens=7)
+    usage = Mock(
+        spec=["prompt_tokens", "completion_tokens", "total_tokens"],
+        prompt_tokens=12,
+        completion_tokens=7,
+        total_tokens=19,
+    )
     stream = _make_sync_stream([
         _make_chunk("Hello"),
         _make_chunk(" world"),
@@ -92,6 +97,9 @@ def test_chunks_received_and_tokens_per_second_recorded_on_open_span(
     attrs: Dict[str, Any] = spans[0].attributes
     assert attrs[SpanAttributes.GENERATION.CHUNKS_RECEIVED] == 3
     assert attrs[SpanAttributes.GENERATION.TOKENS_PER_SECOND] > 0
+    assert attrs[SpanAttributes.COST.NUM_PROMPT_TOKENS] == 12
+    assert attrs[SpanAttributes.COST.NUM_COMPLETION_TOKENS] == 7
+    assert attrs[SpanAttributes.COST.NUM_TOKENS] == 19
 
 
 @pytest.mark.optional


### PR DESCRIPTION
## Summary

Part of #2442 (streaming LLM instrumentation): "Cost tracking should accumulate as chunks arrive (not just at end)". **Stacked on #2690** (sync OpenAI streaming; that commit and #2689's are included in the diff until they merge).

### The bug

`OpenAICallback.handle_generation_chunk` hard-codes `token_usage={}` on the `finish_reason == "stop"` chunk. Confirmed live against a real server: prompt/completion tokens were **always 0** for a streamed OpenAI call before this fix, even when the caller passed `stream_options={"include_usage": True}` -- **27/4 after** the fix, for the same request.

Root cause: OpenAI only sends real usage on a *separate* trailing chunk with empty `choices` (and only when `include_usage` is requested) -- sent right after, not on, the `"stop"` chunk. The existing code finalized the whole generation record the moment it saw `finish_reason == "stop"`, before that trailing chunk ever arrived, so the real numbers were never looked at. Non-streaming responses were unaffected; this was streaming-only.

### The fix

- `handle_generation_chunk` no longer finalizes on `"stop"` -- it just accumulates text, and stashes real usage from whichever chunk carries it (if any).
- A new `finalize_stream()` flushes whatever was accumulated into a real cost record -- real usage if it arrived, empty otherwise (same fallback as before, so behavior for callers who don't request `include_usage` is unchanged).
- The existing stream-iterator wrapping in `_handle_response` now calls `finalize_stream()` via `on_done`, once, when the stream is *actually* exhausted -- matching how a stream really ends, instead of guessing from a single chunk's shape.
- Also extended the per-span streaming-attributes helper from #2690 to write real `COST.NUM_PROMPT_TOKENS`/`NUM_COMPLETION_TOKENS`/`NUM_TOKENS` onto the span once known (previously stuck at whatever the synchronous, pre-consumption `COST.*` dict had -- i.e. zero -- for every streamed call), alongside the `CHUNKS_RECEIVED`/`TOKENS_PER_SECOND` it already recorded. Same graceful no-op if the span has already closed by the time the stream finishes.

## Test plan

- [x] `tests/unit/providers/test_openai_streaming_cost_accumulation.py` (4 new tests): real usage from a trailing chunk gets picked up correctly; the no-`include_usage` case still records the request (just with $0 cost, not silently dropped); `finalize_stream()` on nothing accumulated is a no-op; a full `OpenAICostComputer`-style end-to-end path produces real, non-zero cost for a known-priced model (`gpt-4o-mini`).
- [x] Fixed an under-specified `Mock` in the existing `test_openai_streaming_span_attributes.py` that this change's stricter usage handling exposed (a `Mock(completion_tokens=7)` with no other fields set was silently returning more mocks for `prompt_tokens`/`total_tokens` instead of the real ints a live OpenAI response always has) -- now asserts the new `COST.NUM_*` span attributes too.
- [x] Verified live against a real server end-to-end: prompt/completion tokens correctly non-zero after the fix, using a real streamed request with `stream_options={"include_usage": True}`.
- [x] Existing `test_otel_instrument.py`, `test_tru_llama_workflow.py`, `test_openai_capabilities.py`, `test_async_openai_capabilities.py` all still pass -- no regression to non-streaming cost tracking or anything else sharing this callback class.
- [x] `ruff check` / `ruff format --check` (pinned `0.5.5`) pass.
