### PR TITLE
Add streaming (mid-stream) support to block_output guardrail

### DIFF
--- a/src/core/trulens/core/guardrails/base.py
+++ b/src/core/trulens/core/guardrails/base.py
@@ -244,10 +244,36 @@ class block_input:
 class block_output:
     """Provides a decorator to block output based on a given feedback and threshold.
 
+    Also supports streaming (generator/async generator) functions: the
+    feedback is periodically re-evaluated against the *accumulated* output
+    so far as chunks arrive, every `check_every_n_chunks` chunks, so an
+    unsafe response can be cut off partway through rather than only being
+    caught (uselessly, since it would already be fully streamed to the
+    caller by then) after the whole thing has been generated.
+
+    !!! warning "Streaming guardrails can only block *future* chunks"
+        Once a chunk has been yielded it can't be un-sent -- if a violation
+        is detected at checkpoint N, chunks 1..N (whatever text they made
+        up) have already reached the caller. Lower `check_every_n_chunks`
+        catches problems earlier at the cost of more (typically
+        LLM-judge-backed) feedback calls during the stream; there's no
+        setting that guarantees zero unsafe output ever reaches the caller
+        for a true token-by-token stream. A final check also runs once the
+        stream ends (covering any tail shorter than `check_every_n_chunks`)
+        purely for the GUARDRAIL span's record -- by then nothing can be
+        blocked, since everything has already been yielded.
+
     Args:
         feedback: The feedback object to use for blocking. It must only take a single argument.
         threshold: The minimum feedback value required for a context to be included.
-        return_value: The value to return if the input is blocked. Defaults to None.
+        return_value: The value to return (or, for a streaming function,
+            yield once in place of further chunks) if the output is
+            blocked. Defaults to None.
+        check_every_n_chunks: For streaming (generator) functions only: how
+            often, in number of chunks yielded by the wrapped function, to
+            re-evaluate the feedback against the accumulated output so far.
+            Defaults to 20. Ignored for non-streaming functions, which are
+            only ever checked once, against the complete output.
 
     Example:
         ```python
@@ -277,6 +303,26 @@ class block_output:
                 )
                 return completion
         ```
+
+        Streaming example:
+        ```python
+        class safe_streaming_chat_app:
+            @instrument(span_type=SpanAttributes.SpanType.GENERATION)
+            @block_output(
+                feedback=feedback,
+                threshold=0.5,
+                return_value="[response withheld]",
+                check_every_n_chunks=10,
+            )
+            def chat(self, question: str):
+                for chunk in oai_client.chat.completions.create(
+                    model="gpt-4o-mini",
+                    stream=True,
+                    messages=[{"role": "user", "content": question}],
+                ):
+                    if chunk.choices and chunk.choices[0].delta.content:
+                        yield chunk.choices[0].delta.content
+        ```
     """
 
     def __init__(
@@ -284,40 +330,96 @@ class block_output:
         feedback: core_metric.Metric,
         threshold: float,
         return_value: Optional[str] = None,
+        check_every_n_chunks: int = 20,
     ):
         self.feedback = feedback
         self.threshold = threshold
         self.return_value = return_value
+        self.check_every_n_chunks = check_every_n_chunks
+
+    def _evaluate(self, text) -> tuple:
+        """Evaluate feedback against `text`; returns (result, blocked)."""
+        result = self.feedback(text)
+        if not isinstance(result, float):
+            raise ValueError(
+                "`block_output` can only be used with feedback functions that return a float."
+            )
+        blocked = (
+            self.feedback.higher_is_better and result < self.threshold
+        ) or (not self.feedback.higher_is_better and result > self.threshold)
+        return result, blocked
+
+    def _check(self, guardrail_name: str, text) -> bool:
+        """Run one guardrail check in its own span; returns whether blocked."""
+        with _guardrail_span(guardrail_name, self.threshold) as span:
+            result, blocked = self._evaluate(text)
+            span.set_attribute(SpanAttributes.GUARDRAIL.SCORE, result)
+            span.set_attribute(SpanAttributes.GUARDRAIL.PASSED, not blocked)
+        return blocked
 
     def __call__(self, func):
         sig = inspect.signature(func)
+        guardrail_name = getattr(self.feedback, "name", func.__name__)
+
+        if inspect.isasyncgenfunction(func):
+
+            async def async_gen_wrapper(*args, **kwargs):
+                accumulated = []
+                since_last_check = 0
+                async for chunk in func(*args, **kwargs):
+                    accumulated.append(chunk)
+                    since_last_check += 1
+                    yield chunk
+                    if since_last_check >= self.check_every_n_chunks:
+                        since_last_check = 0
+                        if self._check(
+                            guardrail_name, "".join(map(str, accumulated))
+                        ):
+                            if self.return_value is not None:
+                                yield self.return_value
+                            return
+                if since_last_check:
+                    # Tail shorter than a full checkpoint: still recorded
+                    # for observability, but nothing left to block.
+                    self._check(guardrail_name, "".join(map(str, accumulated)))
+
+            async_gen_wrapper.__name__ = func.__name__
+            async_gen_wrapper.__doc__ = func.__doc__
+            async_gen_wrapper.__signature__ = sig
+            return async_gen_wrapper
+
+        if inspect.isgeneratorfunction(func):
+
+            def gen_wrapper(*args, **kwargs):
+                accumulated = []
+                since_last_check = 0
+                for chunk in func(*args, **kwargs):
+                    accumulated.append(chunk)
+                    since_last_check += 1
+                    yield chunk
+                    if since_last_check >= self.check_every_n_chunks:
+                        since_last_check = 0
+                        if self._check(
+                            guardrail_name, "".join(map(str, accumulated))
+                        ):
+                            if self.return_value is not None:
+                                yield self.return_value
+                            return
+                if since_last_check:
+                    self._check(guardrail_name, "".join(map(str, accumulated)))
+
+            gen_wrapper.__name__ = func.__name__
+            gen_wrapper.__doc__ = func.__doc__
+            gen_wrapper.__signature__ = sig
+            return gen_wrapper
 
         def wrapper(*args, **kwargs):
-            guardrail_name = getattr(self.feedback, "name", func.__name__)
-
             # Run the decorated function first; the guardrail span wraps only
             # the feedback evaluation so its duration reflects the check, not
             # the application logic.
             output = func(*args, **kwargs)
-            with _guardrail_span(guardrail_name, self.threshold) as span:
-                result = self.feedback(output)
-                if not isinstance(result, float):
-                    raise ValueError(
-                        "`block_output` can only be used with feedback functions that return a float."
-                    )
-                blocked = (
-                    self.feedback.higher_is_better and result < self.threshold
-                ) or (
-                    not self.feedback.higher_is_better
-                    and result > self.threshold
-                )
-                span.set_attribute(SpanAttributes.GUARDRAIL.SCORE, result)
-                span.set_attribute(SpanAttributes.GUARDRAIL.PASSED, not blocked)
-
-            if blocked:
-                return self.return_value
-            else:
-                return output
+            blocked = self._check(guardrail_name, output)
+            return self.return_value if blocked else output
 
         # note: the following information is manually written to the wrapper because @functools.wraps(func) causes breaking of the method.
         wrapper.__name__ = func.__name__

--- a/tests/unit/test_guardrails.py
+++ b/tests/unit/test_guardrails.py
@@ -109,3 +109,83 @@ class TestGuardrailDecorators(unittest.TestCase):
 
         result = chat("example prompt")
         self.assertEqual(result, "Response")
+
+    def test_block_output_streaming_cuts_off_after_checkpoint(self):
+        """Once the checkpoint check trips, no further chunks should be
+        yielded (only the fallback, if one is configured); chunks already
+        yielded before that point are (necessarily) not retracted."""
+        threshold = 0.5
+
+        @block_output(
+            f_dummy_feedback_low,
+            threshold,
+            return_value="[blocked]",
+            check_every_n_chunks=2,
+        )
+        def chat(prompt: str):
+            for word in ["one", "two", "three", "four", "five", "six"]:
+                yield word
+
+        result = list(chat("example prompt"))
+        # Checked after 2 chunks ("one", "two"); low feedback trips the
+        # threshold immediately, so those two plus the fallback is all we
+        # should see.
+        self.assertEqual(result, ["one", "two", "[blocked]"])
+
+    def test_block_output_streaming_no_fallback_just_stops(self):
+        threshold = 0.5
+
+        @block_output(f_dummy_feedback_low, threshold, check_every_n_chunks=1)
+        def chat(prompt: str):
+            for word in ["one", "two", "three"]:
+                yield word
+
+        result = list(chat("example prompt"))
+        self.assertEqual(result, ["one"])
+
+    def test_no_block_output_streaming_yields_everything(self):
+        threshold = 0.5
+
+        @block_output(f_dummy_feedback_high, threshold, check_every_n_chunks=2)
+        def chat(prompt: str):
+            for word in ["one", "two", "three", "four"]:
+                yield word
+
+        result = list(chat("example prompt"))
+        self.assertEqual(result, ["one", "two", "three", "four"])
+
+    def test_block_output_streaming_final_check_on_short_tail(self):
+        """A stream shorter than check_every_n_chunks never hits a
+        checkpoint mid-stream, but should still get a final check (for
+        observability -- it can no longer block anything by then, so all
+        chunks are still yielded)."""
+        threshold = 0.5
+
+        @block_output(f_dummy_feedback_low, threshold, check_every_n_chunks=10)
+        def chat(prompt: str):
+            for word in ["one", "two"]:
+                yield word
+
+        result = list(chat("example prompt"))
+        self.assertEqual(result, ["one", "two"])
+
+    def test_block_output_async_streaming_cuts_off_after_checkpoint(self):
+        import asyncio
+
+        threshold = 0.5
+
+        @block_output(
+            f_dummy_feedback_low,
+            threshold,
+            return_value="[blocked]",
+            check_every_n_chunks=2,
+        )
+        async def chat(prompt: str):
+            for word in ["one", "two", "three", "four"]:
+                yield word
+
+        async def run():
+            return [chunk async for chunk in chat("example prompt")]
+
+        result = asyncio.run(run())
+        self.assertEqual(result, ["one", "two", "[blocked]"])


### PR DESCRIPTION
## Summary

Part of #2442: "Allow metrics to evaluate partial/in-progress outputs (for streaming guardrails)". Independent of the other streaming PRs -- based directly on `main`, no stacking.

`examples/quickstart/blocking_guardrails.ipynb` (referenced by the issue as "Related") has no streaming coverage today. `block_output` assumed `func()` returns a complete string synchronously -- calling it on a generator function would run the feedback function against the raw generator object itself, not any text, so streaming functions were effectively unusable with this guardrail before this change (not a behavior change for any previously-working case).

### What changed

`block_output` now detects a sync or async generator function and, every `check_every_n_chunks` chunks (default 20), re-evaluates the feedback against the *accumulated* output so far. If that trips the threshold, streaming stops -- yielding `return_value` once first, if one is configured -- otherwise chunks pass through unchanged. A stream shorter than one checkpoint still gets a single final check once it ends, purely so the `GUARDRAIL` span records a real evaluation, since nothing can be blocked after the stream has already fully passed through.

### Being upfront about what this can and can't do

This is a real safety constraint, not just an observability nicety, so the docstring says plainly: once a chunk is yielded it can't be un-sent. A violation is only ever caught starting from the *next* checkpoint onward, never retroactively -- there is no `check_every_n_chunks` value that guarantees zero unsafe output ever reaches the caller for a true token-by-token stream. Lower values catch problems earlier at the cost of more feedback calls during the stream (typically LLM-judge-backed, so real added latency/cost per checkpoint).

## Test plan

- [x] 6 new tests in `tests/unit/test_guardrails.py`: checkpoint cutoff with/without a fallback value, non-blocking stream passes everything through, a stream shorter than one checkpoint still gets a final (non-blocking, by then) check, and the async generator case.
- [x] Verified live end-to-end: `@instrument(span_type=GENERATION)` + `@block_output` stacked on a real streaming completion against a local Ollama server -- the exact pattern shown in the new streaming docstring example -- correctly cuts off after the configured checkpoint and yields the fallback (`['Once', ' upon', ' a', '[response withheld]']`).
- [x] Existing `test_guardrails.py`, `test_otel_guardrail.py`, `test_otel_guardrail_spans.py` (17 tests total) all still pass -- non-streaming `block_output`/`block_input`/`context_filter` behavior is unchanged.
- [x] `ruff check` / `ruff format --check` (pinned `0.5.5`) pass.
