### PR TITLE
fix(code_quality): Missing docstring on public function `pytest_collection_modi

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -42,6 +42,31 @@ def pytest_addoption(parser):
 
 
 def pytest_collection_modifyitems(config, items):
+    """Filter collected test items based on CLI flags and environment variables.
+
+    Applies skip markers to tests according to the following rules:
+
+    - Tests marked ``required_only`` are skipped when optional or snowflake
+      test modes are active, or when basic tests are disabled.
+    - Tests marked ``optional`` are skipped unless ``--run_optional_tests`` is
+      set or the ``TEST_OPTIONAL`` environment variable is truthy.
+    - Tests marked ``snowflake`` are skipped unless ``--run_snowflake_tests``
+      is set or the ``TEST_SNOWFLAKE`` environment variable is truthy.
+    - Tests marked ``huggingface`` are skipped unless
+      ``--run_huggingface_tests`` is set or the ``TEST_HUGGINGFACE``
+      environment variable is truthy.
+    - Unmarked tests are skipped when basic tests are disabled via
+      ``--skip_basic_tests`` or the ``SKIP_BASIC_TESTS`` environment variable.
+
+    Args:
+        config: The pytest configuration object providing access to CLI options.
+        items: The list of collected test ``Item`` objects to be modified
+            in-place.
+
+    Raises:
+        ValueError: If a test item is marked with more than one of
+            ``required_only``, ``optional``, ``snowflake``, or ``huggingface``.
+    """
     basic = not config.getoption("--skip_basic_tests") and os.environ.get(
         "SKIP_BASIC_TESTS", ""
     ).lower() not in ["1", "true"]


### PR DESCRIPTION
## TLDR

**Gap:** Missing docstring on public function `pytest_collection_modifyitems` in conftest.py (truera/trulens)

**Wedge type:** `code_quality`

**Issue:** https://github.com/truera/trulens/blob/main/conftest.py

## Changes

- `conftest.py`

**Diff size:** 25 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>