### PR TITLE
feat(otel): track streaming tokens, TTFT and throughput (#2442)

### DIFF
--- a/docs/otel/semantic_conventions.md
+++ b/docs/otel/semantic_conventions.md
@@ -54,6 +54,10 @@
 | `ai.observability.mcp.output_is_error` | Whether the MCP tool call resulted in an error. | Never | | bool |
 | `ai.observability.mcp.execution_time_ms` | Time taken to execute the MCP tool call in milliseconds. | Never | | float |
 | `ai.observability.generation` | Namespace for attributes specific to a generation span. | | Y | |
+| `ai.observability.generation.is_streaming` | Whether the generation was streamed back incrementally. | Never | | bool |
+| `ai.observability.generation.time_to_first_token_ms` | Milliseconds spent waiting for the first chunk of a streamed generation. | Never | | float |
+| `ai.observability.generation.tokens_per_second` | Completion tokens generated per second, measured from the first chunk to the last so that it reflects generation throughput rather than including time to first token. Only set when the completion token count is known, which for a stream means the request asked for usage to be included. | Never | | float |
+| `ai.observability.generation.chunks_received` | Number of chunks received over a streamed generation. | Never | | int |
 | `ai.observability.graph_task` | Namespace for attributes specific to a graph task function execution span. | | Y | |
 | `ai.observability.graph_task.task_name` | Name of the task function. | Never | | str |
 | `ai.observability.graph_task.input_state` | Input state to the task. | Never | | Any |

--- a/examples/quickstart/streaming_apps.ipynb
+++ b/examples/quickstart/streaming_apps.ipynb
@@ -103,9 +103,10 @@
     "        completion = oai_client.chat.completions.create(\n",
     "            model=\"gpt-4.1-mini\",\n",
     "            stream=True,\n",
-    "            stream_options={\n",
-    "                \"include_usage\": True\n",
-    "            },  # not yet tracked by trulens\n",
+    "            # Asks OpenAI for a final usage chunk. Without it a streamed\n",
+    "            # response carries no token counts, so cost and tokens/sec cannot\n",
+    "            # be reported.\n",
+    "            stream_options={\"include_usage\": True},\n",
     "            temperature=0,\n",
     "            messages=[\n",
     "                {\n",
@@ -205,6 +206,52 @@
     "# Check full output:\n",
     "\n",
     "record.main_output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspect the streaming metrics\n",
+    "\n",
+    "Streaming a response makes the total latency a poor summary on its own: most of\n",
+    "it is time spent streaming, not time the user spent waiting to see anything.\n",
+    "TruLens records the split as span attributes, so you can see how long the first\n",
+    "chunk took separately from how fast the rest arrived."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "from trulens.otel.semconv.trace import SpanAttributes\n",
+    "\n",
+    "events = session.get_events(\n",
+    "    app_name=\"LLM App\", app_version=\"v1\", record_ids=[record.record_id]\n",
+    ")\n",
+    "\n",
+    "reported = [\n",
+    "    SpanAttributes.GENERATION.IS_STREAMING,\n",
+    "    SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS,\n",
+    "    SpanAttributes.GENERATION.TOKENS_PER_SECOND,\n",
+    "    SpanAttributes.GENERATION.CHUNKS_RECEIVED,\n",
+    "    SpanAttributes.COST.NUM_COMPLETION_TOKENS,\n",
+    "    SpanAttributes.COST.COST,\n",
+    "]\n",
+    "\n",
+    "for record_attributes in events[\"record_attributes\"]:\n",
+    "    if isinstance(record_attributes, str):\n",
+    "        record_attributes = json.loads(record_attributes)\n",
+    "\n",
+    "    if not record_attributes.get(SpanAttributes.GENERATION.IS_STREAMING):\n",
+    "        continue\n",
+    "\n",
+    "    for name in reported:\n",
+    "        print(f\"{name}: {record_attributes.get(name)}\")"
    ]
   },
   {

--- a/src/core/trulens/core/otel/instrument.py
+++ b/src/core/trulens/core/otel/instrument.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from contextvars import ContextVar
 import inspect
 import logging
+import time
 import types
 from types import TracebackType
 from typing import (
@@ -285,6 +286,45 @@ def _set_span_attributes(
         )
 
 
+def _set_streaming_attributes(
+    span: Span,
+    started: float,
+    first_yield: float | None,
+    chunks_received: int,
+) -> None:
+    """Record streaming timing for a generator that TruLens iterated itself.
+
+    This covers anything that streams without going through a provider we
+    instrument directly: LangChain's `stream`/`astream`, or a plain async
+    generator. Token counts are unknowable from here, so throughput is left
+    unset rather than guessed at.
+
+    Skipped when a provider has already reported a stream on this span. One
+    that tracks its own sees chunks as they leave the network and knows how many
+    tokens they held, so its measurements are the better ones and must not be
+    overwritten by this coarser view. A provider reporting a *non*-streaming
+    call does not block us: the generator around it may still be streaming
+    something of its own.
+    """
+    if span is None or not span.is_recording():
+        return
+
+    existing = getattr(span, "attributes", None) or {}
+    if existing.get(SpanAttributes.GENERATION.IS_STREAMING):
+        return
+
+    span.set_attribute(SpanAttributes.GENERATION.IS_STREAMING, True)
+    span.set_attribute(
+        SpanAttributes.GENERATION.CHUNKS_RECEIVED, chunks_received
+    )
+
+    if first_yield is not None:
+        span.set_attribute(
+            SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS,
+            (first_yield - started) * 1000.0,
+        )
+
+
 def _finalize_span(
     span: Span,
     span_type: SpanAttributes.SpanType,
@@ -422,13 +462,19 @@ class instrument:
             ) as span:
                 ret = None
                 func_exception: Exception | None = None
+                started = time.perf_counter()
+                first_yield: float | None = None
+                streamed = False
                 # Run function.
                 try:
                     result = func(*args, **kwargs)
                     if isinstance(result, types.GeneratorType):
+                        streamed = True
                         yield "is_generator"
                         ret = []
                         for curr in result:
+                            if first_yield is None:
+                                first_yield = time.perf_counter()
                             ret.append(curr)
                             yield curr
                     else:
@@ -441,6 +487,15 @@ class instrument:
                     # None as a return value.
                     func_exception = e
                 finally:
+                    if streamed:
+                        # Also runs when the consumer abandons the generator,
+                        # so a partially consumed stream is still measured.
+                        _set_streaming_attributes(
+                            span,
+                            started,
+                            first_yield,
+                            len(ret) if ret else 0,
+                        )
                     _finalize_span(
                         span,
                         self.span_type,
@@ -531,11 +586,15 @@ class instrument:
             ) as span:
                 ret = None
                 func_exception: Exception | None = None
+                started = time.perf_counter()
+                first_yield: float | None = None
                 # Run function.
                 try:
                     result = func(*args, **kwargs)
                     ret = []
                     async for curr in result:
+                        if first_yield is None:
+                            first_yield = time.perf_counter()
                         ret.append(curr)
                         yield curr
                 except Exception as e:
@@ -544,6 +603,12 @@ class instrument:
                     # None as a return value.
                     func_exception = e
                 finally:
+                    _set_streaming_attributes(
+                        span,
+                        started,
+                        first_yield,
+                        len(ret) if ret else 0,
+                    )
                     _finalize_span(
                         span,
                         self.span_type,

--- a/src/dashboard/trulens/dashboard/tabs/Records.py
+++ b/src/dashboard/trulens/dashboard/tabs/Records.py
@@ -6,6 +6,7 @@ import pandas as pd
 import streamlit as st
 from trulens.core.otel.utils import is_otel_tracing_enabled
 from trulens.dashboard.components.record_viewer import record_viewer
+from trulens.dashboard.components.record_viewer_otel import OtelSpan
 from trulens.dashboard.components.record_viewer_otel import record_viewer_otel
 from trulens.dashboard.constants import EXTERNAL_APP_COL_NAME
 from trulens.dashboard.constants import HIDE_RECORD_COL_NAME
@@ -33,6 +34,7 @@ from trulens.dashboard.ux.styles import aggrid_css
 from trulens.dashboard.ux.styles import cell_rules
 from trulens.dashboard.ux.styles import default_direction
 from trulens.dashboard.ux.styles import radio_button_css
+from trulens.otel.semconv.trace import SpanAttributes
 
 
 def init_page_state():
@@ -166,15 +168,56 @@ def _escape_problematic_markdown(text: str) -> str:
     return escaped
 
 
+def _first_token_latency_ms(
+    event_spans: Optional[Sequence[OtelSpan]],
+) -> Optional[float]:
+    """Time-to-first-token of the earliest streamed generation in a record.
+
+    A record may contain several streamed generations, but what a user waits on
+    before seeing anything is the first one to start, so that is the one worth
+    putting next to latency. Returns None when nothing in the record streamed.
+    """
+    if not event_spans:
+        return None
+
+    streamed = [
+        span
+        for span in event_spans
+        if SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS
+        in (span.get("record_attributes") or {})
+    ]
+    if not streamed:
+        return None
+
+    earliest = min(streamed, key=lambda span: span.get("start_timestamp") or 0)
+
+    return earliest["record_attributes"][
+        SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS
+    ]
+
+
 def _render_record_metrics(
-    records_df: pd.DataFrame, selected_row: pd.Series
+    records_df: pd.DataFrame,
+    selected_row: pd.Series,
+    event_spans: Optional[Sequence[OtelSpan]] = None,
 ) -> None:
     """Render record level metrics (e.g. total tokens, cost, latency) compared
     to the average when appropriate."""
 
     app_specific_df = records_df[records_df["app_id"] == selected_row["app_id"]]
 
-    token_col, cost_col, latency_col, _ = st_columns([1, 1, 1, 3])
+    time_to_first_token_ms = _first_token_latency_ms(event_spans)
+    if time_to_first_token_ms is None:
+        token_col, cost_col, latency_col, _ = st_columns([1, 1, 1, 3])
+        ttft_col = None
+    else:
+        token_col, cost_col, latency_col, ttft_col, _ = st_columns([
+            1,
+            1,
+            1,
+            1,
+            2,
+        ])
 
     num_tokens = selected_row["total_tokens"]
     with token_col.container(height=128, border=True):
@@ -217,6 +260,18 @@ def _render_record_metrics(
             if delta_latency != 0
             else "Latency of the app execution.",
         )
+
+    if ttft_col is not None:
+        with ttft_col.container(height=128, border=True):
+            st.metric(
+                label="Time to first token (s)",
+                value=f"{time_to_first_token_ms / 1000:.3g}s",
+                help=(
+                    "How long the first streamed generation took to produce its"
+                    " first chunk. The rest of the latency above is time spent"
+                    " streaming the remainder of the response."
+                ),
+            )
 
 
 def _render_record_detail(
@@ -264,7 +319,15 @@ def _render_record_detail(
         else:
             st_code(json.dumps(output_value, indent=2), wrap_lines=True)
 
-    _render_record_metrics(records_df, selected_row)
+    # Fetched before the metrics row so that time-to-first-token can be shown
+    # alongside latency, and reused for the trace viewer further down.
+    event_spans: List[OtelSpan] = []
+    if not is_sis_compatibility_enabled() and is_otel_tracing_enabled():
+        event_spans = _get_event_otel_spans(
+            selected_row["record_id"], selected_row["app_name"]
+        )
+
+    _render_record_metrics(records_df, selected_row, event_spans)
 
     online_eval_status = selected_row.get("online_eval_status")
     if online_eval_status:
@@ -306,9 +369,6 @@ def _render_record_detail(
     elif is_otel_tracing_enabled():
         with trace_details:
             st.subheader("Trace Details")
-            event_spans = _get_event_otel_spans(
-                selected_row["record_id"], selected_row["app_name"]
-            )
             if event_spans:
                 record_viewer_otel(
                     spans=event_spans,

--- a/src/otel/semconv/trulens/otel/semconv/trace.py
+++ b/src/otel/semconv/trulens/otel/semconv/trace.py
@@ -425,6 +425,26 @@ class SpanAttributes:
 
         base = BASE_SCOPE + ".generation"
 
+        IS_STREAMING = base + ".is_streaming"
+        """Whether the generation was streamed back incrementally."""
+
+        TIME_TO_FIRST_TOKEN_MS = base + ".time_to_first_token_ms"
+        """Milliseconds between issuing the request and receiving the first chunk.
+
+        Only set for streaming generations.
+        """
+
+        TOKENS_PER_SECOND = base + ".tokens_per_second"
+        """Completion tokens generated per second over the streaming window.
+
+        Measured from the first chunk to the last so that it reflects generation
+        throughput rather than including time-to-first-token. Only set for
+        streaming generations whose completion token count is known.
+        """
+
+        CHUNKS_RECEIVED = base + ".chunks_received"
+        """Number of chunks received over the stream."""
+
     class GRAPH_TASK:
         """A graph task function execution."""
 

--- a/src/providers/openai/trulens/providers/openai/endpoint.py
+++ b/src/providers/openai/trulens/providers/openai/endpoint.py
@@ -23,6 +23,7 @@ the involved classes will need to be adapted here. The important classes are:
 import inspect
 import logging
 import pprint
+import time
 from typing import (
     Any,
     Callable,
@@ -50,7 +51,21 @@ except ImportError:
         from langchain_core.messages import Generation
         from langchain_core.outputs import LLMResult
 
+from langchain_community.callbacks.openai_info import MODEL_COST_PER_1K_TOKENS
 from langchain_community.callbacks.openai_info import OpenAICallbackHandler
+from langchain_community.callbacks.openai_info import (
+    get_openai_token_cost_for_model,
+)
+from langchain_community.callbacks.openai_info import standardize_model_name
+
+try:
+    from langchain_community.callbacks.openai_info import TokenType
+except ImportError:
+    # Older langchain-community versions distinguish completion tokens with an
+    # `is_completion` flag instead of a token type.
+    TokenType = None
+
+from opentelemetry import trace
 import pydantic
 from pydantic.v1 import BaseModel as v1BaseModel
 from trulens.core.feedback import endpoint as core_endpoint
@@ -113,6 +128,195 @@ TOpenAIResponse = TOpenAIReturn
 T = TypeVar("T")  # TODO bound
 
 
+def token_cost_for_model(
+    model_name: str, prompt_tokens: int, completion_tokens: int
+) -> Optional[float]:
+    """Price a prompt/completion token split using langchain's model table.
+
+    Returns None when the model is unknown to langchain, in which case the
+    caller should leave the recorded cost alone rather than reporting zero.
+    """
+    if not model_name:
+        return None
+
+    try:
+        standardized = standardize_model_name(model_name)
+        if standardized not in MODEL_COST_PER_1K_TOKENS:
+            return None
+
+        if TokenType is not None:
+            completion_cost = get_openai_token_cost_for_model(
+                standardized,
+                completion_tokens,
+                token_type=TokenType.COMPLETION,
+            )
+        else:
+            completion_cost = get_openai_token_cost_for_model(
+                standardized, completion_tokens, is_completion=True
+            )
+
+        return (
+            get_openai_token_cost_for_model(standardized, prompt_tokens)
+            + completion_cost
+        )
+    except Exception:
+        logger.debug(
+            "Could not determine token cost for model %s.",
+            model_name,
+            exc_info=True,
+        )
+        return None
+
+
+def cost_attributes(callback: Any, model_name: str) -> Dict[str, Any]:
+    """Build the span attributes describing what a call has cost so far."""
+    ret = {
+        SpanAttributes.COST.COST: callback.cost.cost,
+        SpanAttributes.COST.CURRENCY: callback.cost.cost_currency,
+        SpanAttributes.COST.NUM_TOKENS: callback.cost.n_tokens,
+        SpanAttributes.COST.NUM_PROMPT_TOKENS: callback.cost.n_prompt_tokens,
+        SpanAttributes.COST.NUM_COMPLETION_TOKENS: callback.cost.n_completion_tokens,
+        SpanAttributes.COST.NUM_REASONING_TOKENS: callback.cost.n_reasoning_tokens,
+    }
+    if model_name:
+        ret[SpanAttributes.COST.MODEL] = model_name
+
+    return ret
+
+
+class StreamingSpanUpdater:
+    """Keeps cost and streaming attributes current while a stream is consumed.
+
+    An openai client hands back a `Stream` as soon as the response headers
+    arrive, well before the model has produced anything. Cost tracking runs at
+    that moment, so a streamed call used to be recorded with zero tokens and
+    zero cost no matter how much it went on to generate. This updater rewrites
+    those attributes on the enclosing span as each chunk is consumed, which also
+    means a stream abandoned part way through still records what it produced.
+
+    The span is captured up front rather than looked up per chunk: chunks are
+    consumed from inside the caller's own generator, where the current OTEL
+    context is not guaranteed to still be the one the call was made under.
+    """
+
+    def __init__(
+        self,
+        span: Any,
+        callback: Any,
+        request_start: float,
+        first_token_time: Optional[float] = None,
+        model_name: str = "",
+    ) -> None:
+        self._span = span
+        self._callback = callback
+        self._request_start = request_start
+        self._first_token_time = first_token_time
+        self._last_token_time = first_token_time
+        self._model_name = model_name
+        self._chunks_received = 0
+
+    def attach(self, response: Any) -> Any:
+        """Interpose this updater on a stream's underlying iterator."""
+        iterator = getattr(response, "_iterator", None)
+        if iterator is None:
+            # Not an openai stream object, so there is nothing to hook into.
+            return response
+
+        if isinstance(response, openai.AsyncStream):
+            response._iterator = self._wrap_async(iterator)
+        else:
+            response._iterator = self._wrap_sync(iterator)
+
+        # Record what is known before any chunk is consumed so that a stream
+        # which is never iterated is still marked as one.
+        self._write()
+
+        return response
+
+    def _wrap_sync(self, iterator):
+        try:
+            for chunk in iterator:
+                yield self._observe(chunk)
+        finally:
+            self._write()
+
+    async def _wrap_async(self, iterator):
+        try:
+            async for chunk in iterator:
+                yield self._observe(chunk)
+        finally:
+            self._write()
+
+    def _observe(self, chunk: T) -> T:
+        now = time.perf_counter()
+        if self._first_token_time is None:
+            self._first_token_time = now
+        self._last_token_time = now
+        self._chunks_received += 1
+
+        if not self._model_name:
+            self._model_name = getattr(chunk, "model", "") or ""
+
+        self._write()
+
+        return chunk
+
+    def _time_to_first_token_ms(self) -> Optional[float]:
+        if self._first_token_time is None:
+            return None
+
+        return (self._first_token_time - self._request_start) * 1000.0
+
+    def _tokens_per_second(self) -> Optional[float]:
+        """Completion throughput across the streaming window.
+
+        Measured from the first chunk rather than from the request so that it
+        describes generation speed instead of being dragged down by
+        time-to-first-token. Returns None unless the completion token count is
+        known, which for a stream means the caller asked for
+        `stream_options={"include_usage": True}`.
+        """
+        completion_tokens = self._callback.cost.n_completion_tokens
+        if not completion_tokens:
+            return None
+
+        if self._first_token_time is None or self._last_token_time is None:
+            return None
+
+        elapsed = self._last_token_time - self._first_token_time
+        if elapsed <= 0:
+            return None
+
+        return completion_tokens / elapsed
+
+    def _write(self) -> None:
+        span = self._span
+        if span is None or not span.is_recording():
+            return
+
+        attributes = cost_attributes(self._callback, self._model_name)
+        attributes[SpanAttributes.GENERATION.IS_STREAMING] = True
+        attributes[SpanAttributes.GENERATION.CHUNKS_RECEIVED] = (
+            self._chunks_received
+        )
+
+        time_to_first_token_ms = self._time_to_first_token_ms()
+        if time_to_first_token_ms is not None:
+            attributes[SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS] = (
+                time_to_first_token_ms
+            )
+
+        tokens_per_second = self._tokens_per_second()
+        if tokens_per_second is not None:
+            attributes[SpanAttributes.GENERATION.TOKENS_PER_SECOND] = (
+                tokens_per_second
+            )
+
+        for key, value in attributes.items():
+            if value is not None:
+                span.set_attribute(key, value)
+
+
 class OpenAICostComputer:
     @staticmethod
     def handle_response(response: Any) -> Dict[str, Any]:
@@ -126,9 +330,20 @@ class OpenAICostComputer:
         callback = OpenAICallback(endpoint=endpoint)
         model_name = ""
 
+        # The clock starts here rather than at the call site: by the time cost
+        # tracking sees the response the request has been dispatched and, for a
+        # stream, the client is waiting on the first chunk.
+        request_start = time.perf_counter()
+        first_token_time = None
+        is_streaming = isinstance(response, (openai.Stream, openai.AsyncStream))
+
         if hasattr(response, "__iter__") and not hasattr(response, "model"):
+            is_streaming = True
             try:
                 first_chunk = next(response)
+                # Pulling the first chunk is what blocks on the model, so this
+                # is the moment the first token arrived.
+                first_token_time = time.perf_counter()
                 model_name = first_chunk.model or ""
                 response = prepend_first_chunk(response, first_chunk)
             except Exception:
@@ -146,16 +361,25 @@ class OpenAICostComputer:
             callbacks=[callback],
         )
 
-        ret = {
-            SpanAttributes.COST.COST: callback.cost.cost,
-            SpanAttributes.COST.CURRENCY: callback.cost.cost_currency,
-            SpanAttributes.COST.NUM_TOKENS: callback.cost.n_tokens,
-            SpanAttributes.COST.NUM_PROMPT_TOKENS: callback.cost.n_prompt_tokens,
-            SpanAttributes.COST.NUM_COMPLETION_TOKENS: callback.cost.n_completion_tokens,
-            SpanAttributes.COST.NUM_REASONING_TOKENS: callback.cost.n_reasoning_tokens,
-        }
-        if model_name:
-            ret[SpanAttributes.COST.MODEL] = model_name
+        ret = cost_attributes(callback, model_name)
+
+        # Cost tracking wraps every `create` on the client, including
+        # embeddings and moderations. Only say whether something streamed when
+        # it was a generation in the first place.
+        if is_streaming or hasattr(response, "choices"):
+            ret[SpanAttributes.GENERATION.IS_STREAMING] = is_streaming
+
+        if is_streaming:
+            # Nothing has been generated yet, so the cost values above are all
+            # zero. Hand the still-open span to an updater which corrects them
+            # as the caller consumes the stream.
+            StreamingSpanUpdater(
+                span=trace.get_current_span(),
+                callback=callback,
+                request_start=request_start,
+                first_token_time=first_token_time,
+                model_name=model_name,
+            ).attach(response)
 
         return ret
 
@@ -320,10 +544,54 @@ class OpenAICallback(core_endpoint.EndpointCallback):
     """Pairs where first element is the cost attribute name and second is
     attribute of langchain.OpenAICallbackHandler that corresponds to it."""
 
+    def handle_generation_usage(self, model_name: str, usage: Any) -> None:
+        """Record the token counts reported by a stream's usage chunk.
+
+        A streamed response only carries usage when the request asked for it
+        with `stream_options={"include_usage": True}`, and that chunk arrives
+        after the one bearing `finish_reason == "stop"`. It reports totals for
+        the whole stream, so these counts replace rather than add to what the
+        stop chunk already flushed (which is zero, having had no usage of its
+        own to report).
+        """
+        if isinstance(usage, pydantic.BaseModel):
+            usage = usage.model_dump()
+        elif isinstance(usage, v1BaseModel):
+            usage = usage.dict()
+        elif not isinstance(usage, dict):
+            usage = dict(usage)
+
+        prompt_tokens = usage.get("prompt_tokens") or 0
+        completion_tokens = usage.get("completion_tokens") or 0
+        total_tokens = usage.get("total_tokens") or (
+            prompt_tokens + completion_tokens
+        )
+        completion_details = usage.get("completion_tokens_details") or {}
+        reasoning_tokens = completion_details.get("reasoning_tokens") or 0
+
+        self.cost.n_prompt_tokens = prompt_tokens
+        self.cost.n_completion_tokens = completion_tokens
+        self.cost.n_tokens = total_tokens
+        self.cost.n_reasoning_tokens = reasoning_tokens
+
+        cost = token_cost_for_model(
+            model_name, prompt_tokens, completion_tokens
+        )
+        if cost is not None:
+            self.cost.cost = cost
+
     def handle_generation_chunk(self, response: Any) -> None:
         super().handle_generation_chunk(response=response)
 
         try:
+            usage = getattr(response, "usage", None)
+            if usage is not None:
+                self.handle_generation_usage(
+                    getattr(response, "model", "") or "", usage
+                )
+                self.chunks = []
+                return response
+
             if hasattr(response, "choices"):
                 choices = response.choices
 

--- a/tests/unit/test_otel_streaming.py
+++ b/tests/unit/test_otel_streaming.py
@@ -1,0 +1,435 @@
+"""Tests for streaming instrumentation: TTFT, throughput and chunk counts."""
+
+import asyncio
+import os
+import time
+import unittest
+from unittest import mock
+
+import openai
+from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
+from openai.types.chat.chat_completion_chunk import Choice
+from openai.types.chat.chat_completion_chunk import ChoiceDelta
+from openai.types.completion_usage import CompletionUsage
+from opentelemetry import trace
+from opentelemetry.baggage import remove_baggage
+from opentelemetry.baggage import set_baggage
+import opentelemetry.context as context_api
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from trulens.core.otel.instrument import instrument
+from trulens.core.otel.recording import Recording
+from trulens.experimental.otel_tracing.core.session import (
+    _set_up_tracer_provider,
+)
+from trulens.otel.semconv.trace import SpanAttributes
+from trulens.providers.openai.endpoint import OpenAICostComputer
+
+_MODEL = "gpt-3.5-turbo"
+"""A model langchain knows the price of, so cost assertions are meaningful."""
+
+_FIRST_TOKEN_DELAY = 0.05
+"""Long enough that a time-to-first-token measurement cannot round to zero."""
+
+
+def _content_chunk(content: str) -> ChatCompletionChunk:
+    return ChatCompletionChunk(
+        id="chatcmpl-test",
+        created=0,
+        model=_MODEL,
+        object="chat.completion.chunk",
+        choices=[
+            Choice(
+                index=0,
+                delta=ChoiceDelta(content=content),
+                finish_reason=None,
+            )
+        ],
+    )
+
+
+def _stop_chunk() -> ChatCompletionChunk:
+    return ChatCompletionChunk(
+        id="chatcmpl-test",
+        created=0,
+        model=_MODEL,
+        object="chat.completion.chunk",
+        choices=[Choice(index=0, delta=ChoiceDelta(), finish_reason="stop")],
+    )
+
+
+def _usage_chunk(
+    prompt_tokens: int, completion_tokens: int
+) -> ChatCompletionChunk:
+    """The final chunk sent when `stream_options={"include_usage": True}`."""
+    return ChatCompletionChunk(
+        id="chatcmpl-test",
+        created=0,
+        model=_MODEL,
+        object="chat.completion.chunk",
+        choices=[],
+        usage=CompletionUsage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+        ),
+    )
+
+
+def _make_stream(chunks, delay: float = 0.0) -> openai.Stream:
+    """Build an openai Stream over `chunks` without touching the network.
+
+    `__init__` is bypassed deliberately: it wants a live client and an httpx
+    response, and everything under test reads only `_iterator`.
+    """
+
+    def iterator():
+        for i, chunk in enumerate(chunks):
+            if i == 0 and delay:
+                time.sleep(delay)
+            yield chunk
+
+    stream = openai.Stream.__new__(openai.Stream)
+    stream._iterator = iterator()
+    return stream
+
+
+class TestOpenAIStreamingCostTracking(unittest.TestCase):
+    """The openai provider path, which knows token counts and chunk timing."""
+
+    def setUp(self) -> None:
+        # Cost tracking builds an OpenAIEndpoint, whose client insists on a key
+        # even though nothing here reaches the network.
+        patcher = mock.patch.dict(
+            os.environ, {"OPENAI_API_KEY": "sk-test-not-a-real-key"}
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.exporter = InMemorySpanExporter()
+        _set_up_tracer_provider()
+        self.span_processor = SimpleSpanProcessor(self.exporter)
+        trace.get_tracer_provider().add_span_processor(self.span_processor)
+        self.tracer = trace.get_tracer_provider().get_tracer(__name__)
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        self.span_processor.shutdown()
+        return super().tearDown()
+
+    def _consume(self, chunks, delay: float = 0.0, stop_after: int = -1):
+        """Run a stream through cost tracking and return the finished span."""
+        stream = _make_stream(chunks, delay=delay)
+        with self.tracer.start_as_current_span("llm_call"):
+            returned = OpenAICostComputer.handle_response(stream)
+            for i, _ in enumerate(stream):
+                if i == stop_after:
+                    break
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        return returned, spans[0]
+
+    def test_streaming_is_flagged_immediately(self) -> None:
+        """`is_streaming` is known before a single chunk has been consumed."""
+        returned, _ = self._consume([_content_chunk("hi"), _stop_chunk()])
+        self.assertTrue(returned[SpanAttributes.GENERATION.IS_STREAMING])
+
+    def test_non_streaming_is_flagged(self) -> None:
+        response = openai.types.chat.ChatCompletion(
+            id="chatcmpl-test",
+            created=0,
+            model=_MODEL,
+            object="chat.completion",
+            choices=[],
+            usage=CompletionUsage(
+                prompt_tokens=3, completion_tokens=4, total_tokens=7
+            ),
+        )
+        with self.tracer.start_as_current_span("llm_call"):
+            returned = OpenAICostComputer.handle_response(response)
+
+        self.assertFalse(returned[SpanAttributes.GENERATION.IS_STREAMING])
+
+    def test_embedding_response_is_not_called_a_generation(self) -> None:
+        """Cost tracking wraps every `create`, not just generation ones."""
+        response = openai.types.CreateEmbeddingResponse(
+            data=[],
+            model="text-embedding-3-small",
+            object="list",
+            usage=openai.types.create_embedding_response.Usage(
+                prompt_tokens=5, total_tokens=5
+            ),
+        )
+        with self.tracer.start_as_current_span("embedding_call"):
+            returned = OpenAICostComputer.handle_response(response)
+
+        self.assertNotIn(SpanAttributes.GENERATION.IS_STREAMING, returned)
+
+    def test_chunks_and_ttft_recorded(self) -> None:
+        chunks = [_content_chunk(c) for c in "abcd"] + [_stop_chunk()]
+        _, span = self._consume(chunks, delay=_FIRST_TOKEN_DELAY)
+
+        self.assertTrue(span.attributes[SpanAttributes.GENERATION.IS_STREAMING])
+        self.assertEqual(
+            span.attributes[SpanAttributes.GENERATION.CHUNKS_RECEIVED],
+            len(chunks),
+        )
+        # The first chunk is pulled eagerly by cost tracking, so the measured
+        # time-to-first-token must reflect the wait for it.
+        self.assertGreaterEqual(
+            span.attributes[SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS],
+            _FIRST_TOKEN_DELAY * 1000.0 * 0.5,
+        )
+
+    def test_usage_chunk_populates_tokens_and_cost(self) -> None:
+        chunks = [
+            _content_chunk("a"),
+            _content_chunk("b"),
+            _stop_chunk(),
+            _usage_chunk(prompt_tokens=11, completion_tokens=7),
+        ]
+        _, span = self._consume(chunks)
+
+        self.assertEqual(
+            span.attributes[SpanAttributes.COST.NUM_PROMPT_TOKENS], 11
+        )
+        self.assertEqual(
+            span.attributes[SpanAttributes.COST.NUM_COMPLETION_TOKENS], 7
+        )
+        self.assertEqual(span.attributes[SpanAttributes.COST.NUM_TOKENS], 18)
+        self.assertGreater(span.attributes[SpanAttributes.COST.COST], 0.0)
+        self.assertEqual(span.attributes[SpanAttributes.COST.MODEL], _MODEL)
+
+    def test_tokens_per_second_requires_known_token_counts(self) -> None:
+        """Throughput is reported only when usage says how many tokens there were."""
+        without_usage = [_content_chunk("a"), _stop_chunk()]
+        _, span = self._consume(without_usage)
+        self.assertNotIn(
+            SpanAttributes.GENERATION.TOKENS_PER_SECOND, span.attributes
+        )
+
+        self.setUp()  # fresh exporter for the second stream
+        with_usage = [
+            _content_chunk("a"),
+            _content_chunk("b"),
+            _stop_chunk(),
+            _usage_chunk(prompt_tokens=11, completion_tokens=7),
+        ]
+        _, span = self._consume(with_usage, delay=_FIRST_TOKEN_DELAY)
+        self.assertGreater(
+            span.attributes[SpanAttributes.GENERATION.TOKENS_PER_SECOND], 0.0
+        )
+
+    def test_abandoned_stream_records_what_it_produced(self) -> None:
+        """A stream dropped part way through still reports its chunk count."""
+        chunks = [_content_chunk(c) for c in "abcdefgh"] + [_stop_chunk()]
+        _, span = self._consume(chunks, stop_after=2)
+
+        chunks_received = span.attributes[
+            SpanAttributes.GENERATION.CHUNKS_RECEIVED
+        ]
+        self.assertEqual(chunks_received, 3)
+        self.assertTrue(span.attributes[SpanAttributes.GENERATION.IS_STREAMING])
+
+    def test_async_stream_is_measured(self) -> None:
+        chunks = [_content_chunk("a"), _content_chunk("b"), _stop_chunk()]
+
+        async def iterator():
+            for chunk in chunks:
+                yield chunk
+
+        stream = openai.AsyncStream.__new__(openai.AsyncStream)
+        stream._iterator = iterator()
+
+        async def run():
+            with self.tracer.start_as_current_span("llm_call"):
+                OpenAICostComputer.handle_response(stream)
+                async for _ in stream:
+                    pass
+
+        asyncio.run(run())
+
+        span = self.exporter.get_finished_spans()[0]
+        self.assertTrue(span.attributes[SpanAttributes.GENERATION.IS_STREAMING])
+        self.assertEqual(
+            span.attributes[SpanAttributes.GENERATION.CHUNKS_RECEIVED],
+            len(chunks),
+        )
+
+
+class TestGenericStreamingInstrumentation(unittest.TestCase):
+    """The framework-agnostic path: any instrumented generator."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        instrument.enable_all_instrumentation()
+        return super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        instrument.disable_all_instrumentation()
+        return super().tearDownClass()
+
+    def setUp(self) -> None:
+        self.exporter = InMemorySpanExporter()
+        _set_up_tracer_provider()
+        self.span_processor = SimpleSpanProcessor(self.exporter)
+        trace.get_tracer_provider().add_span_processor(self.span_processor)
+        self.tokens = []
+        self.tokens.append(
+            context_api.attach(
+                set_baggage("__trulens_recording__", Recording(None))
+            )
+        )
+        self.tokens.append(
+            context_api.attach(
+                set_baggage(SpanAttributes.RECORD_ID, "test_record_id")
+            )
+        )
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        self.span_processor.shutdown()
+        remove_baggage("__trulens_recording__")
+        remove_baggage(SpanAttributes.RECORD_ID)
+        for token in self.tokens[::-1]:
+            context_api.detach(token)
+        return super().tearDown()
+
+    def test_sync_generator_records_streaming_attributes(self) -> None:
+        @instrument()
+        def my_function():
+            time.sleep(_FIRST_TOKEN_DELAY)
+            yield "Kojikun"
+            yield "Nolan"
+            yield "Sachiboy"
+
+        for _ in my_function():
+            pass
+
+        span = self.exporter.get_finished_spans()[0]
+        self.assertTrue(span.attributes[SpanAttributes.GENERATION.IS_STREAMING])
+        self.assertEqual(
+            span.attributes[SpanAttributes.GENERATION.CHUNKS_RECEIVED], 3
+        )
+        self.assertGreaterEqual(
+            span.attributes[SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS],
+            _FIRST_TOKEN_DELAY * 1000.0 * 0.5,
+        )
+        # Token counts are unknowable here, so throughput must not be guessed.
+        self.assertNotIn(
+            SpanAttributes.GENERATION.TOKENS_PER_SECOND, span.attributes
+        )
+
+    def test_non_generator_is_not_marked_as_streaming(self) -> None:
+        @instrument()
+        def my_function():
+            return "Kojikun"
+
+        my_function()
+
+        span = self.exporter.get_finished_spans()[0]
+        self.assertNotIn(
+            SpanAttributes.GENERATION.IS_STREAMING, span.attributes
+        )
+
+    def test_non_streaming_provider_call_does_not_suppress_measurement(
+        self,
+    ) -> None:
+        """A provider reporting no stream must not silence the generator's own.
+
+        Only a provider that actually streamed knows better than we do; one
+        that made an ordinary call says nothing about what the generator
+        wrapped around it is doing.
+        """
+
+        @instrument()
+        def my_function():
+            # What cost tracking writes for a non-streamed provider call.
+            trace.get_current_span().set_attribute(
+                SpanAttributes.GENERATION.IS_STREAMING, False
+            )
+            yield "Kojikun"
+            yield "Nolan"
+
+        for _ in my_function():
+            pass
+
+        span = self.exporter.get_finished_spans()[0]
+        self.assertTrue(span.attributes[SpanAttributes.GENERATION.IS_STREAMING])
+        self.assertEqual(
+            span.attributes[SpanAttributes.GENERATION.CHUNKS_RECEIVED], 2
+        )
+
+    def test_provider_measurements_survive_the_wrapping_generator(
+        self,
+    ) -> None:
+        """The openai numbers must win over the generator's coarser view.
+
+        A streaming app yields only the chunks carrying content, so counting
+        yields would undercount, and it can say nothing about tokens per
+        second. Whatever the provider measured has to reach the span intact.
+        """
+        chunks = [
+            _content_chunk("a"),
+            _content_chunk("b"),
+            _stop_chunk(),
+            _usage_chunk(prompt_tokens=11, completion_tokens=7),
+        ]
+        stream = _make_stream(chunks, delay=_FIRST_TOKEN_DELAY)
+
+        @instrument()
+        def stream_completion():
+            OpenAICostComputer.handle_response(stream)
+            for chunk in stream:
+                if chunk.choices and chunk.choices[0].delta.content:
+                    yield chunk.choices[0].delta.content
+
+        with mock.patch.dict(
+            os.environ, {"OPENAI_API_KEY": "sk-test-not-a-real-key"}
+        ):
+            yielded = list(stream_completion())
+
+        self.assertEqual(yielded, ["a", "b"])
+
+        span = self.exporter.get_finished_spans()[0]
+        self.assertEqual(
+            span.attributes[SpanAttributes.GENERATION.CHUNKS_RECEIVED],
+            len(chunks),
+        )
+        self.assertGreater(
+            span.attributes[SpanAttributes.GENERATION.TOKENS_PER_SECOND], 0.0
+        )
+        self.assertEqual(
+            span.attributes[SpanAttributes.COST.NUM_COMPLETION_TOKENS], 7
+        )
+
+    def test_async_generator_records_streaming_attributes(self) -> None:
+        @instrument()
+        async def my_function():
+            await asyncio.sleep(_FIRST_TOKEN_DELAY)
+            yield "Kojikun"
+            yield "Nolan"
+
+        async def run():
+            async for _ in my_function():
+                pass
+
+        asyncio.run(run())
+
+        span = self.exporter.get_finished_spans()[0]
+        self.assertTrue(span.attributes[SpanAttributes.GENERATION.IS_STREAMING])
+        self.assertEqual(
+            span.attributes[SpanAttributes.GENERATION.CHUNKS_RECEIVED], 2
+        )
+        self.assertGreaterEqual(
+            span.attributes[SpanAttributes.GENERATION.TIME_TO_FIRST_TOKEN_MS],
+            _FIRST_TOKEN_DELAY * 1000.0 * 0.5,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2442

# Description

Adds first-class support for streaming LLM responses: time to first token, streaming throughput, chunk counts, and cost that stays current while a stream is being consumed.

This also fixes a defect found while implementing it. Cost tracking runs the moment the openai client hands back a `Stream`, which is as soon as the response headers arrive and before the model has generated anything, and nothing read the counts again once chunks started flowing. Every streamed call was therefore recorded with zero tokens and zero cost. The usage chunk that OpenAI sends for `stream_options={"include_usage": True}` was being dropped as well, because it arrives with an empty `choices` list and the chunk handler only looked inside `choices`. That is the reason for the `# not yet tracked by trulens` comment that had been sitting in `examples/quickstart/streaming_apps.ipynb`.

Four attributes are added to `SpanAttributes.GENERATION`, which until now held only its base scope:

- `ai.observability.generation.is_streaming`
- `ai.observability.generation.time_to_first_token_ms`
- `ai.observability.generation.tokens_per_second`
- `ai.observability.generation.chunks_received`

Streaming is measured both for OpenAI, where token counts are known, and for any instrumented generator, which covers LangChain `stream`/`astream` and plain async generators without framework-specific code. The record detail view in the dashboard now shows time to first token beside latency.

## Other details good to know for developers

`StreamingSpanUpdater` in the openai endpoint captures the enclosing span up front and interposes itself on the stream's iterator, rewriting cost and streaming attributes as each chunk is consumed. This works because the enclosing span stays open for the length of the stream, and it means a stream abandoned part way through still records what it produced. The span is captured rather than looked up per chunk because chunks are consumed from inside the caller's own generator, where the current OTEL context is not guaranteed to still be the one the call was made under.

Time to first token is measured at the eager `next(response)` that cost tracking already performs in order to learn the model name. That call is what blocks on the model, so it is the real first-token wait rather than a proxy for it.

Where both the provider path and the generic generator path apply to the same span, the provider measurement wins. It sees chunks as they leave the network and knows how many tokens they carried, whereas counting yields would undercount an app that only yields content chunks. A provider reporting a *non*-streaming call does not suppress the generic path, since a generator wrapped around an ordinary call may still be streaming something of its own.

`tokens_per_second` is deliberately left unset rather than guessed when the completion token count is unknown, which is always the case for a bare generator and is the case for OpenAI unless the request opts into usage.

Point 3 of the proposed approach in the issue, evaluating partial or in-progress output for streaming guardrails, is not included here. It means running metrics against a buffer that is still being written, which is a change to the guardrails path rather than to instrumentation, and folding it in would make this diff hard to review. Happy to open a follow-up issue for it against `examples/quickstart/blocking_guardrails.ipynb`.

The semantic conventions reference is updated in this PR, so no separate documentation change is needed.

### Testing

`tests/unit/test_otel_streaming.py` adds 13 tests, none of which touch the network. They construct `openai.Stream` and `AsyncStream` objects directly, since the code under test reads only `_iterator`. Coverage includes sync and async streams, chunk counts, time to first token, throughput being absent when token counts are unknown, tokens and cost from the usage chunk, abandoned streams, and embedding responses not being labelled as generations.

The one worth calling out is `test_provider_measurements_survive_the_wrapping_generator`, which runs a stream through an instrumented generator that yields only the two content chunks and checks the span still reports all four chunks along with real throughput and token counts.

`tests/unit/test_otel_instrument.py`, `test_otel_span.py`, `test_otel_recording.py`, `test_exporter.py` and `tests/unit/providers/test_openai_capabilities.py` were also run with no regressions. ruff check and ruff format are clean at the version pinned in `.pre-commit-config.yaml`.

One gap worth stating: the LangChain `astream` path has not been exercised against a real LangChain app. It goes through the generic generator wrapper with no LangChain-specific code, but that part is untested end to end.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update