### PR TITLE
fix(feedback): ndcg_at_k shape crash and cohens_kappa label mutation

### DIFF
--- a/src/feedback/trulens/feedback/groundtruth.py
+++ b/src/feedback/trulens/feedback/groundtruth.py
@@ -12,7 +12,6 @@ import pydantic
 from scipy import stats
 from sklearn.metrics import cohen_kappa_score
 from sklearn.metrics import matthews_corrcoef
-from sklearn.metrics import ndcg_score
 from sklearn.metrics import roc_auc_score
 from trulens.core.utils import imports as import_utils
 from trulens.core.utils import pyschema as pyschema_utils
@@ -40,6 +39,11 @@ logger = logging.getLogger(__name__)
 
 # Canonical implementation lives in trulens-core; re-export for back-compat.
 paired_permutation_pvalue = stats_utils.paired_permutation_pvalue
+
+
+def _dcg(scores: list[float]) -> float:
+    """Discounted cumulative gain: ``sum(score_i / log2(i + 2))`` (0-based)."""
+    return sum(score / np.log2(i + 2) for i, score in enumerate(scores))
 
 
 # TODEP
@@ -364,16 +368,18 @@ class GroundTruthAgreement(
                         index_in_golden
                     ]  # Use the true relevance score
 
-            # Step 5: Prepare the ground truth scores as a vector
-            # Ideal DCG (IDCG) is calculated by placing all relevant items at the top in descending order
-            ideal_golden_scores = sorted(golden_scores, reverse=True)[:k]
-
-            # Step 6: Calculate NDCG@k using sklearn's ndcg_score
-            return ndcg_score(
-                y_true=np.array([ideal_golden_scores]),
-                y_score=np.array([rel_scores[:k]]),  # Consider only top-k items
-                k=k,
-            )
+            # Step 5: Compute NDCG@k directly from the standard formula.
+            # DCG discounts each retrieved chunk's golden relevance by the
+            # log of its rank; IDCG is the best achievable DCG@k, i.e. the
+            # golden scores in descending order. This is computed by hand
+            # rather than via sklearn's ndcg_score, which requires matching
+            # y_true/y_score shapes (it raises when the golden set annotates
+            # fewer/more chunks than the retriever returns) and averages
+            # gains across tied y_score values, distorting the score when
+            # several retrieved chunks share the same (zero) relevance.
+            dcg = _dcg(rel_scores[:k])
+            ideal_dcg = _dcg(sorted(golden_scores, reverse=True)[:k])
+            return dcg / ideal_dcg if ideal_dcg > 0 else 0.0
         else:
             return np.nan
 
@@ -1094,12 +1100,18 @@ class GroundTruthAggregator(
             # threshold at 0.5 for binary classification
             scores = [1 if score >= threshold else 0 for score in scores]
 
-        if any(isinstance(label, float) for label in self.true_labels):
-            self.true_labels = [
-                1 if label >= threshold else 0 for label in self.true_labels
+        # convert to categorical if necessary; binarize into a local list so
+        # that self.true_labels is not mutated — mutating it here would
+        # silently corrupt every other metric computed afterwards (e.g. mae,
+        # brier_score) and make subsequent calls with a different threshold
+        # no-ops since the labels would already be ints.
+        true_labels = self.true_labels
+        if any(isinstance(label, float) for label in true_labels):
+            true_labels = [
+                1 if label >= threshold else 0 for label in true_labels
             ]
 
-        kappa = cohen_kappa_score(self.true_labels, scores)
+        kappa = cohen_kappa_score(true_labels, scores)
         return kappa
 
     def recall(self, scores: list[float] | list[list], threshold=0.5):

--- a/tests/unit/test_groundtruth_aggregator.py
+++ b/tests/unit/test_groundtruth_aggregator.py
@@ -468,6 +468,55 @@ class TestGroundTruthAggregator(TestCase):
         )
 
     @pytest.mark.optional
+    def test_cohens_kappa_does_not_mutate_true_labels(self):
+        """Cohen's kappa must not mutate the stored true_labels in place.
+
+        Binarizing used to overwrite self.true_labels, silently corrupting
+        every metric computed afterwards (e.g. mae, brier_score) and making
+        subsequent calls with a different threshold no-ops since the labels
+        would already be ints.
+        """
+        true_labels = [0.0, 0.6, 0.7, 1.0]
+        scores = [0.55, 0.65, 0.68, 0.95]
+        aggregator = GroundTruthAggregator(true_labels=true_labels)
+
+        mae_before = aggregator.mae(scores)
+        brier_before = aggregator.brier_score(scores)
+
+        # The threshold applies to both true_labels and scores:
+        # t=0.5: true=[0,1,1,1], pred=[1,1,1,1] -> kappa=0.0
+        # t=0.7: true=[0,0,1,1], pred=[0,0,0,1] -> po=0.75, pe=0.5, kappa=0.5
+        self.assertEqual(
+            aggregator.cohens_kappa(scores, threshold=0.5),
+            0.0,
+            msg="Cohen's kappa should be 0.0 at threshold 0.5",
+        )
+        self.assertEqual(
+            aggregator.cohens_kappa(scores, threshold=0.7),
+            0.5,
+            msg=(
+                "A second call with a different threshold must binarize "
+                "against the original float labels, not previously mutated ints"
+            ),
+        )
+
+        self.assertEqual(
+            aggregator.true_labels,
+            true_labels,
+            msg="cohens_kappa must not mutate stored true_labels",
+        )
+        self.assertEqual(
+            aggregator.mae(scores),
+            mae_before,
+            msg="mae must be unaffected by prior cohens_kappa calls",
+        )
+        self.assertEqual(
+            aggregator.brier_score(scores),
+            brier_before,
+            msg="brier_score must be unaffected by prior cohens_kappa calls",
+        )
+
+    @pytest.mark.optional
     def test_mae(self):
         """Test Mean Absolute Error."""
         # Perfect predictions

--- a/tests/unit/test_groundtruth_agreement.py
+++ b/tests/unit/test_groundtruth_agreement.py
@@ -440,6 +440,45 @@ class TestGroundTruthAgreement(TestCase):
         self.assertTrue(np.isnan(result))
 
     @pytest.mark.optional
+    def test_ndcg_at_k_fewer_golden_chunks_than_retrieved(self):
+        """Test NDCG@k when the golden set annotates fewer chunks than retrieved.
+
+        The golden set annotates 2 chunks while 5 are retrieved. This used
+        to raise a shape-mismatch ValueError from sklearn's ndcg_score
+        because the ideal-relevance vector was truncated to the golden
+        count while the retrieved vector was truncated to k.
+        """
+        result = self.agreement_with_chunks.ndcg_at_k(
+            "What is machine learning?",
+            [
+                "Machine learning is a subset of AI",
+                "Some irrelevant text",
+                "More irrelevant text",
+                "Even more irrelevant text",
+                "Yet another irrelevant text",
+            ],
+        )
+        # DCG = 1.0 (only the first retrieved chunk is relevant)
+        # IDCG = 1.0 + 0.8/log2(3) = 1.50473
+        expected = 1.0 / (1.0 + 0.8 / np.log2(3))
+        self.assertAlmostEqual(result, expected, places=10)
+
+    @pytest.mark.optional
+    def test_ndcg_at_k_imperfect_ranking(self):
+        """Test NDCG@k with an imperfect ranking (relevant chunk not first)."""
+        result = self.agreement_with_chunks.ndcg_at_k(
+            "What is machine learning?",
+            [
+                "It uses algorithms to learn patterns",
+                "Machine learning is a subset of AI",
+            ],
+        )
+        # DCG = 0.8/log2(2) + 1.0/log2(3) = 1.43093
+        # IDCG = 1.0/log2(2) + 0.8/log2(3) = 1.50473
+        expected = (0.8 + 1.0 / np.log2(3)) / (1.0 + 0.8 / np.log2(3))
+        self.assertAlmostEqual(result, expected, places=10)
+
+    @pytest.mark.optional
     def test_precision_at_k_perfect_precision(self):
         """Test precision@k with perfect precision."""
         self._test_ir_metric(


### PR DESCRIPTION
## Summary

Two independent bugs in `src/feedback/trulens/feedback/groundtruth.py`:

**1. `ndcg_at_k` crashes when the golden set annotates fewer chunks than the retriever returns**

The old implementation passed `y_true=sorted(golden_scores, reverse=True)[:k]` (truncated to the golden count) and `y_score=rel_scores[:k]` (truncated to k) to sklearn's `ndcg_score`, which requires matching shapes. Whenever `len(golden) < len(retrieved)` and `k >= len(retrieved)`, this raises:

```
ValueError: array is not broadcastable to correct shape
```

This is the common case: golden sets typically annotate only the relevant chunks while retrievers return many. Reproduction:

```python
from trulens.feedback.dummy.provider import DummyProvider
from trulens.feedback.groundtruth import GroundTruthAgreement

gta = GroundTruthAgreement(
    ground_truth=[{"query": "q",
        "expected_chunks": [{"text": "chunk A", "expect_score": 1.0},
                             {"text": "chunk B", "expect_score": 0.8}]}],
    provider=DummyProvider(name="test", delay=0.0),
)
gta.ndcg_at_k("q", ["chunk A", "x1", "x2", "x3", "x4"])  # ValueError
```

Beyond the crash, the old construction was also semantically wrong in two ways: `ndcg_score` averages gains across tied `y_score` values (distorting the score when several retrieved chunks share the same zero relevance — e.g. it returns 0.92354 for the scenario above where the standard formula gives 0.66457), and pairing the ideal gains with the relevance scores by index misplaces gains whenever the retrieved order is not monotonic.

The fix computes NDCG@k directly from the standard formula — DCG over the top-k retrieved chunks, IDCG from the golden scores in descending order — and drops the `ndcg_score` import.

**Behavior change note:** for the narrow case where the top-k retrieved chunks are exactly the golden chunks (e.g. the reversed ideal order covered by the regression test) the result matches the previous sklearn value to floating-point precision; for most other previously working inputs the value changes as well, from the old incorrect value to the standard NDCG@k value.

**2. `cohens_kappa` permanently mutates `self.true_labels`**

Binarization wrote the result back to the stored field:

```python
if any(isinstance(label, float) for label in self.true_labels):
    self.true_labels = [1 if label >= threshold else 0 for label in self.true_labels]
```

With float labels (e.g. human-annotated scores), one `cohens_kappa` call silently corrupts every metric computed afterwards on the same aggregator — e.g. `mae` changes from 0.1675 to 0.3175 and `brier_score` from 0.0770 to 0.1325 for `true_labels=[0.0, 0.6, 0.7, 1.0]`, `scores=[0.55, 0.65, 0.68, 0.95]` — and a second call with a different `threshold` becomes a no-op (the labels are already ints, so the binarization branch is skipped). The fix binarizes into a local list.

## Testing

- 3 new regression tests; the 2 bug-locking tests fail on `main` and pass with this change, the third locks the numeric equivalence case:
  - `test_ndcg_at_k_fewer_golden_chunks_than_retrieved` (was ValueError)
  - `test_cohens_kappa_does_not_mutate_true_labels` (was silent corruption)
  - `test_ndcg_at_k_imperfect_ranking` (numeric lock)
- `tests/unit/test_groundtruth_agreement.py` + `tests/unit/test_groundtruth_aggregator.py` with `--run_optional_tests`: 75 passed; the single failure (`test_constructor_default_provider_warning`) reproduces on unmodified `main` (local environment issue, unrelated to this change)
- `ruff check` / `ruff format --check` clean on all touched files

## Checklist

- [x] Bug fixes verified against unmodified `main`
- [x] No other writers of `true_labels` or users of `ndcg_score` remain (grepped)
- [x] Existing behavior preserved where it was correct (empty retrieved list, unknown query, int labels)