### PR TITLE
feat(feedback): additional_instructions and cot reasons for conversation metrics

### DIFF
--- a/docs/component_guides/instrumentation/conversation_evaluation.md
+++ b/docs/component_guides/instrumentation/conversation_evaluation.md
@@ -119,6 +119,42 @@ Selector.select_conversation_output()  # Ordered record outputs
 Conversation selectors cannot be mixed with record or span selectors in the same
 `Metric`. Attach separate metrics at each scope instead.
 
+### Add domain context to the judge
+
+Every conversation-level metric accepts `additional_instructions`, which appends
+domain guidance to the judge's system prompt. Reach for it when assistant turns
+are not natural language, such as SQL result rows, JSON payloads, or generated
+code, because the default prompts are calibrated for prose:
+
+```python
+f_conversation_coherence = Metric(
+    implementation=provider.coherence_across_turns,
+    name="Coherence Across Turns",
+    additional_instructions=(
+        "Assistant turns are structured SQL result rows rather than prose. "
+        "Judge coherence on whether each result follows from the user request "
+        "in the same turn and stays consistent with earlier results."
+    ),
+).on_conversation()
+```
+
+### Return the judge's reasoning
+
+Each conversation-level metric also has a `_with_cot_reasons` variant that
+returns the score together with the reasoning behind it, so a low score points at
+the turn that caused it instead of leaving the whole transcript under suspicion:
+
+```python
+f_conversation_coherence = Metric(
+    implementation=provider.coherence_across_turns_with_cot_reasons,
+    name="Coherence Across Turns",
+).on_conversation()
+```
+
+The conversation-level metrics are `coherence_across_turns`,
+`conversation_helpfulness`, `topic_adherence`, and `agent_goal_accuracy`. Each
+one has a matching `_with_cot_reasons` variant.
+
 ## Attach both metrics to an app
 
 Turn-level and conversation-level metrics can run on the same recorded application:

--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -4400,19 +4400,99 @@ class LLMProvider(core_provider.Provider):
     def conversation_helpfulness(
         self,
         records: Union[List[Any], str],
+        additional_instructions: Optional[str] = None,
         temperature: float = 0.0,
     ) -> float:
-        """Evaluate helpfulness across a multi-turn conversation."""
+        """
+        Uses chat completion model. A function that completes a template to
+        evaluate helpfulness across a multi-turn conversation.
+
+        Example:
+            ```python
+            from trulens.core import Metric
+            feedback = Metric(
+                implementation=provider.conversation_helpfulness,
+                name="Conversation Helpfulness",
+                additional_instructions=additional_instructions,
+            ).on_conversation()
+            ```
+
+        Args:
+            records (Union[List[Any], str]): The ordered conversation records, or a transcript string.
+            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
+            temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+
+        Returns:
+            float: A value between 0.0 (not helpful) and 1.0 (helpful).
+        """
         from trulens.feedback.templates import (
             conversation as templates_conversation,
         )
 
         transcript = templates_conversation.conversation_to_prompt(records)
+        system_prompt = self._build_criteria_with_instructions(
+            criteria=None,
+            default_criteria=templates_conversation.ConversationHelpfulness.system_prompt,
+            additional_instructions=additional_instructions,
+        )
         user_prompt = templates_conversation.ConversationHelpfulness.user_prompt_template.format(
             transcript=transcript
         )
         return self.generate_score(
-            system_prompt=templates_conversation.ConversationHelpfulness.system_prompt,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            min_score_val=0,
+            max_score_val=3,
+            temperature=temperature,
+        )
+
+    def conversation_helpfulness_with_cot_reasons(
+        self,
+        records: Union[List[Any], str],
+        additional_instructions: Optional[str] = None,
+        temperature: float = 0.0,
+    ) -> Tuple[float, Dict]:
+        """
+        Uses chat completion model. A function that completes a template to
+        evaluate helpfulness across a multi-turn conversation. Also uses chain
+        of thought methodology and emits the reasons.
+
+        Example:
+            ```python
+            from trulens.core import Metric
+            feedback = Metric(
+                implementation=provider.conversation_helpfulness_with_cot_reasons,
+                name="Conversation Helpfulness",
+                additional_instructions=additional_instructions,
+            ).on_conversation()
+            ```
+
+        Args:
+            records (Union[List[Any], str]): The ordered conversation records, or a transcript string.
+            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
+            temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+
+        Returns:
+            Tuple[float, Dict]: A tuple containing a value between 0.0 (not helpful) and 1.0 (helpful) and a dictionary containing the reasons for the evaluation.
+        """
+        from trulens.feedback.templates import (
+            conversation as templates_conversation,
+        )
+
+        transcript = templates_conversation.conversation_to_prompt(records)
+        system_prompt = self._build_criteria_with_instructions(
+            criteria=None,
+            default_criteria=templates_conversation.ConversationHelpfulness.system_prompt,
+            additional_instructions=additional_instructions,
+        )
+        user_prompt = (
+            templates_conversation.ConversationHelpfulness.user_prompt_template.format(
+                transcript=transcript
+            )
+            + templates_base.COT_REASONS_TEMPLATE
+        )
+        return self.generate_score_and_reasons(
+            system_prompt=system_prompt,
             user_prompt=user_prompt,
             min_score_val=0,
             max_score_val=3,
@@ -4423,18 +4503,43 @@ class LLMProvider(core_provider.Provider):
         self,
         records: Union[List[Any], str],
         reference_topics: List[str],
+        additional_instructions: Optional[str] = None,
         temperature: float = 0.0,
     ) -> float:
-        """Evaluate topic adherence across a multi-turn conversation."""
+        """
+        Uses chat completion model. A function that completes a template to
+        evaluate topic adherence across a multi-turn conversation.
+
+        Example:
+            ```python
+            from trulens.core import Metric
+            feedback = Metric(
+                implementation=provider.topic_adherence,
+                name="Topic Adherence",
+                additional_instructions=additional_instructions,
+            ).on_conversation()
+            ```
+
+        Args:
+            records (Union[List[Any], str]): The ordered conversation records, or a transcript string.
+            reference_topics (List[str]): The topics the conversation is expected to adhere to.
+            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
+            temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+
+        Returns:
+            float: A value between 0.0 (off topic) and 1.0 (on topic).
+        """
         from trulens.feedback.templates import (
             conversation as templates_conversation,
         )
 
         transcript = templates_conversation.conversation_to_prompt(records)
-        system_prompt = (
-            templates_conversation.TopicAdherence.system_prompt_template.format(
+        system_prompt = self._build_criteria_with_instructions(
+            criteria=None,
+            default_criteria=templates_conversation.TopicAdherence.system_prompt_template.format(
                 reference_topics=", ".join(reference_topics)
-            )
+            ),
+            additional_instructions=additional_instructions,
         )
         return self.generate_score(
             system_prompt=system_prompt,
@@ -4444,21 +4549,100 @@ class LLMProvider(core_provider.Provider):
             temperature=temperature,
         )
 
-    def agent_goal_accuracy(
+    def topic_adherence_with_cot_reasons(
         self,
         records: Union[List[Any], str],
-        reference_goal: Optional[str] = None,
+        reference_topics: List[str],
+        additional_instructions: Optional[str] = None,
         temperature: float = 0.0,
-    ) -> float:
-        """Evaluate whether an agent fulfilled the conversation goal."""
+    ) -> Tuple[float, Dict]:
+        """
+        Uses chat completion model. A function that completes a template to
+        evaluate topic adherence across a multi-turn conversation. Also uses
+        chain of thought methodology and emits the reasons.
+
+        Example:
+            ```python
+            from trulens.core import Metric
+            feedback = Metric(
+                implementation=provider.topic_adherence_with_cot_reasons,
+                name="Topic Adherence",
+                additional_instructions=additional_instructions,
+            ).on_conversation()
+            ```
+
+        Args:
+            records (Union[List[Any], str]): The ordered conversation records, or a transcript string.
+            reference_topics (List[str]): The topics the conversation is expected to adhere to.
+            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
+            temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+
+        Returns:
+            Tuple[float, Dict]: A tuple containing a value between 0.0 (off topic) and 1.0 (on topic) and a dictionary containing the reasons for the evaluation.
+        """
         from trulens.feedback.templates import (
             conversation as templates_conversation,
         )
 
         transcript = templates_conversation.conversation_to_prompt(records)
-        system_prompt = templates_conversation.AgentGoalAccuracy.system_prompt_template.format(
-            reference_goal=reference_goal
-            or "Infer the user's intended goal from the conversation."
+        system_prompt = self._build_criteria_with_instructions(
+            criteria=None,
+            default_criteria=templates_conversation.TopicAdherence.system_prompt_template.format(
+                reference_topics=", ".join(reference_topics)
+            ),
+            additional_instructions=additional_instructions,
+        )
+        return self.generate_score_and_reasons(
+            system_prompt=system_prompt,
+            user_prompt=f"Conversation Transcript:\n{transcript}"
+            + templates_base.COT_REASONS_TEMPLATE,
+            min_score_val=0,
+            max_score_val=3,
+            temperature=temperature,
+        )
+
+    def agent_goal_accuracy(
+        self,
+        records: Union[List[Any], str],
+        reference_goal: Optional[str] = None,
+        additional_instructions: Optional[str] = None,
+        temperature: float = 0.0,
+    ) -> float:
+        """
+        Uses chat completion model. A function that completes a template to
+        evaluate whether an agent fulfilled the conversation goal.
+
+        Example:
+            ```python
+            from trulens.core import Metric
+            feedback = Metric(
+                implementation=provider.agent_goal_accuracy,
+                name="Agent Goal Accuracy",
+                additional_instructions=additional_instructions,
+            ).on_conversation()
+            ```
+
+        Args:
+            records (Union[List[Any], str]): The ordered conversation records, or a transcript string.
+            reference_goal (Optional[str]): The goal the agent was expected to fulfill. Defaults to None, in which case the goal is inferred from the conversation.
+            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
+            temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+
+        Returns:
+            float: A value of 0.0 (goal not achieved) or 1.0 (goal achieved).
+        """
+        from trulens.feedback.templates import (
+            conversation as templates_conversation,
+        )
+
+        transcript = templates_conversation.conversation_to_prompt(records)
+        system_prompt = self._build_criteria_with_instructions(
+            criteria=None,
+            default_criteria=templates_conversation.AgentGoalAccuracy.system_prompt_template.format(
+                reference_goal=reference_goal
+                or "Infer the user's intended goal from the conversation."
+            ),
+            additional_instructions=additional_instructions,
         )
         return self.generate_score(
             system_prompt=system_prompt,
@@ -4468,20 +4652,148 @@ class LLMProvider(core_provider.Provider):
             temperature=temperature,
         )
 
-    def coherence_across_turns(
+    def agent_goal_accuracy_with_cot_reasons(
         self,
         records: Union[List[Any], str],
+        reference_goal: Optional[str] = None,
+        additional_instructions: Optional[str] = None,
         temperature: float = 0.0,
-    ) -> float:
-        """Evaluate logical coherence across conversation turns."""
+    ) -> Tuple[float, Dict]:
+        """
+        Uses chat completion model. A function that completes a template to
+        evaluate whether an agent fulfilled the conversation goal. Also uses
+        chain of thought methodology and emits the reasons.
+
+        Example:
+            ```python
+            from trulens.core import Metric
+            feedback = Metric(
+                implementation=provider.agent_goal_accuracy_with_cot_reasons,
+                name="Agent Goal Accuracy",
+                additional_instructions=additional_instructions,
+            ).on_conversation()
+            ```
+
+        Args:
+            records (Union[List[Any], str]): The ordered conversation records, or a transcript string.
+            reference_goal (Optional[str]): The goal the agent was expected to fulfill. Defaults to None, in which case the goal is inferred from the conversation.
+            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
+            temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+
+        Returns:
+            Tuple[float, Dict]: A tuple containing a value of 0.0 (goal not achieved) or 1.0 (goal achieved) and a dictionary containing the reasons for the evaluation.
+        """
         from trulens.feedback.templates import (
             conversation as templates_conversation,
         )
 
         transcript = templates_conversation.conversation_to_prompt(records)
+        system_prompt = self._build_criteria_with_instructions(
+            criteria=None,
+            default_criteria=templates_conversation.AgentGoalAccuracy.system_prompt_template.format(
+                reference_goal=reference_goal
+                or "Infer the user's intended goal from the conversation."
+            ),
+            additional_instructions=additional_instructions,
+        )
+        return self.generate_score_and_reasons(
+            system_prompt=system_prompt,
+            user_prompt=f"Conversation Transcript:\n{transcript}"
+            + templates_base.COT_REASONS_TEMPLATE,
+            min_score_val=0,
+            max_score_val=1,
+            temperature=temperature,
+        )
+
+    def coherence_across_turns(
+        self,
+        records: Union[List[Any], str],
+        additional_instructions: Optional[str] = None,
+        temperature: float = 0.0,
+    ) -> float:
+        """
+        Uses chat completion model. A function that completes a template to
+        evaluate logical coherence across conversation turns.
+
+        Example:
+            ```python
+            from trulens.core import Metric
+            feedback = Metric(
+                implementation=provider.coherence_across_turns,
+                name="Coherence Across Turns",
+                additional_instructions=additional_instructions,
+            ).on_conversation()
+            ```
+
+        Args:
+            records (Union[List[Any], str]): The ordered conversation records, or a transcript string.
+            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
+            temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+
+        Returns:
+            float: A value between 0.0 (not coherent) and 1.0 (coherent).
+        """
+        from trulens.feedback.templates import (
+            conversation as templates_conversation,
+        )
+
+        transcript = templates_conversation.conversation_to_prompt(records)
+        system_prompt = self._build_criteria_with_instructions(
+            criteria=None,
+            default_criteria=templates_conversation.CoherenceAcrossTurns.system_prompt,
+            additional_instructions=additional_instructions,
+        )
         return self.generate_score(
-            system_prompt=templates_conversation.CoherenceAcrossTurns.system_prompt,
+            system_prompt=system_prompt,
             user_prompt=f"Conversation Transcript:\n{transcript}",
+            min_score_val=0,
+            max_score_val=3,
+            temperature=temperature,
+        )
+
+    def coherence_across_turns_with_cot_reasons(
+        self,
+        records: Union[List[Any], str],
+        additional_instructions: Optional[str] = None,
+        temperature: float = 0.0,
+    ) -> Tuple[float, Dict]:
+        """
+        Uses chat completion model. A function that completes a template to
+        evaluate logical coherence across conversation turns. Also uses chain
+        of thought methodology and emits the reasons.
+
+        Example:
+            ```python
+            from trulens.core import Metric
+            feedback = Metric(
+                implementation=provider.coherence_across_turns_with_cot_reasons,
+                name="Coherence Across Turns",
+                additional_instructions=additional_instructions,
+            ).on_conversation()
+            ```
+
+        Args:
+            records (Union[List[Any], str]): The ordered conversation records, or a transcript string.
+            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
+            temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+
+        Returns:
+            Tuple[float, Dict]: A tuple containing a value between 0.0 (not coherent) and 1.0 (coherent) and a dictionary containing the reasons for the evaluation.
+        """
+        from trulens.feedback.templates import (
+            conversation as templates_conversation,
+        )
+
+        transcript = templates_conversation.conversation_to_prompt(records)
+        system_prompt = self._build_criteria_with_instructions(
+            criteria=None,
+            default_criteria=templates_conversation.CoherenceAcrossTurns.system_prompt,
+            additional_instructions=additional_instructions,
+        )
+        return self.generate_score_and_reasons(
+            system_prompt=system_prompt,
+            user_prompt=f"Conversation Transcript:\n{transcript}"
+            + templates_base.COT_REASONS_TEMPLATE,
             min_score_val=0,
             max_score_val=3,
             temperature=temperature,

--- a/tests/unit/test_feedback_criteria_and_additional_instructions.py
+++ b/tests/unit/test_feedback_criteria_and_additional_instructions.py
@@ -8,6 +8,8 @@ import warnings
 from trulens.core import Metric
 from trulens.feedback import llm_provider
 from trulens.feedback.templates import agent as templates_agent
+from trulens.feedback.templates import base as templates_base
+from trulens.feedback.templates import conversation as templates_conversation
 from trulens.feedback.templates import quality as templates_quality
 
 
@@ -341,6 +343,256 @@ class TestFeedbackAdditionalInstructions(TestCase):
             additional_instructions,
             self.provider.last_system_prompt,
         )
+
+
+class TestConversationAdditionalInstructions(TestCase):
+    """Test that conversation-level metrics accept additional_instructions."""
+
+    def setUp(self):
+        self.provider = MockLLMProvider()
+        self.records = [
+            {"input": "What is 2+2?", "output": "Four."},
+            {"input": "Why?", "output": "Two pairs total four items."},
+        ]
+
+    def test_coherence_across_turns_default_no_additional_instructions(self):
+        """Test coherence across turns without additional instructions."""
+        result = self.provider.coherence_across_turns(records=self.records)
+
+        # Check that result is valid
+        self.assertIsInstance(result, float)
+
+        # Check that the default system prompt is left untouched
+        self.assertEqual(
+            templates_conversation.CoherenceAcrossTurns.system_prompt,
+            self.provider.last_system_prompt,
+        )
+
+    def test_coherence_across_turns_with_additional_instructions(self):
+        """Test coherence across turns with additional instructions."""
+        additional_instructions = (
+            "Assistant turns are structured SQL result rows, not prose."
+        )
+
+        result = self.provider.coherence_across_turns(
+            records=self.records,
+            additional_instructions=additional_instructions,
+        )
+
+        # Check that result is valid
+        self.assertIsInstance(result, float)
+
+        # Check that additional instructions are in the prompt
+        self.assertIsNotNone(self.provider.last_system_prompt)
+        self.assertIn(
+            additional_instructions,
+            self.provider.last_system_prompt,
+        )
+        self.assertIn(
+            templates_conversation.CoherenceAcrossTurns.system_prompt,
+            self.provider.last_system_prompt,
+        )
+
+    def test_conversation_helpfulness_with_additional_instructions(self):
+        """Test conversation helpfulness with additional instructions."""
+        additional_instructions = "Terse answers are acceptable here."
+
+        result = self.provider.conversation_helpfulness(
+            records=self.records,
+            additional_instructions=additional_instructions,
+        )
+
+        # Check that result is valid
+        self.assertIsInstance(result, float)
+
+        # Check that additional instructions are in the prompt
+        self.assertIsNotNone(self.provider.last_system_prompt)
+        self.assertIn(
+            additional_instructions,
+            self.provider.last_system_prompt,
+        )
+
+    def test_topic_adherence_with_additional_instructions(self):
+        """Test topic adherence with additional instructions."""
+        additional_instructions = "Arithmetic follow-ups count as on topic."
+
+        result = self.provider.topic_adherence(
+            records=self.records,
+            reference_topics=["arithmetic"],
+            additional_instructions=additional_instructions,
+        )
+
+        # Check that result is valid
+        self.assertIsInstance(result, float)
+
+        # Check that both the reference topics and the additional instructions
+        # are in the prompt
+        self.assertIsNotNone(self.provider.last_system_prompt)
+        self.assertIn("arithmetic", self.provider.last_system_prompt)
+        self.assertIn(
+            additional_instructions,
+            self.provider.last_system_prompt,
+        )
+
+    def test_agent_goal_accuracy_with_additional_instructions(self):
+        """Test agent goal accuracy with additional instructions."""
+        additional_instructions = "A partial answer does not achieve the goal."
+
+        result = self.provider.agent_goal_accuracy(
+            records=self.records,
+            reference_goal="Explain why 2+2 is four.",
+            additional_instructions=additional_instructions,
+        )
+
+        # Check that result is valid
+        self.assertIsInstance(result, float)
+
+        # Check that both the reference goal and the additional instructions
+        # are in the prompt
+        self.assertIsNotNone(self.provider.last_system_prompt)
+        self.assertIn(
+            "Explain why 2+2 is four.", self.provider.last_system_prompt
+        )
+        self.assertIn(
+            additional_instructions,
+            self.provider.last_system_prompt,
+        )
+
+    def test_conversation_metric_through_metric_class(self):
+        """Test that Metric passes additional_instructions to a conversation metric."""
+        additional_instructions = "UNIQUE_CONVERSATION_INSTRUCTIONS_E2E_TEST"
+
+        feedback = Metric(
+            implementation=self.provider.coherence_across_turns,
+            name="Coherence Across Turns",
+            additional_instructions=additional_instructions,
+        )
+
+        result = feedback(records=self.records)
+
+        # Verify result is valid
+        self.assertIsInstance(result, float)
+
+        # Verify additional_instructions reached the provider's prompt
+        self.assertIsNotNone(self.provider.last_system_prompt)
+        self.assertIn(additional_instructions, self.provider.last_system_prompt)
+
+
+class TestConversationCotReasons(TestCase):
+    """Test the chain of thought variants of conversation-level metrics."""
+
+    def setUp(self):
+        self.provider = MockLLMProvider()
+        self.records = [
+            {"input": "What is 2+2?", "output": "Four."},
+            {"input": "Why?", "output": "Two pairs total four items."},
+        ]
+
+    def _assert_cot_result(self, result):
+        self.assertIsInstance(result, tuple)
+        self.assertIsInstance(result[0], float)
+        self.assertIsInstance(result[1], dict)
+
+    def test_coherence_across_turns_with_cot_reasons(self):
+        """Test that coherence across turns emits reasons and the transcript."""
+        additional_instructions = "Structured rows are coherent by convention."
+
+        result = self.provider.coherence_across_turns_with_cot_reasons(
+            records=self.records,
+            additional_instructions=additional_instructions,
+        )
+
+        self._assert_cot_result(result)
+
+        # Check that the reasons template and the transcript are in the user prompt
+        self.assertIsNotNone(self.provider.last_user_prompt)
+        self.assertIn(
+            templates_base.COT_REASONS_TEMPLATE,
+            self.provider.last_user_prompt,
+        )
+        self.assertIn(
+            "Turn 1 User: What is 2+2?", self.provider.last_user_prompt
+        )
+
+        # Check that additional instructions are in the system prompt
+        self.assertIn(
+            additional_instructions,
+            self.provider.last_system_prompt,
+        )
+
+    def test_conversation_helpfulness_with_cot_reasons(self):
+        """Test that conversation helpfulness emits reasons."""
+        additional_instructions = "Terse answers are acceptable here."
+
+        result = self.provider.conversation_helpfulness_with_cot_reasons(
+            records=self.records,
+            additional_instructions=additional_instructions,
+        )
+
+        self._assert_cot_result(result)
+        self.assertIn(
+            templates_base.COT_REASONS_TEMPLATE,
+            self.provider.last_user_prompt,
+        )
+        self.assertIn(
+            additional_instructions,
+            self.provider.last_system_prompt,
+        )
+
+    def test_topic_adherence_with_cot_reasons(self):
+        """Test that topic adherence emits reasons."""
+        additional_instructions = "Arithmetic follow-ups count as on topic."
+
+        result = self.provider.topic_adherence_with_cot_reasons(
+            records=self.records,
+            reference_topics=["arithmetic"],
+            additional_instructions=additional_instructions,
+        )
+
+        self._assert_cot_result(result)
+        self.assertIn(
+            templates_base.COT_REASONS_TEMPLATE,
+            self.provider.last_user_prompt,
+        )
+        self.assertIn("arithmetic", self.provider.last_system_prompt)
+        self.assertIn(
+            additional_instructions,
+            self.provider.last_system_prompt,
+        )
+
+    def test_agent_goal_accuracy_with_cot_reasons(self):
+        """Test that agent goal accuracy emits reasons."""
+        additional_instructions = "A partial answer does not achieve the goal."
+
+        result = self.provider.agent_goal_accuracy_with_cot_reasons(
+            records=self.records,
+            reference_goal="Explain why 2+2 is four.",
+            additional_instructions=additional_instructions,
+        )
+
+        self._assert_cot_result(result)
+        self.assertIn(
+            templates_base.COT_REASONS_TEMPLATE,
+            self.provider.last_user_prompt,
+        )
+        self.assertIn(
+            "Explain why 2+2 is four.", self.provider.last_system_prompt
+        )
+        self.assertIn(
+            additional_instructions,
+            self.provider.last_system_prompt,
+        )
+
+    def test_cot_variants_accept_a_transcript_string(self):
+        """Test that the chain of thought variants accept a plain transcript."""
+        transcript = "Turn 1 User: Hello\nTurn 1 Assistant: Hi"
+
+        result = self.provider.coherence_across_turns_with_cot_reasons(
+            records=transcript
+        )
+
+        self._assert_cot_result(result)
+        self.assertIn(transcript, self.provider.last_user_prompt)
 
 
 class TestFeedbackIntegrationWithFeedbackClass(TestCase):

--- a/tests/unit/test_templates_conversation.py
+++ b/tests/unit/test_templates_conversation.py
@@ -42,6 +42,43 @@ def test_conversation_provider_methods_use_supported_score_arguments() -> None:
     )
 
 
+def test_conversation_cot_methods_use_supported_score_arguments() -> None:
+    provider = mock.create_autospec(llm_provider.LLMProvider, instance=True)
+    provider.generate_score_and_reasons.return_value = (1.0, {"reason": "ok"})
+    records = [{"input": "Help", "output": "Done"}]
+
+    assert llm_provider.LLMProvider.topic_adherence_with_cot_reasons(
+        provider,
+        records=records,
+        reference_topics=["support"],
+    ) == (1.0, {"reason": "ok"})
+    provider.generate_score_and_reasons.assert_called_once_with(
+        system_prompt=mock.ANY,
+        user_prompt=mock.ANY,
+        min_score_val=0,
+        max_score_val=3,
+        temperature=0.0,
+    )
+
+
+def test_agent_goal_accuracy_cot_keeps_binary_output_space() -> None:
+    provider = mock.create_autospec(llm_provider.LLMProvider, instance=True)
+    provider.generate_score_and_reasons.return_value = (1.0, {"reason": "ok"})
+    records = [{"input": "Help", "output": "Done"}]
+
+    assert llm_provider.LLMProvider.agent_goal_accuracy_with_cot_reasons(
+        provider,
+        records=records,
+    ) == (1.0, {"reason": "ok"})
+    provider.generate_score_and_reasons.assert_called_once_with(
+        system_prompt=mock.ANY,
+        user_prompt=mock.ANY,
+        min_score_val=0,
+        max_score_val=1,
+        temperature=0.0,
+    )
+
+
 def test_agent_goal_accuracy_requests_score_only() -> None:
     prompt = templates_conversation.AgentGoalAccuracy.system_prompt_template
     assert "Reason:" not in prompt


### PR DESCRIPTION
# Description

Fixes #2699.

The four conversation-level metrics added in 2.12 (`coherence_across_turns`,
`conversation_helpfulness`, `topic_adherence`, `agent_goal_accuracy`) had no way
to pass domain context to the judge and returned a bare float. This adds an
`additional_instructions` parameter to all four, and adds a
`_with_cot_reasons` variant of each that returns `Tuple[float, Dict]`.

`additional_instructions` matters more at conversation scope than at turn scope
because the judge reads a whole transcript at once. When assistant turns are
structured output such as SQL result rows or JSON, the default prompts are
calibrated for prose and score correct output as incoherent. The reasoning
output matters because a single number over a five turn conversation does not
say which turn broke the thread.

Both additions follow the idiom already used by the turn-level metrics in the
same file. `additional_instructions` is threaded through
`_build_criteria_with_instructions`, which is how `coherence`, `harmfulness`,
`correctness` and `conciseness` already fold instructions into a template's
default system prompt. The chain of thought variants append
`templates_base.COT_REASONS_TEMPLATE` to the user prompt and call
`generate_score_and_reasons`, which is how `sentiment_with_cot_reasons` and the
agent trace metrics do it. Parameter order, type hints, docstring layout and
return types match the turn-level methods. The score ranges are unchanged, so
`agent_goal_accuracy_with_cot_reasons` stays binary while the other three stay
on the 0 to 3 Likert scale.

## Other details good to know for developers

`additional_instructions` is placed after the existing domain parameters
(`reference_topics`, `reference_goal`) rather than immediately after `records`,
so existing positional calls keep working.

The turn-level metrics also carry a `**kwargs` shim that maps the deprecated
`custom_instructions` name onto `additional_instructions`. I left that off here
on purpose. These four methods never accepted `custom_instructions`, so a shim
would introduce a deprecated alias rather than preserve one, and `Metric`
already rewrites that name before it reaches the provider. Happy to add it if
you would rather have the signatures byte-identical.

`tests/unit/static/golden/api.trulens.3.11.yaml` is not regenerated in this PR.
That golden file already predates the 2.12 and 2.13 provider additions: it is
missing `coherence_across_turns`, `conversation_helpfulness`, `topic_adherence`,
`agent_goal_accuracy` and `citation_accuracy` on `main` today. Regenerating it
here would fold that unrelated drift into this change, so it seems better for a
maintainer to run `make write-api` separately.

The docs page `component_guides/instrumentation/conversation_evaluation.md` gains
two short subsections showing `additional_instructions` on a conversation metric
and the `_with_cot_reasons` variant.

### Test coverage

New tests in `tests/unit/test_feedback_criteria_and_additional_instructions.py`
reuse the existing `MockLLMProvider`, which captures the prompts the provider
would have sent. They assert that `additional_instructions` reaches the system
prompt for all four metrics, that the default system prompt is untouched when
the parameter is omitted, that `reference_topics` and `reference_goal` survive
alongside it, and that `Metric(additional_instructions=...)` plumbs through to a
conversation metric end to end. A second class covers the chain of thought
variants: tuple return shape, reasons dictionary, the reasons template landing
in the user prompt, the transcript landing in the user prompt, and a plain
transcript string being accepted in place of records.

New tests in `tests/unit/test_templates_conversation.py` follow the autospec
style already in that file and pin the score arguments the new variants pass to
`generate_score_and_reasons`, including the binary range for
`agent_goal_accuracy_with_cot_reasons`.

### What was verified and what was not

Verified on Python 3.11 with `trulens-core` and `trulens-feedback` installed
from this tree: `tests/unit/test_templates_conversation.py` and
`tests/unit/test_feedback_criteria_and_additional_instructions.py`, 32 passed.
The wider `tests/unit` run went from 488 passed to 501 passed with the same
single pre-existing failure in
`test_otel_async_concurrency.py::test_cancelled_finalization_failure_preserves_cancelled_error`,
which reproduces on an unmodified `main` in a full-directory run and passes in
isolation on both. `ruff check` and `ruff format --check` are clean on the three
changed Python files, run with ruff 0.5.5 to match the pinned pre-commit rev.

Not verified: `tests/unit/static/test_api.py`, the streamlit and dashboard
tests, `test_gepa_fitness.py`, `test_records_utils.py` and `test_reward.py`, all
of which need optional dependencies that are not installed here; any test
requiring provider API keys; and live judge behaviour against a real model. The
new prompt text has not been run through an actual LLM, so the wording of the
appended instructions has not been quality-checked end to end.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [x] This change requires a documentation update