### PR TITLE
fix: import torch-backed optional deps lazily (huggingface provider, bert-score)

### DIFF
--- a/src/feedback/trulens/feedback/groundtruth.py
+++ b/src/feedback/trulens/feedback/groundtruth.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 import logging
 from typing import (
+    TYPE_CHECKING,
     ClassVar,
     Optional,
 )
@@ -21,11 +22,16 @@ from trulens.core.utils import stats as stats_utils
 from trulens.feedback import generated as feedback_generated
 from trulens.feedback import llm_provider
 
-with import_utils.OptionalImports(
-    messages=import_utils.format_import_errors(
-        "bert-score", purpose="measuring BERT Score"
-    )
-):
+# NOTE: bert-score is imported lazily, inside the one method that uses it.
+# `bert_score` imports torch and transformers at module scope, and this module is
+# re-exported by `trulens.feedback.__init__`, so importing it eagerly made every
+# importer of `trulens.feedback` pay for torch. torch's import also dlopens
+# bundled CUDA libraries, which has segfaulted Python 3.13 CI workers mid-test.
+_BERT_SCORE_MESSAGES = import_utils.format_import_errors(
+    "bert-score", purpose="measuring BERT Score"
+)
+
+if TYPE_CHECKING:
     from bert_score import BERTScorer
 
 with import_utils.OptionalImports(
@@ -661,6 +667,9 @@ class GroundTruthAgreement(
             dict: with key 'ground_truth_response'
         """
         if self.bert_scorer is None:
+            with import_utils.OptionalImports(messages=_BERT_SCORE_MESSAGES):
+                from bert_score import BERTScorer
+
             self.bert_scorer = BERTScorer(lang="en", rescale_with_baseline=True)
         ground_truth_response = self._find_response(prompt)
         if ground_truth_response:

--- a/src/providers/huggingface/trulens/providers/huggingface/provider.py
+++ b/src/providers/huggingface/trulens/providers/huggingface/provider.py
@@ -18,9 +18,14 @@ import nltk
 from nltk.tokenize import sent_tokenize
 import numpy as np
 import requests
-import torch
-from transformers import AutoModelForSequenceClassification
-from transformers import AutoTokenizer
+
+# NOTE: torch and transformers are imported lazily, inside the HuggingfaceLocal
+# methods that need them. They are the only consumers, and importing torch at
+# module scope made every importer of this package pay for it -- including
+# `Endpoint.track_all_costs`, which imports `.endpoint` (and so runs this
+# package's `__init__`) on instrumented calls that never touch a local model.
+# torch's import also dlopens bundled CUDA libraries, which has segfaulted the
+# Python 3.13 CI workers mid-test.
 from trulens.core._utils.pycompat import Future  # import style exception
 from trulens.core.feedback import endpoint as core_endpoint
 from trulens.core.feedback import provider as core_provider
@@ -718,6 +723,9 @@ class HuggingfaceLocal(HuggingfaceBase):
     def _retrieve_tokenizer_and_model(
         self, key: str, tokenizer_kwargs: Optional[Dict[str, Any]] = None
     ) -> Tuple[Any, Any]:
+        from transformers import AutoModelForSequenceClassification
+        from transformers import AutoTokenizer
+
         if key not in self._cached_tokenizers:
             tokenizer_kwargs = tokenizer_kwargs if tokenizer_kwargs else {}
             self._cached_tokenizers[key] = AutoTokenizer.from_pretrained(
@@ -759,6 +767,8 @@ class HuggingfaceLocal(HuggingfaceBase):
     # TODEP
     @_tci
     def _doc_groundedness(self, premise: str, hypothesis: str) -> float:
+        import torch
+
         tokenizer, model = self._retrieve_tokenizer_and_model(
             HUGS_DOCNLI_MODEL_PATH, tokenizer_kwargs={"use_fast": False}
         )


### PR DESCRIPTION
## Summary

Two modules imported **torch at module scope** through optional dependencies, on import paths that run during ordinary instrumented calls:

1. `src/providers/huggingface/.../provider.py` — `Endpoint.track_all_costs` imports `trulens.providers.huggingface.endpoint` on instrumented calls, which runs the package `__init__` → `provider.py` → `import torch`, even for runs that never touch a local model.
2. `src/feedback/trulens/feedback/groundtruth.py` — `trulens.feedback.__init__` re-exports `groundtruth`, which imported `bert_score` eagerly; `bert_score` imports torch and transformers at module scope.

torch's import `dlopen`s bundled CUDA libraries, and on Python 3.13 that segfaults CI workers mid-test. In [build 16227](https://dev.azure.com/truera/5a27f3d2-132d-40fc-9b0c-81abd1182f41/_build/results?buildId=16227) (PR #2712) the `py313-static` optional suite segfaulted three times, then pytest-xdist stopped replacing the dead worker and sat idle for 33 minutes until the 45-minute job timeout. Same failure in builds 16220 and 16226; py310 / py311 / py312 are unaffected.

The crashing stack, identical for all three segfaults:

```
ctypes/__init__.py:403 in _load_library
torch/__init__.py:327 in _preload_cuda_lib
torch/__init__.py:444 in <module>
src/providers/huggingface/trulens/providers/huggingface/provider.py:21   # import torch
src/providers/huggingface/trulens/providers/huggingface/__init__.py:15
src/core/trulens/core/otel/instrument.py:402 in sync_wrapper
```

### Changes

- **huggingface provider**: torch and transformers are only used by `HuggingfaceLocal`, so the imports move into the two methods that need them (`_retrieve_tokenizer_and_model`, `_doc_groundedness`).
- **groundtruth**: `BERTScorer` is only used by `GroundTruthAgreement.bert_score`, so the import moves there, still wrapped in `OptionalImports` with the same message so a missing bert-score raises the identical install hint. The name stays available to type checkers via `TYPE_CHECKING`.

Public API is unchanged in both. The removed module-level names (`torch`, `AutoTokenizer`, `AutoModelForSequenceClassification`, `BERTScorer`) are not recorded in `tests/unit/static/golden/*.yaml`, so no golden regeneration is needed.

Note that bert-score is not installed in CI, so only fix 1 addresses the observed py313 timeout; fix 2 closes the same hazard on the second path for anyone who does have bert-score installed.

## Test plan

- [x] `importlib.import_module("trulens.providers.huggingface.endpoint")` — the exact call `track_all_costs` makes — leaves `torch` and `transformers` out of `sys.modules`. Before, it pulled in both.
- [x] `import trulens.feedback` leaves `torch`, `transformers`, and `bert_score` out of `sys.modules`, with bert-score installed. Before, it pulled in all three.
- [x] Public API still resolves: `Huggingface`, `HuggingfaceLocal`, `GroundTruthAgreement`, `GroundTruthAggregator`.
- [x] `HuggingfaceLocal._doc_groundedness` with a pre-seeded model cache returns `0.8807970285415649` — deferred `import torch` resolves at call time.
- [x] `GroundTruthAgreement.bert_score` end-to-end against a real `BERTScorer` (downloads roberta-large) returns `0.9999992847442627` for an exact match — deferred `BERTScorer` import resolves at call time.
- [x] With `bert_score` blocked at the import hook, `bert_score()` raises `ModuleNotFoundError` carrying the `pip install "bert-score>=0.3.13"` hint, matching the previous behaviour.
- [x] `tests/unit/test_groundtruth_agreement.py` + `test_groundtruth_aggregator.py`: 73 passed, 8 skipped.
- [x] `pre-commit run` on both changed files: ruff and ruff-format pass.
- [ ] CI: `py313-static` optional unit suite completes instead of timing out.

## Note

Out of scope, but worth a follow-up: `PYTEST_ISOLATED` (`Makefile:10`) has no `--max-worker-restart` and the run has no `pytest-timeout`, so a hung xdist session burns the full 45-minute job timeout rather than failing fast. That is why this crash presented as a mysterious timeout instead of an obvious segfault.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
