### PR TITLE
test(providers): patch transformers classes, not provider module attrs

### DIFF
--- a/tests/unit/providers/test_huggingface_capabilities.py
+++ b/tests/unit/providers/test_huggingface_capabilities.py
@@ -98,7 +98,10 @@ def test_context_relevance_returns_float(monkeypatch):
 
 @pytest.mark.optional
 def test_huggingface_local_model_loading_cached(monkeypatch):
-    import trulens.providers.huggingface.provider as provider_mod
+    # Patch the transformers classes directly: the provider imports them inside
+    # `_retrieve_tokenizer_and_model` rather than at module scope, so they are
+    # not attributes of the provider module.
+    import transformers
     from trulens.providers.huggingface.provider import HuggingfaceLocal
 
     provider = HuggingfaceLocal()
@@ -119,10 +122,10 @@ def test_huggingface_local_model_loading_cached(monkeypatch):
         return object()
 
     monkeypatch.setattr(
-        provider_mod.AutoTokenizer, "from_pretrained", fake_tokenizer_load
+        transformers.AutoTokenizer, "from_pretrained", fake_tokenizer_load
     )
     monkeypatch.setattr(
-        provider_mod.AutoModelForSequenceClassification,
+        transformers.AutoModelForSequenceClassification,
         "from_pretrained",
         fake_model_load,
     )


### PR DESCRIPTION
## Summary

Regression from #2714. That PR moved the torch and transformers imports into the `HuggingfaceLocal` methods that use them, so `AutoTokenizer` and `AutoModelForSequenceClassification` are no longer attributes of `trulens.providers.huggingface.provider`. `test_huggingface_local_model_loading_cached` patched them there and now fails:

```
E  AttributeError: module 'trulens.providers.huggingface.provider' has no attribute 'AutoTokenizer'
tests/unit/providers/test_huggingface_capabilities.py:122: AttributeError
```

This failed the optional unit suite on all four matrix legs (`default`, `py310-static`, `py311-static`, `py313-static`) in [build 16231](https://dev.azure.com/truera/5a27f3d2-132d-40fc-9b0c-81abd1182f41/_build/results?buildId=16231) — it was the only failing test in every one.

Fix: patch the classes on `transformers` instead. They are the same class objects the provider imports at call time, so the caching assertions are unchanged.

## Test plan

- [x] `tests/unit/providers/test_huggingface_capabilities.py::test_huggingface_local_model_loading_cached` passes; the cache assertions still hold (`from_pretrained` called once, second call served from cache).
- [x] `pre-commit run` on the changed file: ruff and ruff-format pass.
- [ ] CI: optional unit suite green on all four matrix legs.

`test_huggingface_api_init` fails in my local sandbox with `PackageNotFoundError: No package metadata was found for trulens.providers.huggingface` — an artifact of running from a `PYTHONPATH` source tree rather than an installed package. It passed in CI build 16231.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
