### PR TITLE
feat(datasets): immutable DatasetVersion snapshots and Run provenance (#2701)

### DIFF
--- a/docs/component_guides/evaluation/dataset_versions.md
+++ b/docs/component_guides/evaluation/dataset_versions.md
@@ -1,0 +1,145 @@
+# Dataset Versions
+
+A `Dataset` is a stable identity: a name, an id and some metadata. Adding or
+replacing examples changes what that dataset contains, which means a run
+recorded last month cannot be reproduced and two runs cannot be compared with
+any confidence that they saw the same test set.
+
+A `DatasetVersion` is an immutable snapshot of a dataset's examples. Publishing
+one freezes the exact set of examples a run reads, so an evaluation stays
+reproducible and membership changes between test sets stay visible.
+
+## Publishing a version
+
+```python
+from trulens.core import TruSession
+
+session = TruSession()
+
+version = session.create_dataset_version(
+    dataset_name="support-quality",
+    dataframe=examples,
+    column_spec={
+        "input": "question",
+        "ground_truth_output": "expected_answer",
+        "metadata": "metadata",
+    },
+    splits={"regression": ["case-1", "case-2"]},
+    description="Reviewed August failures",
+)
+
+print(version.dataset_version_id)
+```
+
+The `column_spec` maps dataset version item fields to columns in your
+dataframe. The canonical keys are `input`, `input_id`, `expected_response`,
+`expected_contexts` and `metadata`; the legacy `GroundTruth` spellings
+(`query`, `query_id`, `expected_chunks`, `meta`) and the reserved
+`RunConfig.dataset_spec` keys (`ground_truth_output`, `record_root.input`) are
+accepted too, so the same mapping can be handed to both APIs. Keys that do not
+name an item field are ignored.
+
+Examples can also be published from a sequence of
+[GroundTruth][trulens.core.schema.groundtruth.GroundTruth] entries:
+
+```python
+version = session.create_dataset_version(
+    dataset_name="support-quality",
+    ground_truths=ground_truths,
+)
+```
+
+## Content addressing and idempotency
+
+A version id is a hash of the dataset, the ordered contents of the version and
+its source metadata. Two consequences follow:
+
+- **Publishing identical content is idempotent.** The second call returns the
+  version that already exists rather than creating a duplicate.
+- **Published versions are never updated.** `description` and
+  `parent_dataset_version_id` are provenance annotations that are deliberately
+  excluded from the hash, so re-publishing the same examples under a new
+  description returns the original version, description and all.
+
+Item ids are content-addressed too, from the normalized example content
+(`input`, `expected_response`, `expected_contexts`) and the optional
+caller-supplied `input_id`. An item's `metadata` and `splits` are properties of
+the item *within a version* and do not take part in its identity, so
+re-annotating an example produces a new version without making membership
+comparison report the example as removed and re-added.
+
+## Loading a version
+
+Pass only a name to resolve the latest version, or pin an exact snapshot:
+
+```python
+latest = session.get_dataset_version(dataset_name="support-quality")
+
+pinned = session.get_dataset_version(
+    dataset_version_id=version.dataset_version_id,
+)
+
+session.list_dataset_versions("support-quality")  # oldest first
+```
+
+Named splits are carried on the loaded items:
+
+```python
+regression_cases = pinned.split("regression")
+```
+
+## Comparing versions
+
+```python
+diff = session.compare_dataset_versions(
+    baseline.dataset_version_id,
+    candidate.dataset_version_id,
+)
+
+print(len(diff.added), len(diff.removed), len(diff.unchanged))
+```
+
+## Pinning a version to a run
+
+A run can record which snapshot it read, and read that snapshot back:
+
+```python
+from trulens.core.run import RunConfig
+
+run = app.add_run(
+    RunConfig(
+        run_name="august-regression",
+        dataset_name="support-quality",
+        dataset_spec={"input": "question"},
+        dataset_version_id=version.dataset_version_id,
+    )
+)
+
+run.start()  # loads the pinned snapshot instead of the live source
+```
+
+The version id is persisted in the run's source info, shows up in
+`run.describe()`, and is reported by `RunDiff.provenance()` when two runs are
+compared. Comparing two runs pinned to *different* versions logs a warning,
+since the metric deltas then mix changes in the app with changes in the test
+set.
+
+## Existing datasets
+
+Datasets whose examples predate versioning are exposed as **version zero**,
+reconstructed from their `GroundTruth` rows. The original ground truth payloads
+are read but never rewritten. Version zero is materialized as a real row the
+first time a newer version is published for that dataset, so it stays loadable
+afterwards and becomes the parent of the first published version.
+
+Existing APIs are unchanged. In particular, `session.get_ground_truth(
+dataset_name=...)` still returns every ground truth row of the dataset, so
+publishing a version of a subset does not silently change what existing callers
+read. Pass `dataset_version_id` to read a pinned snapshot in the same
+`GroundTruth` shape:
+
+```python
+df = session.get_ground_truth(
+    dataset_version_id=version.dataset_version_id,
+)
+```

--- a/docs/contributing/database.md
+++ b/docs/contributing/database.md
@@ -37,13 +37,26 @@ ground truth data. These are written to via
 | ----- | ----------- |
 | `trulens_dataset` | Dataset definitions (dataset_id, dataset_json) |
 | `trulens_ground_truth` | Ground truth entries linked to datasets |
+| `trulens_dataset_version` | Immutable, content-addressed snapshots of a dataset |
+| `trulens_dataset_version_item` | The examples belonging to one snapshot |
 
 ```text
 dataset (1) ──────< ground_truth (many)
+         (1) ──────< dataset_version (many) ──────< dataset_version_item (many)
 ```
 
 These tables are separate from trace storage and are used to store expected
 outputs for evaluation comparisons.
+
+`trulens_dataset` and `trulens_ground_truth` are mutable: writing to a dataset
+changes what it contains. `trulens_dataset_version` rows are immutable — the
+version id is a hash of the version's ordered contents, so any change to those
+contents is a new row rather than an update to an existing one, and
+`(dataset_id, version_index)` is unique so version history cannot fork. Datasets
+written before versioning existed are exposed as version zero by a
+compatibility loader that reads, but never rewrites, their ground truth
+payloads. See
+[Dataset Versions](../component_guides/evaluation/dataset_versions.md).
 
 ### Benefits of OTEL Schema
 
@@ -128,6 +141,9 @@ Existing migrations in `src/core/trulens/core/database/migrations/versions/`:
 | 8 | Update records app_id |
 | 9 | Update app_json |
 | 10 | Create events table (OTEL) |
+| 11 | Add events table indexes |
+| 12 | Create runs table |
+| 13 | Add dataset_version and dataset_version_item tables |
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -298,6 +298,7 @@ nav:
             - Batch evaluation with runs: component_guides/evaluation/batch_evaluation.md
         - Generating Test Cases:
             - component_guides/evaluation/generate_test_cases.md
+        - Dataset Versions: component_guides/evaluation/dataset_versions.md
         - Migrating to Metric API: component_guides/evaluation/metric_migration.md
         - Evaluate MLFlow Traces: component_guides/evaluation/mlflow.md
     - 🏃 Runtime Evaluation:

--- a/src/connectors/snowflake/trulens/connectors/snowflake/dao/run.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/dao/run.py
@@ -82,6 +82,7 @@ class RunDao(RunDaoBase):
         label: Optional[str] = "",
         llm_judge_name: Optional[str] = "",
         mode: Optional[Mode] = Mode.APP_INVOCATION,
+        dataset_version_id: Optional[str] = None,
     ) -> pd.DataFrame:
         """
         Create a new RunMetadata entity in Snowflake.
@@ -99,6 +100,8 @@ class RunDao(RunDaoBase):
             label: A label for the run.
             llm_judge_name: The name of the LLM judge to use for the evaluation, when applicable.
             mode: The mode of operation (LOG_INGESTION or APP_INVOCATION).
+            dataset_version_id: The id of the immutable dataset version the
+                run is pinned to, when one was selected.
 
         Returns:
             The result of the Snowflake SQL execution - returning a success message but not the created entity.
@@ -138,6 +141,11 @@ class RunDao(RunDaoBase):
                 f"Invalid source type: {source_type}. Choose from {SourceType.__members__.values()}"
             )
         source_info_dict["source_type"] = source_type
+
+        if dataset_version_id:
+            # Only sent when a version is actually pinned, so the payload of
+            # an unversioned run is unchanged.
+            source_info_dict["dataset_version_id"] = dataset_version_id
 
         req_payload["source_info"] = source_info_dict
 

--- a/src/connectors/snowflake/trulens/connectors/snowflake/snowflake_event_table_db.py
+++ b/src/connectors/snowflake/trulens/connectors/snowflake/snowflake_event_table_db.py
@@ -316,7 +316,19 @@ class SnowflakeEventTableDB(core_db.DB):
                 )
                 yield serial_utils.JSONized(app_defn)
 
+    def get_dataset(*args, **kwargs):
+        raise NotImplementedError()
+
     def get_datasets(*args, **kwargs):
+        raise NotImplementedError()
+
+    def get_dataset_version(*args, **kwargs):
+        raise NotImplementedError()
+
+    def get_dataset_version_items(*args, **kwargs):
+        raise NotImplementedError()
+
+    def get_dataset_versions(*args, **kwargs):
         raise NotImplementedError()
 
     def get_db_revision(*args, **kwargs):
@@ -353,6 +365,9 @@ class SnowflakeEventTableDB(core_db.DB):
         raise NotImplementedError()
 
     def insert_dataset(*args, **kwargs):
+        raise NotImplementedError()
+
+    def insert_dataset_version(*args, **kwargs):
         raise NotImplementedError()
 
     def insert_event(*args, **kwargs):

--- a/src/core/trulens/core/app.py
+++ b/src/core/trulens/core/app.py
@@ -1931,6 +1931,7 @@ you use the `%s` wrapper to make sure `%s` does get instrumented. `%s` method
                 label=run_config.label,
                 llm_judge_name=run_config.llm_judge_name,
                 mode=run_config.mode,
+                dataset_version_id=run_config.dataset_version_id,
             )
 
             return Run.from_metadata_df(

--- a/src/core/trulens/core/dao/default_run.py
+++ b/src/core/trulens/core/dao/default_run.py
@@ -58,6 +58,7 @@ class DefaultRunDao(RunDaoBase):
         label: Optional[str] = "",
         llm_judge_name: Optional[str] = "",
         mode: Optional[Mode] = Mode.APP_INVOCATION,
+        dataset_version_id: Optional[str] = None,
     ) -> pd.DataFrame:
         orm = self._db.orm
         now = time.time()
@@ -72,6 +73,8 @@ class DefaultRunDao(RunDaoBase):
             "column_spec": dataset_spec,
             "source_type": source_type,
         }
+        if dataset_version_id:
+            source_info["dataset_version_id"] = dataset_version_id
 
         with self._db.session.begin() as session:
             existing = (

--- a/src/core/trulens/core/dao/run.py
+++ b/src/core/trulens/core/dao/run.py
@@ -32,6 +32,7 @@ class RunDaoBase(abc.ABC):
         label: Optional[str] = "",
         llm_judge_name: Optional[str] = "",
         mode: Optional[Mode] = Mode.APP_INVOCATION,
+        dataset_version_id: Optional[str] = None,
     ) -> pd.DataFrame: ...
 
     @abc.abstractmethod

--- a/src/core/trulens/core/database/base.py
+++ b/src/core/trulens/core/database/base.py
@@ -652,11 +652,104 @@ class DB(serial_utils.SerialModel, abc.ABC, text_utils.WithIdentString):
         raise NotImplementedError()
 
     @abc.abstractmethod
+    def get_dataset(
+        self, dataset_name: str
+    ) -> Optional[dataset_schema.Dataset]:
+        """Get a dataset by name.
+
+        A dataset id hashes both the name and the metadata, so a name can map
+        to more than one row; the one with the lowest id is returned so the
+        choice is deterministic.
+
+        Args:
+            dataset_name: The name of the dataset.
+
+        Returns:
+            The dataset, or `None` if no dataset carries that name.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     def get_datasets(self) -> pd.DataFrame:
         """Get all datasets from the database.
 
         Returns:
             A dataframe with the datasets.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def insert_dataset_version(
+        self, dataset_version: dataset_schema.DatasetVersion
+    ) -> types_schema.DatasetVersionID:
+        """Publish an immutable dataset version and its items.
+
+        The version id is content-addressed, so publishing identical content
+        twice is idempotent and returns the id of the version that already
+        exists rather than updating it.
+
+        Args:
+            dataset_version: The version to publish, with its items loaded.
+
+        Returns:
+            The id of the published (or already existing) version.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_dataset_version(
+        self,
+        dataset_version_id: Optional[types_schema.DatasetVersionID] = None,
+        dataset_name: Optional[str] = None,
+        dataset_id: Optional[types_schema.DatasetID] = None,
+        load_items: bool = True,
+    ) -> Optional[dataset_schema.DatasetVersion]:
+        """Get one dataset version.
+
+        When `dataset_version_id` is given that exact snapshot is loaded.
+        Otherwise the latest version of the named dataset is resolved, falling
+        back to a version zero reconstructed from pre-versioning ground truth
+        rows when nothing has been published yet.
+
+        Args:
+            dataset_version_id: The exact version to load, if pinning one.
+            dataset_name: The dataset whose latest version to resolve.
+            dataset_id: The dataset whose latest version to resolve.
+            load_items: Whether to also load the version's items.
+
+        Returns:
+            The version, or `None` if it could not be resolved.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_dataset_versions(
+        self,
+        dataset_name: Optional[str] = None,
+        dataset_id: Optional[types_schema.DatasetID] = None,
+    ) -> pd.DataFrame:
+        """Get the published versions of a dataset, oldest first.
+
+        Args:
+            dataset_name: The dataset whose versions to list.
+            dataset_id: The dataset whose versions to list.
+
+        Returns:
+            A dataframe with one row per version.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_dataset_version_items(
+        self, dataset_version_id: types_schema.DatasetVersionID
+    ) -> List[dataset_schema.DatasetVersionItem]:
+        """Get the items of a published dataset version, in order.
+
+        Args:
+            dataset_version_id: The version whose items to load.
+
+        Returns:
+            The version's items.
         """
         raise NotImplementedError()
 

--- a/src/core/trulens/core/database/migrations/versions/13_add_dataset_version_tables.py
+++ b/src/core/trulens/core/database/migrations/versions/13_add_dataset_version_tables.py
@@ -1,0 +1,75 @@
+"""Add dataset version tables.
+
+Adds immutable, content-addressed dataset snapshots alongside the existing
+mutable `dataset` / `ground_truth` tables. Existing rows are left untouched;
+they are exposed as version zero by the compatibility loader in
+`trulens.core.database.sqlalchemy`.
+
+Revision ID: 13
+Revises: 12
+Create Date: 2026-08-21 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "13"
+down_revision = "12"
+branch_labels = None
+depends_on = None
+
+
+def upgrade(config) -> None:
+    prefix = config.get_main_option("trulens.table_prefix")
+
+    if prefix is None:
+        raise RuntimeError("trulens.table_prefix is not set")
+
+    op.create_table(
+        prefix + "dataset_version",
+        sa.Column("dataset_version_id", sa.VARCHAR(length=256), nullable=False),
+        sa.Column("dataset_id", sa.VARCHAR(length=256), nullable=False),
+        sa.Column(
+            "parent_dataset_version_id",
+            sa.VARCHAR(length=256),
+            nullable=True,
+        ),
+        sa.Column("version_index", sa.Integer(), nullable=False),
+        sa.Column("content_hash", sa.VARCHAR(length=256), nullable=False),
+        sa.Column("item_count", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.Float(), nullable=False),
+        sa.Column("dataset_version_json", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["dataset_id"], [prefix + "dataset.dataset_id"]
+        ),
+        sa.PrimaryKeyConstraint("dataset_version_id"),
+        sa.UniqueConstraint(
+            "dataset_id",
+            "version_index",
+            name=f"uq_{prefix}dataset_version_dataset_version_index",
+        ),
+    )
+    op.create_table(
+        prefix + "dataset_version_item",
+        sa.Column("dataset_version_id", sa.VARCHAR(length=256), nullable=False),
+        sa.Column("item_id", sa.VARCHAR(length=256), nullable=False),
+        sa.Column("item_index", sa.Integer(), nullable=False),
+        sa.Column("input_id", sa.VARCHAR(length=256), nullable=True),
+        sa.Column("dataset_version_item_json", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["dataset_version_id"],
+            [prefix + "dataset_version.dataset_version_id"],
+        ),
+        sa.PrimaryKeyConstraint("dataset_version_id", "item_id"),
+    )
+
+
+def downgrade(config) -> None:
+    prefix = config.get_main_option("trulens.table_prefix")
+
+    if prefix is None:
+        raise RuntimeError("trulens.table_prefix is not set")
+
+    op.drop_table(prefix + "dataset_version_item")
+    op.drop_table(prefix + "dataset_version")

--- a/src/core/trulens/core/database/orm.py
+++ b/src/core/trulens/core/database/orm.py
@@ -14,6 +14,7 @@ from sqlalchemy import Enum
 from sqlalchemy import Float
 from sqlalchemy import ForeignKey
 from sqlalchemy import Index
+from sqlalchemy import Integer
 from sqlalchemy import Text
 from sqlalchemy import UniqueConstraint
 from sqlalchemy import event
@@ -121,6 +122,8 @@ class ORM(abc.ABC, Generic[T]):
     FeedbackResult: Type[T]
     GroundTruth: Type[T]
     Dataset: Type[T]
+    DatasetVersion: Type[T]
+    DatasetVersionItem: Type[T]
     Event: Type[T]
     Run: Type[T]
 
@@ -406,6 +409,118 @@ def new_orm(base: Type[T], prefix: str = "trulens_") -> Type[ORM[T]]:
                 return cls(
                     dataset_id=obj.dataset_id,
                     dataset_json=obj.model_dump_json(redact_keys=redact_keys),
+                )
+
+        class DatasetVersion(base):
+            """ORM class for
+            [DatasetVersion][trulens.core.schema.dataset.DatasetVersion].
+
+            Rows in this table are immutable once written: a version id is a
+            hash of the version's contents, so any change to the contents is a
+            different row rather than an update to this one.
+            """
+
+            _table_base_name = "dataset_version"
+
+            dataset_version_id = Column(
+                TYPE_ID, nullable=False, primary_key=True
+            )
+            dataset_id = Column(
+                TYPE_ID,
+                ForeignKey(f"{prefix}dataset.dataset_id"),
+                nullable=False,
+            )
+            parent_dataset_version_id = Column(TYPE_ID, nullable=True)
+            version_index = Column(Integer, nullable=False)
+            content_hash = Column(TYPE_ID, nullable=False)
+            item_count = Column(Integer, nullable=False)
+            created_at = Column(TYPE_TIMESTAMP, nullable=False)
+            dataset_version_json = Column(TYPE_JSON, nullable=False)
+
+            @declared_attr.directive
+            def __table_args__(cls):
+                return (
+                    UniqueConstraint(
+                        "dataset_id",
+                        "version_index",
+                        name=f"uq_{cls.__tablename__}_dataset_version_index",
+                    ),
+                )
+
+            dataset = relationship(
+                "Dataset",
+                backref=backref(
+                    "dataset_versions",
+                    cascade="all,delete",
+                    order_by=version_index,
+                ),
+            )
+            # See NOTE(backref order_by).
+
+            @classmethod
+            def parse(
+                cls,
+                obj: dataset_schema.DatasetVersion,
+                redact_keys: bool = False,
+            ) -> ORM.DatasetVersion:
+                return cls(
+                    dataset_version_id=obj.dataset_version_id,
+                    dataset_id=obj.dataset_id,
+                    parent_dataset_version_id=obj.parent_dataset_version_id,
+                    version_index=obj.version_index,
+                    content_hash=obj.content_hash,
+                    item_count=obj.item_count,
+                    created_at=obj.created_at,
+                    dataset_version_json=obj.metadata_json(),
+                )
+
+        class DatasetVersionItem(base):
+            """ORM class for
+            [DatasetVersionItem][trulens.core.schema.dataset.DatasetVersionItem].
+
+            An item id is content-addressed and therefore repeats across the
+            versions that contain the same example; the primary key is the
+            pair of version and item.
+            """
+
+            _table_base_name = "dataset_version_item"
+
+            dataset_version_id = Column(
+                TYPE_ID,
+                ForeignKey(f"{prefix}dataset_version.dataset_version_id"),
+                nullable=False,
+                primary_key=True,
+            )
+            item_id = Column(TYPE_ID, nullable=False, primary_key=True)
+            item_index = Column(Integer, nullable=False)
+            input_id = Column(TYPE_ID, nullable=True)
+            dataset_version_item_json = Column(TYPE_JSON, nullable=False)
+
+            dataset_version = relationship(
+                "DatasetVersion",
+                backref=backref(
+                    "items",
+                    cascade="all,delete",
+                    order_by=item_index,
+                ),
+            )
+            # See NOTE(backref order_by).
+
+            @classmethod
+            def parse(
+                cls,
+                obj: dataset_schema.DatasetVersionItem,
+                item_index: int,
+                redact_keys: bool = False,
+            ) -> ORM.DatasetVersionItem:
+                return cls(
+                    dataset_version_id=obj.dataset_version_id,
+                    item_id=obj.item_id,
+                    item_index=item_index,
+                    input_id=obj.input_id,
+                    dataset_version_item_json=obj.model_dump_json(
+                        redact_keys=redact_keys
+                    ),
                 )
 
         class Run(base):

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -2165,6 +2165,23 @@ class SQLAlchemyDB(core_db.DB):
 
             return _dataset.dataset_id
 
+    def get_dataset(
+        self, dataset_name: str
+    ) -> Optional[dataset_schema.Dataset]:
+        """See [DB.get_dataset][trulens.core.database.base.DB.get_dataset]."""
+
+        with self.session.begin() as session:
+            rows = self._dataset_rows_by_name(session, dataset_name)
+            if not rows:
+                return None
+
+            payload = json.loads(rows[0].dataset_json)
+            return dataset_schema.Dataset(
+                name=payload.get("name", dataset_name),
+                dataset_id=rows[0].dataset_id,
+                meta=payload.get("meta"),
+            )
+
     def get_datasets(self) -> pd.DataFrame:
         """See [DB.get_datasets][trulens.core.database.base.DB.get_datasets]."""
 
@@ -2185,6 +2202,369 @@ class SQLAlchemyDB(core_db.DB):
                 data=[_row(ds) for ds in results],
                 columns=["dataset_id", "name", "meta"],
             )
+
+    def _dataset_rows_by_name(
+        self, session, dataset_name: str
+    ) -> List["db_orm.Dataset"]:
+        """Every dataset row carrying the given name, ordered by id.
+
+        A dataset id hashes the name *and* the metadata, so the same name can
+        legitimately map to more than one row. Ordering by id makes the choice
+        of primary row deterministic.
+        """
+
+        rows = [
+            row
+            for row in session.query(self.orm.Dataset).all()
+            if _dataset_name_of_row(row) == dataset_name
+        ]
+        return sorted(rows, key=lambda row: row.dataset_id)
+
+    def _resolve_dataset_row(
+        self,
+        session,
+        dataset_name: Optional[str] = None,
+        dataset_id: Optional[types_schema.DatasetID] = None,
+    ) -> Optional["db_orm.Dataset"]:
+        """Resolve the single dataset row addressed by a name or an id.
+
+        Versions always hang off one dataset row. When a name maps to several
+        rows the primary one — the lowest id — owns them, so that resolving by
+        name and resolving by id cannot disagree about which rows version zero
+        is reconstructed from.
+        """
+
+        if dataset_id is not None:
+            return (
+                session.query(self.orm.Dataset)
+                .filter_by(dataset_id=dataset_id)
+                .first()
+            )
+
+        if dataset_name is None:
+            raise ValueError(
+                "Either `dataset_name` or `dataset_id` must be provided."
+            )
+
+        rows = self._dataset_rows_by_name(session, dataset_name)
+        return rows[0] if rows else None
+
+    def _synthesize_version_zero(
+        self,
+        session,
+        dataset_row: Optional["db_orm.Dataset"],
+    ) -> Optional[dataset_schema.DatasetVersion]:
+        """Reconstruct version zero from pre-versioning ground truth rows.
+
+        This is the compatibility loader: the original ground truth payloads
+        are read but never rewritten. Rows are ordered by `ground_truth_id` so
+        the reconstruction — and therefore the content-addressed version id —
+        is deterministic.
+
+        Returns:
+            The reconstructed version, or `None` when the dataset has no
+            ground truth rows to reconstruct from.
+        """
+
+        if dataset_row is None:
+            return None
+
+        items = []
+        ground_truth_rows = (
+            session.query(self.orm.GroundTruth)
+            .filter_by(dataset_id=dataset_row.dataset_id)
+            .order_by(self.orm.GroundTruth.ground_truth_id)
+            .all()
+        )
+        for ground_truth_row in ground_truth_rows:
+            payload = json.loads(ground_truth_row.ground_truth_json)
+            items.append(
+                dataset_schema.DatasetVersionItem(
+                    input=payload.get("query"),
+                    input_id=payload.get("query_id"),
+                    expected_response=payload.get("expected_response"),
+                    expected_contexts=payload.get("expected_chunks"),
+                    meta=payload.get("meta"),
+                )
+            )
+
+        if not items:
+            return None
+
+        source_meta = {"origin": dataset_schema.VERSION_ZERO_ORIGIN}
+        dataset_name = _dataset_name_of_row(dataset_row)
+        if dataset_name is not None:
+            source_meta["dataset_name"] = dataset_name
+
+        return dataset_schema.DatasetVersion(
+            dataset_id=dataset_row.dataset_id,
+            items=items,
+            description=(
+                "Version zero, reconstructed from ground truth rows that "
+                "predate dataset versioning."
+            ),
+            source_meta=source_meta,
+            created_at=dataset_schema.VERSION_ZERO_CREATED_AT,
+            version_index=0,
+        )
+
+    def insert_dataset_version(
+        self, dataset_version: dataset_schema.DatasetVersion
+    ) -> types_schema.DatasetVersionID:
+        """See [DB.insert_dataset_version][trulens.core.database.base.DB.insert_dataset_version]."""
+
+        # TODO: thread safety. The unique constraint on
+        # (dataset_id, version_index) turns a lost race into an error rather
+        # than a corrupted history.
+        with self.session.begin() as session:
+            if (
+                session.query(self.orm.DatasetVersion)
+                .filter_by(
+                    dataset_version_id=dataset_version.dataset_version_id
+                )
+                .first()
+            ):
+                # Versions are immutable: an identical publish is a no-op.
+                logger.info(
+                    f"{text_utils.UNICODE_CHECK} dataset version "
+                    f"{dataset_version.dataset_version_id} already exists"
+                )
+                return dataset_version.dataset_version_id
+
+            latest = (
+                session.query(self.orm.DatasetVersion)
+                .filter_by(dataset_id=dataset_version.dataset_id)
+                .order_by(self.orm.DatasetVersion.version_index.desc())
+                .first()
+            )
+
+            if latest is None:
+                # First publish for this dataset: materialize the legacy ground
+                # truth rows as version zero so they stay loadable afterwards.
+                version_zero = self._synthesize_version_zero(
+                    session,
+                    self._resolve_dataset_row(
+                        session, dataset_id=dataset_version.dataset_id
+                    ),
+                )
+                if version_zero is not None:
+                    self._write_dataset_version(session, version_zero, 0)
+                    if (
+                        version_zero.dataset_version_id
+                        == dataset_version.dataset_version_id
+                    ):
+                        # The publish is identical to version zero.
+                        return version_zero.dataset_version_id
+                    latest = version_zero
+
+            if latest is not None:
+                version_index = latest.version_index + 1
+                if dataset_version.parent_dataset_version_id is None:
+                    dataset_version.parent_dataset_version_id = (
+                        latest.dataset_version_id
+                    )
+            else:
+                version_index = 0
+
+            self._write_dataset_version(session, dataset_version, version_index)
+
+            logger.info(
+                f"{text_utils.UNICODE_CHECK} added dataset version "
+                f"{dataset_version.dataset_version_id} "
+                f"({dataset_version.item_count} item(s))"
+            )
+
+            return dataset_version.dataset_version_id
+
+    def _write_dataset_version(
+        self,
+        session,
+        dataset_version: dataset_schema.DatasetVersion,
+        version_index: int,
+    ) -> None:
+        """Write a version and its items inside an open transaction."""
+
+        dataset_version.version_index = version_index
+
+        session.add(
+            self.orm.DatasetVersion.parse(
+                dataset_version, redact_keys=self.redact_keys
+            )
+        )
+        session.add_all([
+            self.orm.DatasetVersionItem.parse(
+                item, item_index=index, redact_keys=self.redact_keys
+            )
+            for index, item in enumerate(dataset_version.items)
+        ])
+
+    def get_dataset_version(
+        self,
+        dataset_version_id: Optional[types_schema.DatasetVersionID] = None,
+        dataset_name: Optional[str] = None,
+        dataset_id: Optional[types_schema.DatasetID] = None,
+        load_items: bool = True,
+    ) -> Optional[dataset_schema.DatasetVersion]:
+        """See [DB.get_dataset_version][trulens.core.database.base.DB.get_dataset_version]."""
+
+        with self.session.begin() as session:
+            if dataset_version_id is not None:
+                row = (
+                    session.query(self.orm.DatasetVersion)
+                    .filter_by(dataset_version_id=dataset_version_id)
+                    .first()
+                )
+                if row is None:
+                    return None
+                return self._load_dataset_version(session, row, load_items)
+
+            dataset_row = self._resolve_dataset_row(
+                session, dataset_name=dataset_name, dataset_id=dataset_id
+            )
+            if dataset_row is None:
+                return None
+
+            row = (
+                session.query(self.orm.DatasetVersion)
+                .filter_by(dataset_id=dataset_row.dataset_id)
+                .order_by(self.orm.DatasetVersion.version_index.desc())
+                .first()
+            )
+            if row is not None:
+                return self._load_dataset_version(session, row, load_items)
+
+            # Nothing published yet: fall back to the compatibility loader.
+            return self._synthesize_version_zero(session, dataset_row)
+
+    def get_dataset_versions(
+        self,
+        dataset_name: Optional[str] = None,
+        dataset_id: Optional[types_schema.DatasetID] = None,
+    ) -> pd.DataFrame:
+        """See [DB.get_dataset_versions][trulens.core.database.base.DB.get_dataset_versions]."""
+
+        columns = [
+            "dataset_version_id",
+            "dataset_id",
+            "version_index",
+            "parent_dataset_version_id",
+            "description",
+            "item_count",
+            "content_hash",
+            "created_at",
+            "source_meta",
+        ]
+
+        with self.session.begin() as session:
+            dataset_row = self._resolve_dataset_row(
+                session, dataset_name=dataset_name, dataset_id=dataset_id
+            )
+            if dataset_row is None:
+                return pd.DataFrame(columns=columns)
+
+            rows = (
+                session.query(self.orm.DatasetVersion)
+                .filter_by(dataset_id=dataset_row.dataset_id)
+                .order_by(self.orm.DatasetVersion.version_index)
+                .all()
+            )
+
+            if not rows:
+                version_zero = self._synthesize_version_zero(
+                    session, dataset_row
+                )
+                if version_zero is None:
+                    return pd.DataFrame(columns=columns)
+                versions = [version_zero]
+            else:
+                versions = [
+                    self._load_dataset_version(session, row, load_items=False)
+                    for row in rows
+                ]
+
+            return pd.DataFrame(
+                data=(
+                    (
+                        version.dataset_version_id,
+                        version.dataset_id,
+                        version.version_index,
+                        version.parent_dataset_version_id,
+                        version.description,
+                        version.item_count,
+                        version.content_hash,
+                        version.created_at,
+                        version.source_meta,
+                    )
+                    for version in versions
+                ),
+                columns=columns,
+            )
+
+    def get_dataset_version_items(
+        self, dataset_version_id: types_schema.DatasetVersionID
+    ) -> List[dataset_schema.DatasetVersionItem]:
+        """See [DB.get_dataset_version_items][trulens.core.database.base.DB.get_dataset_version_items]."""
+
+        with self.session.begin() as session:
+            return self._load_dataset_version_items(session, dataset_version_id)
+
+    def _load_dataset_version_items(
+        self, session, dataset_version_id: types_schema.DatasetVersionID
+    ) -> List[dataset_schema.DatasetVersionItem]:
+        """Load a version's items, in the order they were published."""
+
+        rows = (
+            session.query(self.orm.DatasetVersionItem)
+            .filter_by(dataset_version_id=dataset_version_id)
+            .order_by(self.orm.DatasetVersionItem.item_index)
+            .all()
+        )
+
+        items = []
+        for row in rows:
+            payload = json.loads(row.dataset_version_item_json)
+            items.append(
+                dataset_schema.DatasetVersionItem(
+                    item_id=row.item_id,
+                    dataset_version_id=row.dataset_version_id,
+                    input=payload.get("input"),
+                    input_id=payload.get("input_id"),
+                    expected_response=payload.get("expected_response"),
+                    expected_contexts=payload.get("expected_contexts"),
+                    meta=payload.get("meta"),
+                    splits=payload.get("splits"),
+                )
+            )
+        return items
+
+    def _load_dataset_version(
+        self,
+        session,
+        row: "db_orm.DatasetVersion",
+        load_items: bool = True,
+    ) -> dataset_schema.DatasetVersion:
+        """Rebuild a version from its row, optionally with its items."""
+
+        metadata = json.loads(row.dataset_version_json)
+
+        items = (
+            self._load_dataset_version_items(session, row.dataset_version_id)
+            if load_items
+            else []
+        )
+
+        return dataset_schema.DatasetVersion(
+            dataset_id=row.dataset_id,
+            items=items,
+            parent_dataset_version_id=row.parent_dataset_version_id,
+            description=metadata.get("description"),
+            source_meta=metadata.get("source_meta"),
+            created_at=row.created_at,
+            dataset_version_id=row.dataset_version_id,
+            content_hash=row.content_hash,
+            item_count=row.item_count,
+            version_index=row.version_index,
+        )
 
     def insert_event(self, event: Event) -> types_schema.EventID:
         """See [DB.insert_event][trulens.core.database.base.DB.insert_event]."""
@@ -2363,6 +2743,16 @@ def _extract_tokens_and_cost(cost_json: pd.Series) -> pd.DataFrame:
         data=(_extract(c) for c in cost_json),
         columns=["total_tokens", "total_cost", "cost_currency"],
     )
+
+
+def _dataset_name_of_row(row: "db_orm.Dataset") -> Optional[str]:
+    """Read a dataset's name out of its json payload."""
+
+    try:
+        return json.loads(row.dataset_json).get("name")
+    except (json.JSONDecodeError, TypeError, AttributeError):
+        logger.warning("Could not read the name of dataset %s.", row.dataset_id)
+        return None
 
 
 def _extract_ground_truths(

--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -27,6 +27,7 @@ import pydantic
 from pydantic import Field
 import sqlalchemy as sa
 from sqlalchemy import Table
+from sqlalchemy import exc as sa_exc
 from sqlalchemy import inspect
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import sessionmaker
@@ -55,6 +56,14 @@ from trulens.otel.semconv.trace import ResourceAttributes
 from trulens.otel.semconv.trace import SpanAttributes
 
 logger = logging.getLogger(__name__)
+
+_DATASET_VERSION_INSERT_ATTEMPTS = 5
+"""How many times a publish re-reads the latest version index before giving up.
+
+Each retry only loses a race to another publisher, so the bound exists to stop
+a pathological workload from spinning rather than because a legitimate publish
+is expected to need it.
+"""
 
 
 # Imported for backward compatibility. The Snowflake-specific Alembic impl is
@@ -2236,7 +2245,8 @@ class SQLAlchemyDB(core_db.DB):
 
         if dataset_id is not None:
             return (
-                session.query(self.orm.Dataset)
+                session
+                .query(self.orm.Dataset)
                 .filter_by(dataset_id=dataset_id)
                 .first()
             )
@@ -2271,7 +2281,8 @@ class SQLAlchemyDB(core_db.DB):
 
         items = []
         ground_truth_rows = (
-            session.query(self.orm.GroundTruth)
+            session
+            .query(self.orm.GroundTruth)
             .filter_by(dataset_id=dataset_row.dataset_id)
             .order_by(self.orm.GroundTruth.ground_truth_id)
             .all()
@@ -2311,14 +2322,59 @@ class SQLAlchemyDB(core_db.DB):
     def insert_dataset_version(
         self, dataset_version: dataset_schema.DatasetVersion
     ) -> types_schema.DatasetVersionID:
-        """See [DB.insert_dataset_version][trulens.core.database.base.DB.insert_dataset_version]."""
+        """See [DB.insert_dataset_version][trulens.core.database.base.DB.insert_dataset_version].
 
-        # TODO: thread safety. The unique constraint on
-        # (dataset_id, version_index) turns a lost race into an error rather
-        # than a corrupted history.
+        Choosing the next `version_index` is a read-increment-write, so two
+        concurrent publishes can read the same latest index and derive the same
+        next one. The unique constraint on `(dataset_id, version_index)` stops
+        that from corrupting the history, and the loop below turns the loser of
+        the race into a retry that re-reads the now-committed index rather than
+        an error the caller has to handle.
+
+        Retrying rather than locking keeps this portable: SQLite has no
+        `SELECT ... FOR UPDATE`, so a row lock would only serialize the
+        databases that support it.
+        """
+
+        # Both fields are derived from whatever the latest version turns out to
+        # be, so each attempt has to start from the caller's original values.
+        original_parent_id = dataset_version.parent_dataset_version_id
+        original_version_index = dataset_version.version_index
+
+        for attempt in range(_DATASET_VERSION_INSERT_ATTEMPTS):
+            dataset_version.parent_dataset_version_id = original_parent_id
+            dataset_version.version_index = original_version_index
+
+            try:
+                return self._insert_dataset_version_once(dataset_version)
+            except sa_exc.IntegrityError:
+                if attempt == _DATASET_VERSION_INSERT_ATTEMPTS - 1:
+                    raise
+
+                logger.info(
+                    "Another publish took the next version index for dataset "
+                    "%s; re-reading and retrying (attempt %d of %d).",
+                    dataset_version.dataset_id,
+                    attempt + 2,
+                    _DATASET_VERSION_INSERT_ATTEMPTS,
+                )
+
+        raise AssertionError("unreachable")  # pragma: no cover
+
+    def _insert_dataset_version_once(
+        self, dataset_version: dataset_schema.DatasetVersion
+    ) -> types_schema.DatasetVersionID:
+        """One attempt at publishing a version.
+
+        Raises:
+            sqlalchemy.exc.IntegrityError: If another publish committed the
+                same `version_index` first.
+        """
+
         with self.session.begin() as session:
             if (
-                session.query(self.orm.DatasetVersion)
+                session
+                .query(self.orm.DatasetVersion)
                 .filter_by(
                     dataset_version_id=dataset_version.dataset_version_id
                 )
@@ -2332,7 +2388,8 @@ class SQLAlchemyDB(core_db.DB):
                 return dataset_version.dataset_version_id
 
             latest = (
-                session.query(self.orm.DatasetVersion)
+                session
+                .query(self.orm.DatasetVersion)
                 .filter_by(dataset_id=dataset_version.dataset_id)
                 .order_by(self.orm.DatasetVersion.version_index.desc())
                 .first()
@@ -2410,7 +2467,8 @@ class SQLAlchemyDB(core_db.DB):
         with self.session.begin() as session:
             if dataset_version_id is not None:
                 row = (
-                    session.query(self.orm.DatasetVersion)
+                    session
+                    .query(self.orm.DatasetVersion)
                     .filter_by(dataset_version_id=dataset_version_id)
                     .first()
                 )
@@ -2425,7 +2483,8 @@ class SQLAlchemyDB(core_db.DB):
                 return None
 
             row = (
-                session.query(self.orm.DatasetVersion)
+                session
+                .query(self.orm.DatasetVersion)
                 .filter_by(dataset_id=dataset_row.dataset_id)
                 .order_by(self.orm.DatasetVersion.version_index.desc())
                 .first()
@@ -2463,7 +2522,8 @@ class SQLAlchemyDB(core_db.DB):
                 return pd.DataFrame(columns=columns)
 
             rows = (
-                session.query(self.orm.DatasetVersion)
+                session
+                .query(self.orm.DatasetVersion)
                 .filter_by(dataset_id=dataset_row.dataset_id)
                 .order_by(self.orm.DatasetVersion.version_index)
                 .all()
@@ -2514,7 +2574,8 @@ class SQLAlchemyDB(core_db.DB):
         """Load a version's items, in the order they were published."""
 
         rows = (
-            session.query(self.orm.DatasetVersionItem)
+            session
+            .query(self.orm.DatasetVersionItem)
             .filter_by(dataset_version_id=dataset_version_id)
             .order_by(self.orm.DatasetVersionItem.item_index)
             .all()

--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -21,6 +21,7 @@ from trulens.core.dao.run import RunDaoBase
 from trulens.core.enums import Mode
 from trulens.core.feedback.custom_metric import MetricConfig
 from trulens.core.metric import metric as metric_module
+from trulens.core.schema import dataset as dataset_schema
 from trulens.core.utils.json import obj_id_of_obj
 from trulens.otel.semconv.trace import SpanAttributes
 
@@ -172,11 +173,17 @@ class RunDiff:
             ``run_a.compare(run_b)``).
         run_b_name: Name of the candidate run.
         metrics: Per-metric comparison results keyed by metric name.
+        dataset_version_id_a: The immutable dataset version the baseline run
+            was pinned to, if any.
+        dataset_version_id_b: The immutable dataset version the candidate run
+            was pinned to, if any.
     """
 
     run_a_name: str
     run_b_name: str
     metrics: Dict[str, MetricDiff] = dataclasses.field(default_factory=dict)
+    dataset_version_id_a: Optional[str] = None
+    dataset_version_id_b: Optional[str] = None
 
     def summary(self) -> pd.DataFrame:
         """Return a one-row-per-metric summary DataFrame."""
@@ -193,6 +200,25 @@ class RunDiff:
                 "n_items": md.n_items,
             })
         return pd.DataFrame(rows)
+
+    def provenance(self) -> pd.DataFrame:
+        """Return the dataset version each side of the comparison read.
+
+        A comparison is only meaningful over the same test set, so this
+        reports which immutable snapshot each run was pinned to. `None` means
+        the run read a source that was not pinned to a version.
+        """
+
+        return pd.DataFrame([
+            {
+                "run": self.run_a_name,
+                "dataset_version_id": self.dataset_version_id_a,
+            },
+            {
+                "run": self.run_b_name,
+                "dataset_version_id": self.dataset_version_id_b,
+            },
+        ])
 
     def items_df(self, metric_name: str) -> pd.DataFrame:
         """Return per-item details for a given metric as a DataFrame."""
@@ -287,6 +313,11 @@ class RunConfig(BaseModel):
     dataset_spec: Dict[str, str] = Field(
         default=...,
         description="Mandatory column name mapping from reserved dataset fields to column names in user's table.",
+    )
+
+    dataset_version_id: Optional[str] = Field(
+        default=None,
+        description="Optional id of an immutable dataset version to pin. When set, the run reads that exact snapshot instead of the current contents of the source.",
     )
 
     description: Optional[str] = Field(
@@ -427,6 +458,10 @@ class Run(BaseModel):
             default="DATAFRAME",
             description="Type of the source (e.g. 'DATAFRAME').",
         )
+        dataset_version_id: Optional[str] = Field(
+            default=None,
+            description="Id of the immutable dataset version this run read, if one was pinned.",
+        )
 
     source_info: SourceInfo = Field(
         default=...,
@@ -557,6 +592,46 @@ class Run(BaseModel):
             RunStatus.FAILED,
             RunStatus.UNKNOWN,
         ]
+
+    def _fetch_dataset_version_input_df(self) -> pd.DataFrame:
+        """Load the pinned dataset version as this run's input dataframe.
+
+        The frame is built with the column names this run's `column_spec`
+        already refers to, so the rest of the invocation path does not need to
+        know whether the input came from a table or a pinned snapshot.
+
+        Raises:
+            ValueError: If the pinned version cannot be loaded.
+        """
+
+        dataset_version_id = self.source_info.dataset_version_id
+
+        version = self.tru_session.get_dataset_version(
+            dataset_version_id=dataset_version_id
+        )
+        if version is None:
+            raise ValueError(
+                f"Dataset version {dataset_version_id} not found. A run that "
+                "pins a version can only be started once that version is "
+                "readable from the connected database."
+            )
+
+        spec = dataset_schema.normalize_column_spec(
+            self.source_info.column_spec
+        )
+
+        readers = {
+            "input": lambda item: item.input,
+            "input_id": lambda item: item.input_id,
+            "expected_response": lambda item: item.expected_response,
+            "expected_contexts": lambda item: item.expected_contexts,
+            "metadata": lambda item: item.meta,
+        }
+
+        return pd.DataFrame({
+            column_name: [readers[field](item) for item in version.items]
+            for field, column_name in spec.items()
+        })
 
     def _warn_if_snowflake_parallel(self, value: int):
         if value > 1:
@@ -809,10 +884,17 @@ class Run(BaseModel):
             return f"Cannot start a new invocation when in run status: {current_status}. Valid statuses are: {RunStatus.CREATED}, {RunStatus.INVOCATION_PARTIALLY_COMPLETED}, or {RunStatus.FAILED}."
 
         if input_df is None:
-            logger.info(
-                "No input dataframe provided. Fetching input data from source."
-            )
-            input_df = self.run_dao.fetch_source_data(self.source_info.name)
+            if self.source_info.dataset_version_id:
+                logger.info(
+                    "No input dataframe provided. Loading pinned dataset "
+                    f"version {self.source_info.dataset_version_id}."
+                )
+                input_df = self._fetch_dataset_version_input_df()
+            else:
+                logger.info(
+                    "No input dataframe provided. Fetching input data from source."
+                )
+                input_df = self.run_dao.fetch_source_data(self.source_info.name)
 
         dataset_spec = self.source_info.column_spec
 
@@ -1708,6 +1790,17 @@ _NON_METRIC_COLS = {"record_id", "input", "output", "latency"}
 _DIRECTION_WARNED: set = set()
 
 
+def _dataset_version_id_of(run: Any) -> Optional[str]:
+    """Read the dataset version a run was pinned to, if any.
+
+    Comparison accepts anything run-shaped, so a run object that carries no
+    source info simply has no pinned version rather than being an error.
+    """
+
+    source_info = getattr(run, "source_info", None)
+    return getattr(source_info, "dataset_version_id", None)
+
+
 def _lookup_metric_directions(tru_session: Any) -> Dict[str, bool]:
     """Derive ``{metric_name: higher_is_better}`` from stored feedback defs.
 
@@ -1945,8 +2038,26 @@ def compare_runs(
             items=items,
         )
 
+    dataset_version_id_a = _dataset_version_id_of(run_a)
+    dataset_version_id_b = _dataset_version_id_of(run_b)
+
+    if (
+        dataset_version_id_a is not None
+        and dataset_version_id_b is not None
+        and dataset_version_id_a != dataset_version_id_b
+    ):
+        logger.warning(
+            "The two runs were pinned to different dataset versions (%s vs "
+            "%s), so metric deltas mix changes in the app with changes in "
+            "the test set.",
+            dataset_version_id_a,
+            dataset_version_id_b,
+        )
+
     return RunDiff(
         run_a_name=run_a.run_name,
         run_b_name=run_b.run_name,
         metrics=metrics_result,
+        dataset_version_id_a=dataset_version_id_a,
+        dataset_version_id_b=dataset_version_id_b,
     )

--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -2047,9 +2047,8 @@ def compare_runs(
         and dataset_version_id_a != dataset_version_id_b
     ):
         logger.warning(
-            "The two runs were pinned to different dataset versions (%s vs "
-            "%s), so metric deltas mix changes in the app with changes in "
-            "the test set.",
+            "Runs pinned to different dataset versions (%s vs %s); metric "
+            "deltas include both app changes and test-set changes.",
             dataset_version_id_a,
             dataset_version_id_b,
         )

--- a/src/core/trulens/core/schema/dataset.py
+++ b/src/core/trulens/core/schema/dataset.py
@@ -2,14 +2,164 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
-from typing import Hashable, Optional
+from typing import Any, Dict, Hashable, List, Optional, Sequence
 
+import pydantic
 from trulens.core.schema import types as types_schema
 from trulens.core.utils import json as json_utils
 from trulens.core.utils import serial as serial_utils
 
 logger = logging.getLogger(__name__)
+
+DATASET_VERSION_ID_PREFIX = "dataset_version_hash_"
+"""Prefix given to every content-addressed dataset version id."""
+
+DATASET_VERSION_ITEM_ID_PREFIX = "dataset_version_item_hash_"
+"""Prefix given to every content-addressed dataset version item id."""
+
+VERSION_ZERO_CREATED_AT = 0.0
+"""Creation timestamp reported for version zero.
+
+Version zero is reconstructed from
+[GroundTruth][trulens.core.schema.groundtruth.GroundTruth] rows that predate
+versioning and therefore carry no trustworthy creation time. A fixed value
+keeps the reconstruction deterministic.
+"""
+
+VERSION_ZERO_ORIGIN = "ground_truth_compatibility"
+"""Value of the `origin` key in version zero's source metadata."""
+
+
+def _is_missing(value: Any) -> bool:
+    """Whether a value should be normalized away to `None`.
+
+    Covers `None` as well as the NaN floats that pandas produces for empty
+    cells, which would otherwise make otherwise-identical examples hash
+    differently.
+    """
+
+    if value is None:
+        return True
+    # NaN is the only value that is not equal to itself.
+    return isinstance(value, float) and value != value
+
+
+def _normalize_content(value: Any) -> Any:
+    """Normalize example content so cosmetic differences do not change ids.
+
+    Strings are stripped, missing values collapse to `None`, and containers
+    are normalized element-wise while preserving their order.
+    """
+
+    if _is_missing(value):
+        return None
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, (list, tuple)):
+        return [_normalize_content(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _normalize_content(v) for k, v in value.items()}
+    return value
+
+
+def _canonical_json(value: Any) -> str:
+    """Serialize a value so equal content always yields equal bytes.
+
+    Dictionary keys are sorted but list order is preserved, which is what
+    makes a version id depend on the *order* of its items.
+    """
+
+    return json.dumps(
+        value,
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        default=str,
+    )
+
+
+def _content_hash(value: Any) -> str:
+    """Hash a json-able structure into a hex digest."""
+
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+COLUMN_SPEC_FIELDS = (
+    "input",
+    "input_id",
+    "expected_response",
+    "expected_contexts",
+    "metadata",
+)
+"""Canonical column specification keys understood by dataset versions."""
+
+COLUMN_SPEC_ALIASES = {
+    "query": "input",
+    "record_root.input": "input",
+    "query_id": "input_id",
+    "ground_truth_output": "expected_response",
+    "record_root.ground_truth_output": "expected_response",
+    "expected_chunks": "expected_contexts",
+    "meta": "metadata",
+}
+"""Accepted spellings for the canonical column specification keys.
+
+These cover both the legacy
+[GroundTruth][trulens.core.schema.groundtruth.GroundTruth] field names and the
+reserved `dataset_spec` keys used by
+[RunConfig][trulens.core.run.RunConfig], so the same mapping can be handed to
+both APIs.
+"""
+
+
+def normalize_column_spec(column_spec: Dict[str, str]) -> Dict[str, str]:
+    """Resolve a user column specification to canonical item fields.
+
+    Keys are matched case-insensitively and through
+    [COLUMN_SPEC_ALIASES][trulens.core.schema.dataset.COLUMN_SPEC_ALIASES].
+    Keys that do not name a dataset version item field are dropped, which lets
+    a `RunConfig.dataset_spec` carrying extra span attributes be reused as-is.
+
+    Args:
+        column_spec: Mapping from a field name to a dataframe column name.
+
+    Returns:
+        A mapping keyed by
+        [COLUMN_SPEC_FIELDS][trulens.core.schema.dataset.COLUMN_SPEC_FIELDS].
+
+    Raises:
+        ValueError: If no `input` column can be resolved.
+    """
+
+    normalized: Dict[str, str] = {}
+    ignored = []
+
+    for key, value in (column_spec or {}).items():
+        lowered = str(key).lower()
+        field = COLUMN_SPEC_ALIASES.get(lowered, lowered)
+        if field in COLUMN_SPEC_FIELDS:
+            normalized[field] = value
+        else:
+            ignored.append(key)
+
+    if ignored:
+        logger.debug(
+            "Ignoring column spec entries that do not map to dataset version "
+            "item fields: %s",
+            ", ".join(sorted(str(k) for k in ignored)),
+        )
+
+    if "input" not in normalized:
+        raise ValueError(
+            "The column spec must map an `input` column. Supported keys are: "
+            + ", ".join(COLUMN_SPEC_FIELDS)
+            + "."
+        )
+
+    return normalized
 
 
 class Dataset(serial_utils.SerialModel, Hashable):
@@ -48,5 +198,301 @@ class Dataset(serial_utils.SerialModel, Hashable):
         return hash(self.dataset_id)
 
 
+class DatasetVersionItem(serial_utils.SerialModel, Hashable):
+    """A single example belonging to an immutable dataset version.
+
+    The `item_id` is content-addressed from the normalized example content
+    (`input`, `expected_response`, `expected_contexts`) together with the
+    optional caller-supplied `input_id`. `meta` and `splits` are properties of
+    the item *within a version* and deliberately do not take part in item
+    identity, so annotating an example does not make membership comparison
+    report it as removed and re-added.
+    """
+
+    item_id: types_schema.DatasetVersionItemID  # str
+    """The content-addressed identifier for this example."""
+
+    dataset_version_id: Optional[types_schema.DatasetVersionID] = None
+    """The version this item belongs to.
+
+    `None` until the item is attached to a published version."""
+
+    input_id: Optional[str] = None
+    """Caller-supplied stable identifier for the example, if any.
+
+    When given it participates in `item_id`, which lets two examples with
+    identical content stay distinct."""
+
+    input: Optional[str] = None
+    """The query / input of the example."""
+
+    expected_response: Optional[str] = None
+    """The expected response for the input."""
+
+    expected_contexts: Optional[List[Any]] = None
+    """The expected retrieval contexts for the input."""
+
+    meta: types_schema.Metadata = pydantic.Field(default_factory=dict)
+    """Metadata for the example within this version."""
+
+    splits: List[str] = pydantic.Field(default_factory=list)
+    """Names of the splits this example belongs to within this version."""
+
+    def __init__(
+        self,
+        input: Optional[str] = None,
+        input_id: Optional[str] = None,
+        expected_response: Optional[str] = None,
+        expected_contexts: Optional[Sequence[Any]] = None,
+        meta: Optional[types_schema.Metadata] = None,
+        splits: Optional[Sequence[str]] = None,
+        item_id: Optional[types_schema.DatasetVersionItemID] = None,
+        dataset_version_id: Optional[types_schema.DatasetVersionID] = None,
+        **kwargs,
+    ):
+        normalized_contexts = _normalize_content(expected_contexts)
+
+        kwargs["input"] = _normalize_content(input)
+        kwargs["input_id"] = _normalize_content(input_id)
+        kwargs["expected_response"] = _normalize_content(expected_response)
+        kwargs["expected_contexts"] = normalized_contexts
+        kwargs["meta"] = _normalize_content(meta) if meta is not None else {}
+        kwargs["splits"] = sorted({str(s) for s in (splits or [])})
+        kwargs["dataset_version_id"] = dataset_version_id
+
+        super().__init__(item_id="temporary", **kwargs)  # updated below
+
+        self.item_id = item_id if item_id is not None else self.compute_id()
+
+    def compute_id(self) -> types_schema.DatasetVersionItemID:
+        """Compute the content-addressed id for this example."""
+
+        return DATASET_VERSION_ITEM_ID_PREFIX + _content_hash({
+            "input": self.input,
+            "input_id": self.input_id,
+            "expected_response": self.expected_response,
+            "expected_contexts": self.expected_contexts,
+        })
+
+    def identity_digest(self) -> Dict[str, Any]:
+        """The contribution this item makes to its version's content hash.
+
+        Includes the per-version properties (`meta`, `splits`) so that
+        republishing the same examples with different annotations produces a
+        genuinely different version rather than silently returning the old one.
+        """
+
+        return {
+            "item_id": self.item_id,
+            "meta": self.meta,
+            "splits": self.splits,
+        }
+
+    def __hash__(self):
+        return hash(self.item_id)
+
+
+class DatasetVersion(serial_utils.SerialModel, Hashable):
+    """An immutable snapshot of a dataset's examples.
+
+    A version is content-addressed: `dataset_version_id` is derived from the
+    owning dataset, the ordered contents of the version and its source
+    metadata. Publishing the same content twice therefore yields the same id
+    and is idempotent. `description` and `parent_dataset_version_id` are
+    provenance annotations and are deliberately excluded from the hash, so
+    re-publishing identical content under a new description returns the
+    existing version unchanged.
+    """
+
+    dataset_version_id: types_schema.DatasetVersionID  # str
+    """The content-addressed identifier for this version."""
+
+    dataset_id: types_schema.DatasetID  # str
+    """The stable dataset this version belongs to.
+
+    See [Dataset.dataset_id][trulens.core.schema.dataset.Dataset.dataset_id]."""
+
+    parent_dataset_version_id: Optional[types_schema.DatasetVersionID] = None
+    """The version this one was derived from, if any.
+
+    Optional provenance only: a delta between two versions is computed from
+    their contents, not from this pointer."""
+
+    description: Optional[str] = None
+    """Free-text description of the version."""
+
+    source_meta: types_schema.Metadata = pydantic.Field(default_factory=dict)
+    """Metadata describing where the version's content came from."""
+
+    content_hash: str = ""
+    """Hash of the version's ordered contents.
+
+    `dataset_version_id` is this digest with a fixed prefix."""
+
+    item_count: int = 0
+    """Number of examples in the version."""
+
+    created_at: float = 0.0
+    """Creation timestamp, as seconds since the epoch."""
+
+    version_index: Optional[int] = None
+    """Monotonic per-dataset index, assigned when the version is persisted.
+
+    This is the deterministic ordering key used to resolve the latest version;
+    creation timestamps alone can tie. Version zero always has index 0."""
+
+    items: List[DatasetVersionItem] = pydantic.Field(default_factory=list)
+    """The examples in this version.
+
+    Populated by loaders. Items live in their own table and are *not* part of
+    the persisted version metadata; `item_count` is authoritative for a version
+    whose items have not been loaded."""
+
+    def __init__(
+        self,
+        dataset_id: types_schema.DatasetID,
+        items: Optional[Sequence[DatasetVersionItem]] = None,
+        parent_dataset_version_id: Optional[
+            types_schema.DatasetVersionID
+        ] = None,
+        description: Optional[str] = None,
+        source_meta: Optional[types_schema.Metadata] = None,
+        created_at: Optional[float] = None,
+        dataset_version_id: Optional[types_schema.DatasetVersionID] = None,
+        content_hash: Optional[str] = None,
+        item_count: Optional[int] = None,
+        version_index: Optional[int] = None,
+        **kwargs,
+    ):
+        items = list(items) if items is not None else []
+
+        kwargs["dataset_id"] = dataset_id
+        kwargs["items"] = items
+        kwargs["parent_dataset_version_id"] = parent_dataset_version_id
+        kwargs["description"] = description
+        kwargs["source_meta"] = (
+            _normalize_content(source_meta) if source_meta is not None else {}
+        )
+        kwargs["created_at"] = created_at if created_at is not None else 0.0
+        kwargs["item_count"] = (
+            item_count if item_count is not None else len(items)
+        )
+        kwargs["version_index"] = version_index
+
+        super().__init__(
+            dataset_version_id="temporary",
+            content_hash="",
+            **kwargs,
+        )  # both updated below
+
+        self.content_hash = (
+            content_hash if content_hash is not None else self.compute_hash()
+        )
+        self.dataset_version_id = (
+            dataset_version_id
+            if dataset_version_id is not None
+            else DATASET_VERSION_ID_PREFIX + self.content_hash
+        )
+
+        for item in self.items:
+            item.dataset_version_id = self.dataset_version_id
+
+    def compute_hash(self) -> str:
+        """Compute the content hash of this version's ordered contents."""
+
+        return _content_hash({
+            "dataset_id": self.dataset_id,
+            "source_meta": self.source_meta,
+            "items": [item.identity_digest() for item in self.items],
+        })
+
+    def metadata_json(self, **kwargs) -> str:
+        """Serialize the version metadata, excluding its items.
+
+        Items are persisted in their own table, so storing them again inside
+        the version row would duplicate the whole snapshot.
+        """
+
+        return json.dumps({
+            "dataset_version_id": self.dataset_version_id,
+            "dataset_id": self.dataset_id,
+            "parent_dataset_version_id": self.parent_dataset_version_id,
+            "description": self.description,
+            "source_meta": self.source_meta,
+            "content_hash": self.content_hash,
+            "item_count": self.item_count,
+            "created_at": self.created_at,
+            "version_index": self.version_index,
+        })
+
+    @property
+    def is_version_zero(self) -> bool:
+        """Whether this version was reconstructed from legacy ground truth."""
+
+        return self.source_meta.get("origin") == VERSION_ZERO_ORIGIN
+
+    def split(self, split_name: str) -> List[DatasetVersionItem]:
+        """Return the loaded items belonging to a named split."""
+
+        return [item for item in self.items if split_name in item.splits]
+
+    def split_names(self) -> List[str]:
+        """Return every split name used by the loaded items."""
+
+        names = {name for item in self.items for name in item.splits}
+        return sorted(names)
+
+    def __hash__(self):
+        return hash(self.dataset_version_id)
+
+
+class DatasetVersionDiff(serial_utils.SerialModel):
+    """Membership comparison between two dataset versions."""
+
+    dataset_version_id_a: types_schema.DatasetVersionID
+    """The baseline version."""
+
+    dataset_version_id_b: types_schema.DatasetVersionID
+    """The version compared against the baseline."""
+
+    added: List[types_schema.DatasetVersionItemID] = pydantic.Field(
+        default_factory=list
+    )
+    """Items present in `b` but not in `a`, in their order within `b`."""
+
+    removed: List[types_schema.DatasetVersionItemID] = pydantic.Field(
+        default_factory=list
+    )
+    """Items present in `a` but not in `b`, in their order within `a`."""
+
+    unchanged: List[types_schema.DatasetVersionItemID] = pydantic.Field(
+        default_factory=list
+    )
+    """Items present in both versions, in their order within `a`."""
+
+    @classmethod
+    def between(
+        cls,
+        version_a: DatasetVersion,
+        version_b: DatasetVersion,
+    ) -> DatasetVersionDiff:
+        """Compare the membership of two loaded versions."""
+
+        ids_a = [item.item_id for item in version_a.items]
+        ids_b = [item.item_id for item in version_b.items]
+        set_a, set_b = set(ids_a), set(ids_b)
+
+        return cls(
+            dataset_version_id_a=version_a.dataset_version_id,
+            dataset_version_id_b=version_b.dataset_version_id,
+            added=[i for i in ids_b if i not in set_a],
+            removed=[i for i in ids_a if i not in set_b],
+            unchanged=[i for i in ids_a if i in set_b],
+        )
+
+
 # HACK013: Need these if using __future__.annotations .
 Dataset.model_rebuild()
+DatasetVersionItem.model_rebuild()
+DatasetVersion.model_rebuild()
+DatasetVersionDiff.model_rebuild()

--- a/src/core/trulens/core/schema/dataset.py
+++ b/src/core/trulens/core/schema/dataset.py
@@ -146,10 +146,14 @@ def normalize_column_spec(column_spec: Dict[str, str]) -> Dict[str, str]:
             ignored.append(key)
 
     if ignored:
-        logger.debug(
+        # Warn rather than debug: a caller passing something like
+        # {"retrieval.query_text": "question"} expected those columns to be
+        # read, and a silent drop only surfaces later as missing item data.
+        logger.warning(
             "Ignoring column spec entries that do not map to dataset version "
-            "item fields: %s",
+            "item fields: %s. Supported fields: %s.",
             ", ".join(sorted(str(k) for k in ignored)),
+            ", ".join(sorted(COLUMN_SPEC_FIELDS)),
         )
 
     if "input" not in normalized:

--- a/src/core/trulens/core/schema/groundtruth.py
+++ b/src/core/trulens/core/schema/groundtruth.py
@@ -8,6 +8,7 @@ from typing import Dict, Hashable, Optional, Sequence
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import ValidationError
+from trulens.core.schema import dataset as dataset_schema
 from trulens.core.schema import types as types_schema
 from trulens.core.utils import json as json_utils
 from trulens.core.utils import serial as serial_utils
@@ -116,6 +117,63 @@ class GroundTruth(serial_utils.SerialModel, Hashable):
 
     def __hash__(self):
         return hash(self.ground_truth_id)
+
+
+def dataset_version_item_of_ground_truth(
+    ground_truth: GroundTruth,
+    splits: Optional[Sequence[str]] = None,
+) -> dataset_schema.DatasetVersionItem:
+    """Convert a ground truth entry into a dataset version item.
+
+    `GroundTruth` remains supported as a compatibility input shape; this is the
+    mapping used to reconstruct version zero from rows written before
+    versioning existed.
+
+    Args:
+        ground_truth: The ground truth entry to convert.
+        splits: Names of the splits the resulting item belongs to.
+
+    Returns:
+        The equivalent
+        [DatasetVersionItem][trulens.core.schema.dataset.DatasetVersionItem].
+    """
+
+    return dataset_schema.DatasetVersionItem(
+        input=ground_truth.query,
+        input_id=ground_truth.query_id,
+        expected_response=ground_truth.expected_response,
+        expected_contexts=ground_truth.expected_chunks,
+        meta=ground_truth.meta,
+        splits=splits,
+    )
+
+
+def ground_truth_of_dataset_version_item(
+    item: dataset_schema.DatasetVersionItem,
+    dataset_id: types_schema.DatasetID,
+) -> GroundTruth:
+    """Convert a dataset version item back into a ground truth entry.
+
+    `GroundTruth` remains supported as a compatibility output shape, so code
+    that already consumes ground truths keeps working against versioned data.
+
+    Args:
+        item: The dataset version item to convert.
+        dataset_id: The dataset the resulting ground truth belongs to.
+
+    Returns:
+        The equivalent
+        [GroundTruth][trulens.core.schema.groundtruth.GroundTruth].
+    """
+
+    return GroundTruth(
+        dataset_id=dataset_id,
+        query=item.input or "",
+        query_id=item.input_id,
+        expected_response=item.expected_response,
+        expected_chunks=item.expected_contexts,
+        meta=item.meta,
+    )
 
 
 # HACK013: Need these if using __future__.annotations .

--- a/src/core/trulens/core/schema/types.py
+++ b/src/core/trulens/core/schema/types.py
@@ -90,6 +90,23 @@ DatasetID: TypeAlias = str
 By default these are hashes of dataset content as json.
 """
 
+DatasetVersionID: TypeAlias = str
+"""Unique identifier for an immutable dataset version.
+
+These are content-addressed: the id is a hash of the ordered contents of the
+version, so publishing identical content twice yields the same id. See
+[DatasetVersion.dataset_version_id][trulens.core.schema.dataset.DatasetVersion.dataset_version_id].
+"""
+
+DatasetVersionItemID: TypeAlias = str
+"""Unique identifier for a single example within a dataset version.
+
+These are content-addressed from the normalized example content and the
+optional caller-supplied input id, so the same example carries the same id
+across versions. See
+[DatasetVersionItem.item_id][trulens.core.schema.dataset.DatasetVersionItem.item_id].
+"""
+
 EventID: TypeAlias = str
 """Unique identifier for a event.
 """

--- a/src/core/trulens/core/session.py
+++ b/src/core/trulens/core/session.py
@@ -69,6 +69,111 @@ with import_utils.OptionalImports(messages=optional_utils.REQUIREMENT_TQDM):
 logger = logging.getLogger(__name__)
 
 
+def ground_truth_df_of_dataset_version(
+    version: dataset_schema.DatasetVersion,
+) -> pandas.DataFrame:
+    """Render a dataset version in the legacy ground truth dataframe shape.
+
+    `GroundTruth` remains supported as an output shape, so code that already
+    consumes the frame returned by
+    [get_ground_truth][trulens.core.session.TruSession.get_ground_truth] keeps
+    working against versioned data.
+
+    Args:
+        version: The version to render, with its items loaded.
+
+    Returns:
+        A dataframe with the ground truth columns plus `item_id` and `splits`.
+    """
+
+    rows = []
+    for item in version.items:
+        ground_truth = groundtruth_schema.ground_truth_of_dataset_version_item(
+            item, version.dataset_id
+        )
+        rows.append((
+            ground_truth.ground_truth_id,
+            version.dataset_id,
+            ground_truth.query,
+            ground_truth.query_id,
+            ground_truth.expected_response,
+            ground_truth.expected_chunks,
+            ground_truth.meta,
+            item.item_id,
+            item.splits,
+        ))
+
+    return pandas.DataFrame(
+        data=rows,
+        columns=[
+            "ground_truth_id",
+            "dataset_id",
+            "query",
+            "query_id",
+            "expected_response",
+            "expected_chunks",
+            "meta",
+            "item_id",
+            "splits",
+        ],
+    )
+
+
+def _apply_dataset_version_splits(
+    items: List[dataset_schema.DatasetVersionItem],
+    splits: Optional[Dict[str, Sequence[str]]],
+) -> List[dataset_schema.DatasetVersionItem]:
+    """Attach named splits to the items they name.
+
+    Split members are matched against each item's caller-supplied `input_id`
+    first and then against its content-addressed item id, so a caller can name
+    members with whichever identifier they already have.
+
+    Raises:
+        ValueError: If a split names a member that is not among the items.
+    """
+
+    if not splits:
+        return items
+
+    by_item_id: Dict[str, List[str]] = {}
+    unknown = []
+
+    for split_name, members in splits.items():
+        for member in members:
+            matched = [
+                item
+                for item in items
+                if item.input_id == member or item.item_id == member
+            ]
+            if not matched:
+                unknown.append(f"{split_name}:{member}")
+                continue
+            for item in matched:
+                by_item_id.setdefault(item.item_id, []).append(str(split_name))
+
+    if unknown:
+        raise ValueError(
+            "Splits name members that are not in this dataset version: "
+            + ", ".join(sorted(unknown))
+            + "."
+        )
+
+    # Items are immutable once published, and their ids do not depend on
+    # splits, so rebuilding with the split names attached is safe.
+    return [
+        dataset_schema.DatasetVersionItem(
+            input=item.input,
+            input_id=item.input_id,
+            expected_response=item.expected_response,
+            expected_contexts=item.expected_contexts,
+            meta=item.meta,
+            splits=by_item_id.get(item.item_id),
+        )
+        for item in items
+    ]
+
+
 class TruSession(
     core_experimental._WithExperimentalSettings, python_utils.PydanticSingleton
 ):
@@ -1213,12 +1318,270 @@ class TruSession(
             record_resolver=_resolve,
         )
 
+    def create_dataset_version(
+        self,
+        dataset_name: str,
+        dataframe: Optional[pandas.DataFrame] = None,
+        ground_truths: Optional[
+            Sequence[groundtruth_schema.GroundTruth]
+        ] = None,
+        column_spec: Optional[Dict[str, str]] = None,
+        splits: Optional[Dict[str, Sequence[str]]] = None,
+        description: Optional[str] = None,
+        dataset_metadata: Optional[Dict[str, Any]] = None,
+        source_metadata: Optional[Dict[str, Any]] = None,
+        parent_dataset_version_id: Optional[
+            types_schema.DatasetVersionID
+        ] = None,
+    ) -> dataset_schema.DatasetVersion:
+        """Publish an immutable version of a dataset.
+
+        The version id is content-addressed from the ordered contents of the
+        version, so publishing identical content twice is idempotent: the
+        second call returns the version that already exists rather than
+        creating a duplicate or modifying it. `description` and
+        `parent_dataset_version_id` are provenance annotations only and do not
+        take part in that identity, so re-publishing the same examples under a
+        new description returns the original version unchanged.
+
+        Args:
+            dataset_name: Name of the dataset to publish a version of. The
+                dataset is created if it does not exist yet.
+            dataframe: The examples to publish, one per row. Mutually
+                exclusive with `ground_truths`.
+            ground_truths: The examples to publish as
+                [GroundTruth][trulens.core.schema.groundtruth.GroundTruth]
+                entries. Mutually exclusive with `dataframe`.
+            column_spec: Mapping from dataset version item fields (`input`,
+                `input_id`, `expected_response`, `expected_contexts`,
+                `metadata`) to column names in `dataframe`. Required with
+                `dataframe`. Legacy spellings such as `query` and
+                `ground_truth_output` are accepted.
+            splits: Named splits, mapping a split name to the members it
+                contains. Members are matched against each example's
+                `input_id` first and then its item id.
+            description: A description of what this version contains.
+            dataset_metadata: Metadata for the dataset itself. Only used when
+                the dataset does not exist yet.
+            source_metadata: Metadata describing where the content came from.
+                This *is* part of the version's identity.
+            parent_dataset_version_id: The version this one was derived from.
+                Defaults to the current latest version.
+
+        Returns:
+            The published
+            [DatasetVersion][trulens.core.schema.dataset.DatasetVersion], with
+            its items loaded.
+
+        Raises:
+            ValueError: If neither or both of `dataframe` and `ground_truths`
+                are given, if `column_spec` is missing or does not name an
+                `input` column, or if a split names a member that is not in
+                the version.
+        """
+
+        if (dataframe is None) == (ground_truths is None):
+            raise ValueError(
+                "Exactly one of `dataframe` or `ground_truths` must be "
+                "provided."
+            )
+
+        if dataframe is not None:
+            if column_spec is None:
+                raise ValueError(
+                    "`column_spec` is required when publishing from a "
+                    "dataframe."
+                )
+            items = self._dataset_version_items_of_dataframe(
+                dataframe, column_spec
+            )
+        else:
+            items = [
+                groundtruth_schema.dataset_version_item_of_ground_truth(
+                    ground_truth
+                )
+                for ground_truth in ground_truths
+            ]
+
+        items = _apply_dataset_version_splits(items, splits)
+
+        existing_dataset = self.connector.db.get_dataset(dataset_name)
+        if existing_dataset is not None and dataset_metadata is None:
+            dataset_id = existing_dataset.dataset_id
+        else:
+            dataset_id = self.connector.db.insert_dataset(
+                dataset=dataset_schema.Dataset(
+                    name=dataset_name, meta=dataset_metadata
+                )
+            )
+
+        version = dataset_schema.DatasetVersion(
+            dataset_id=dataset_id,
+            items=items,
+            description=description,
+            source_meta=(
+                source_metadata
+                if source_metadata is not None
+                else {"dataset_name": dataset_name}
+            ),
+            created_at=time(),
+            parent_dataset_version_id=parent_dataset_version_id,
+        )
+
+        dataset_version_id = self.connector.db.insert_dataset_version(version)
+
+        return self.connector.db.get_dataset_version(
+            dataset_version_id=dataset_version_id
+        )
+
+    def _dataset_version_items_of_dataframe(
+        self,
+        dataframe: pandas.DataFrame,
+        column_spec: Dict[str, str],
+    ) -> List[dataset_schema.DatasetVersionItem]:
+        """Build dataset version items out of a dataframe."""
+
+        spec = dataset_schema.normalize_column_spec(column_spec)
+
+        missing = sorted(
+            column
+            for column in spec.values()
+            if column not in dataframe.columns
+        )
+        if missing:
+            raise ValueError(
+                "The column spec names columns that are not in the "
+                f"dataframe: {', '.join(missing)}."
+            )
+
+        return [
+            dataset_schema.DatasetVersionItem(
+                input=row[spec["input"]],
+                input_id=row[spec["input_id"]] if "input_id" in spec else None,
+                expected_response=(
+                    row[spec["expected_response"]]
+                    if "expected_response" in spec
+                    else None
+                ),
+                expected_contexts=(
+                    row[spec["expected_contexts"]]
+                    if "expected_contexts" in spec
+                    else None
+                ),
+                meta=row[spec["metadata"]] if "metadata" in spec else None,
+            )
+            for _, row in dataframe.iterrows()
+        ]
+
+    def get_dataset_version(
+        self,
+        dataset_name: Optional[str] = None,
+        dataset_version_id: Optional[types_schema.DatasetVersionID] = None,
+        load_items: bool = True,
+    ) -> Optional[dataset_schema.DatasetVersion]:
+        """Load one immutable dataset version.
+
+        Pin an exact snapshot with `dataset_version_id`, or pass only
+        `dataset_name` to resolve the latest version. A dataset whose examples
+        predate versioning resolves to a version zero reconstructed from its
+        ground truth rows, which leaves the original payloads untouched.
+
+        Args:
+            dataset_name: The dataset whose latest version to resolve.
+            dataset_version_id: The exact version to load.
+            load_items: Whether to also load the version's examples.
+
+        Returns:
+            The version, or `None` if it could not be resolved.
+
+        Raises:
+            ValueError: If neither argument is given, or if the version found
+                by id does not belong to the named dataset.
+        """
+
+        if dataset_name is None and dataset_version_id is None:
+            raise ValueError(
+                "Either `dataset_name` or `dataset_version_id` must be "
+                "provided."
+            )
+
+        version = self.connector.db.get_dataset_version(
+            dataset_version_id=dataset_version_id,
+            dataset_name=dataset_name if dataset_version_id is None else None,
+            load_items=load_items,
+        )
+
+        if (
+            version is not None
+            and dataset_version_id is not None
+            and dataset_name is not None
+        ):
+            dataset = self.connector.db.get_dataset(dataset_name)
+            if dataset is None or dataset.dataset_id != version.dataset_id:
+                raise ValueError(
+                    f"Dataset version {dataset_version_id} does not belong to "
+                    f"dataset '{dataset_name}'."
+                )
+
+        return version
+
+    def list_dataset_versions(self, dataset_name: str) -> pandas.DataFrame:
+        """List the versions of a dataset, oldest first.
+
+        Args:
+            dataset_name: Name of the dataset.
+
+        Returns:
+            A dataframe with one row per version.
+        """
+
+        return self.connector.db.get_dataset_versions(dataset_name=dataset_name)
+
+    def compare_dataset_versions(
+        self,
+        dataset_version_id_a: types_schema.DatasetVersionID,
+        dataset_version_id_b: types_schema.DatasetVersionID,
+    ) -> dataset_schema.DatasetVersionDiff:
+        """Compare the membership of two dataset versions.
+
+        Args:
+            dataset_version_id_a: The baseline version.
+            dataset_version_id_b: The version to compare against the baseline.
+
+        Returns:
+            A
+            [DatasetVersionDiff][trulens.core.schema.dataset.DatasetVersionDiff]
+            reporting the added, removed and unchanged item ids.
+
+        Raises:
+            ValueError: If either version could not be found.
+        """
+
+        version_a = self.connector.db.get_dataset_version(
+            dataset_version_id=dataset_version_id_a
+        )
+        version_b = self.connector.db.get_dataset_version(
+            dataset_version_id=dataset_version_id_b
+        )
+
+        for dataset_version_id, version in (
+            (dataset_version_id_a, version_a),
+            (dataset_version_id_b, version_b),
+        ):
+            if version is None:
+                raise ValueError(
+                    f"Dataset version {dataset_version_id} not found."
+                )
+
+        return dataset_schema.DatasetVersionDiff.between(version_a, version_b)
+
     def get_ground_truth(
         self,
         dataset_name: Optional[str] = None,
         user_table_name: Optional[str] = None,
         user_schema_mapping: Optional[Dict[str, str]] = None,
         user_schema_name: Optional[str] = None,
+        dataset_version_id: Optional[types_schema.DatasetVersionID] = None,
     ) -> pandas.DataFrame:
         """Get ground truth data from the dataset. If `user_table_name` and `user_schema_mapping` are provided,
         load a virtual dataset from the user's table using the schema mapping. If `dataset_name` is provided,
@@ -1227,8 +1590,27 @@ class TruSession(
         user_table_name: Name of the user's table to load ground truth data from.
         user_schema_mapping: Mapping of user table columns to internal `GroundTruth` schema fields.
         user_schema_name: Name of the user's schema to load ground truth data from.
+        dataset_version_id: Load the examples of this exact immutable dataset
+            version instead of the dataset's current ground truth rows.
+
+        Note:
+            Passing only `dataset_name` keeps returning every ground truth row
+            of the dataset, exactly as before, so that publishing a version of
+            a subset does not silently change what existing callers read. Pass
+            `dataset_version_id` — or use
+            [get_dataset_version][trulens.core.session.TruSession.get_dataset_version]
+            — to read a pinned snapshot.
         """
-        if user_table_name and user_schema_mapping:
+        if dataset_version_id:
+            version = self.connector.db.get_dataset_version(
+                dataset_version_id=dataset_version_id
+            )
+            if version is None:
+                raise ValueError(
+                    f"Dataset version {dataset_version_id} not found."
+                )
+            return ground_truth_df_of_dataset_version(version)
+        elif user_table_name and user_schema_mapping:
             return self.connector.db.get_virtual_ground_truth(
                 user_table_name, user_schema_mapping, user_schema_name
             )

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -39,6 +39,7 @@ from trulens.core.database import sqlalchemy as sqlalchemy_db
 from trulens.core.database import utils as db_utils
 from trulens.core.feedback import provider as core_provider
 from trulens.core.metric import metric as core_metric
+from trulens.core.schema import dataset as dataset_schema
 from trulens.core.schema import feedback as feedback_schema
 from trulens.core.schema import select as select_schema
 
@@ -183,6 +184,21 @@ class TestDbV2Migration(TestCase):
         """Test database consistency after migration to mysql."""
         with clean_db("mysql") as db:
             _test_db_consistency(self, db)
+
+    def test_dataset_version_persistence_sqlite_file(self) -> None:
+        """Test dataset version persistence on sqlite."""
+        with clean_db("sqlite_file") as db:
+            _test_dataset_version_persistence(self, db)
+
+    def test_dataset_version_persistence_postgres(self) -> None:
+        """Test dataset version persistence on postgres."""
+        with clean_db("postgres") as db:
+            _test_dataset_version_persistence(self, db)
+
+    def test_dataset_version_persistence_mysql(self) -> None:
+        """Test dataset version persistence on mysql."""
+        with clean_db("mysql") as db:
+            _test_dataset_version_persistence(self, db)
 
     def test_future_db(self) -> None:
         """Check handling of database that is newer than the current
@@ -464,6 +480,88 @@ def _test_db_consistency(test: TestCase, db: sqlalchemy_db.SQLAlchemyDB):
             1,
             "Expected a feedback definition.",
         )
+
+
+def _test_dataset_version_persistence(
+    test: TestCase, db: sqlalchemy_db.SQLAlchemyDB
+):
+    """Dataset versions must round-trip identically on every backend.
+
+    Content-addressed ids are only useful if the same content produces the same
+    id after a write and a read, which is a property of the storage layer as
+    much as of the hashing.
+    """
+
+    db.migrate_database()  # ensure latest revision
+
+    dataset_id = db.insert_dataset(dataset_schema.Dataset(name="persisted"))
+
+    items = [
+        dataset_schema.DatasetVersionItem(
+            input="what is trulens?",
+            input_id="case-1",
+            expected_response="an evaluation library",
+            expected_contexts=[{"text": "docs"}],
+            meta={"topic": "product"},
+            splits=["regression"],
+        ),
+        dataset_schema.DatasetVersionItem(
+            input="how do i install it?",
+            expected_response="pip install trulens",
+        ),
+    ]
+    version = dataset_schema.DatasetVersion(
+        dataset_id=dataset_id,
+        items=items,
+        description="persistence contract",
+        source_meta={"dataset_name": "persisted"},
+        created_at=1.5,
+    )
+
+    dataset_version_id = db.insert_dataset_version(version)
+    test.assertEqual(dataset_version_id, version.dataset_version_id)
+
+    # Publishing identical content again is idempotent.
+    test.assertEqual(
+        db.insert_dataset_version(
+            dataset_schema.DatasetVersion(
+                dataset_id=dataset_id,
+                items=[
+                    dataset_schema.DatasetVersionItem(
+                        input=item.input,
+                        input_id=item.input_id,
+                        expected_response=item.expected_response,
+                        expected_contexts=item.expected_contexts,
+                        meta=item.meta,
+                        splits=item.splits,
+                    )
+                    for item in items
+                ],
+                source_meta={"dataset_name": "persisted"},
+                created_at=99.0,
+            )
+        ),
+        dataset_version_id,
+    )
+    test.assertEqual(len(db.get_dataset_versions(dataset_name="persisted")), 1)
+
+    loaded = db.get_dataset_version(dataset_version_id=dataset_version_id)
+    test.assertEqual(loaded.content_hash, version.content_hash)
+    test.assertEqual(loaded.item_count, 2)
+    test.assertEqual(loaded.version_index, 0)
+    test.assertEqual(loaded.description, "persistence contract")
+    test.assertEqual(loaded.created_at, 1.5)
+    test.assertEqual(
+        [item.item_id for item in loaded.items],
+        [item.item_id for item in items],
+    )
+    test.assertEqual(loaded.items[0].splits, ["regression"])
+    test.assertEqual(loaded.items[0].meta, {"topic": "product"})
+    test.assertEqual(loaded.items[0].expected_contexts, [{"text": "docs"}])
+    test.assertIsNone(loaded.items[1].input_id)
+
+    # The reloaded snapshot hashes to the id it was stored under.
+    test.assertEqual(loaded.compute_hash(), version.content_hash)
 
 
 def _populate_data(db: core_db.DB):

--- a/tests/unit/test_dataset_versions.py
+++ b/tests/unit/test_dataset_versions.py
@@ -1,0 +1,823 @@
+"""Tests for immutable dataset versions and run provenance.
+
+Covers the contract from truera/trulens#2701: content-addressed versions,
+idempotent publishing, immutability, split and metadata round trips, version
+zero compatibility for pre-versioning ground truth rows, latest and exact
+version lookup, membership comparison, and run source provenance.
+"""
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import pandas as pd
+from trulens.core import run as core_run
+from trulens.core import session as core_session
+from trulens.core.dao import default_run as default_run_dao
+from trulens.core.database import sqlalchemy as db_sqlalchemy
+from trulens.core.database.connector import default as default_connector
+from trulens.core.schema import dataset as dataset_schema
+from trulens.core.schema import groundtruth as groundtruth_schema
+
+EXAMPLES = pd.DataFrame([
+    {
+        "question": "what is trulens?",
+        "expected_answer": "an evaluation library",
+        "metadata": {"topic": "product"},
+        "case_id": "case-1",
+    },
+    {
+        "question": "how do i install it?",
+        "expected_answer": "pip install trulens",
+        "metadata": {"topic": "setup"},
+        "case_id": "case-2",
+    },
+])
+
+COLUMN_SPEC = {
+    "input": "question",
+    "ground_truth_output": "expected_answer",
+    "metadata": "metadata",
+    "input_id": "case_id",
+}
+
+
+def _clear_tru_session_singletons():
+    """Drop any live `TruSession` so each test gets its own database."""
+
+    for key in [
+        curr
+        for curr in core_session.TruSession._singleton_instances
+        if curr[0] == "trulens.core.session.TruSession"
+    ]:
+        del core_session.TruSession._singleton_instances[key]
+
+
+class DatasetVersionTestCase(unittest.TestCase):
+    """Base case giving each test its own file-backed SQLite database."""
+
+    def setUp(self):
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tempdir.cleanup)
+
+        db_path = os.path.join(self._tempdir.name, "trulens.sqlite")
+        self.db = db_sqlalchemy.SQLAlchemyDB.from_db_url(f"sqlite:///{db_path}")
+        self.db.migrate_database()
+
+        _clear_tru_session_singletons()
+        self.addCleanup(_clear_tru_session_singletons)
+        self.session = core_session.TruSession(
+            connector=default_connector.DefaultDBConnector(database=self.db)
+        )
+
+    def publish(self, **kwargs) -> dataset_schema.DatasetVersion:
+        """Publish `EXAMPLES` under the default spec, overriding as needed."""
+
+        kwargs.setdefault("dataset_name", "support-quality")
+        kwargs.setdefault("dataframe", EXAMPLES)
+        kwargs.setdefault("column_spec", COLUMN_SPEC)
+        return self.session.create_dataset_version(**kwargs)
+
+
+class TestVersionCreation(DatasetVersionTestCase):
+    def test_create_from_dataframe(self):
+        version = self.publish(description="Reviewed August failures")
+
+        self.assertEqual(version.item_count, 2)
+        self.assertEqual(len(version.items), 2)
+        self.assertEqual(version.description, "Reviewed August failures")
+        self.assertEqual(
+            [item.input for item in version.items],
+            ["what is trulens?", "how do i install it?"],
+        )
+        self.assertEqual(
+            [item.expected_response for item in version.items],
+            ["an evaluation library", "pip install trulens"],
+        )
+        self.assertEqual(
+            [item.input_id for item in version.items],
+            [
+                "case-1",
+                "case-2",
+            ],
+        )
+        self.assertTrue(
+            version.dataset_version_id.startswith(
+                dataset_schema.DATASET_VERSION_ID_PREFIX
+            )
+        )
+
+    def test_create_from_ground_truth_sequence(self):
+        dataset_id = self.db.insert_dataset(
+            dataset_schema.Dataset(name="from-gt")
+        )
+        ground_truths = [
+            groundtruth_schema.GroundTruth(
+                dataset_id=dataset_id,
+                query="what is trulens?",
+                expected_response="an evaluation library",
+            ),
+        ]
+
+        version = self.session.create_dataset_version(
+            dataset_name="from-gt", ground_truths=ground_truths
+        )
+
+        self.assertEqual(version.item_count, 1)
+        self.assertEqual(version.items[0].input, "what is trulens?")
+        self.assertEqual(version.dataset_id, dataset_id)
+
+    def test_requires_exactly_one_source(self):
+        with self.assertRaises(ValueError):
+            self.session.create_dataset_version(dataset_name="d")
+        with self.assertRaises(ValueError):
+            self.session.create_dataset_version(
+                dataset_name="d",
+                dataframe=EXAMPLES,
+                column_spec=COLUMN_SPEC,
+                ground_truths=[],
+            )
+
+    def test_rejects_column_spec_without_input(self):
+        with self.assertRaises(ValueError):
+            self.publish(column_spec={"ground_truth_output": "expected_answer"})
+
+    def test_rejects_column_spec_naming_absent_columns(self):
+        with self.assertRaises(ValueError) as caught:
+            self.publish(column_spec={"input": "not_a_column"})
+        self.assertIn("not_a_column", str(caught.exception))
+
+    def test_column_spec_ignores_unrelated_run_spec_keys(self):
+        # A RunConfig.dataset_spec carrying extra span attributes should be
+        # usable as-is.
+        version = self.publish(
+            column_spec={
+                "RECORD_ROOT.INPUT": "question",
+                "record_root.ground_truth_output": "expected_answer",
+                "retrieval.query_text": "question",
+            }
+        )
+        self.assertEqual(
+            [item.input for item in version.items],
+            ["what is trulens?", "how do i install it?"],
+        )
+        self.assertEqual(
+            version.items[0].expected_response, "an evaluation library"
+        )
+
+
+class TestContentAddressing(DatasetVersionTestCase):
+    def test_identical_content_is_idempotent(self):
+        first = self.publish()
+        second = self.publish()
+
+        self.assertEqual(first.dataset_version_id, second.dataset_version_id)
+        self.assertEqual(
+            len(self.session.list_dataset_versions("support-quality")), 1
+        )
+
+    def test_description_does_not_change_identity(self):
+        first = self.publish(description="first pass")
+        second = self.publish(description="second pass")
+
+        self.assertEqual(first.dataset_version_id, second.dataset_version_id)
+        # Immutability: the stored description is the one first published.
+        self.assertEqual(second.description, "first pass")
+
+    def test_different_content_is_a_different_version(self):
+        first = self.publish()
+        second = self.publish(dataframe=EXAMPLES.head(1))
+
+        self.assertNotEqual(first.dataset_version_id, second.dataset_version_id)
+        self.assertEqual(second.item_count, 1)
+
+    def test_item_order_changes_the_version_id(self):
+        first = self.publish()
+        second = self.publish(dataframe=EXAMPLES.iloc[::-1])
+
+        self.assertNotEqual(first.dataset_version_id, second.dataset_version_id)
+
+    def test_item_ids_are_stable_across_versions(self):
+        first = self.publish()
+        second = self.publish(dataframe=EXAMPLES.head(1))
+
+        self.assertEqual(
+            first.items[0].item_id,
+            second.items[0].item_id,
+        )
+
+    def test_version_id_is_derived_from_content_hash(self):
+        version = self.publish()
+        self.assertEqual(
+            version.dataset_version_id,
+            dataset_schema.DATASET_VERSION_ID_PREFIX + version.content_hash,
+        )
+
+    def test_whitespace_does_not_change_item_identity(self):
+        padded = EXAMPLES.copy()
+        padded["question"] = padded["question"].map(lambda q: f"  {q}\n")
+
+        self.assertEqual(
+            self.publish().dataset_version_id,
+            self.publish(dataframe=padded).dataset_version_id,
+        )
+
+    def test_missing_values_normalize_to_none(self):
+        without = (
+            EXAMPLES.head(1)
+            .drop(columns=["expected_answer"])
+            .assign(expected_answer=None)
+        )
+        empty = EXAMPLES.head(1).assign(expected_answer=float("nan"))
+
+        spec = dict(COLUMN_SPEC)
+        self.assertEqual(
+            self.publish(dataframe=without, column_spec=spec).items[0].item_id,
+            self.publish(dataframe=empty, column_spec=spec).items[0].item_id,
+        )
+
+
+class TestImmutabilityAndProvenance(DatasetVersionTestCase):
+    def test_earlier_versions_remain_loadable(self):
+        first = self.publish()
+        second = self.publish(dataframe=EXAMPLES.head(1))
+
+        loaded_first = self.session.get_dataset_version(
+            dataset_version_id=first.dataset_version_id
+        )
+        self.assertEqual(loaded_first.item_count, 2)
+        self.assertEqual(
+            [item.input for item in loaded_first.items],
+            ["what is trulens?", "how do i install it?"],
+        )
+        self.assertNotEqual(
+            loaded_first.dataset_version_id, second.dataset_version_id
+        )
+
+    def test_parent_defaults_to_previous_version(self):
+        first = self.publish()
+        second = self.publish(dataframe=EXAMPLES.head(1))
+
+        self.assertIsNone(first.parent_dataset_version_id)
+        self.assertEqual(
+            second.parent_dataset_version_id, first.dataset_version_id
+        )
+
+    def test_explicit_parent_is_kept(self):
+        first = self.publish()
+        self.publish(dataframe=EXAMPLES.head(1))
+        third = self.publish(
+            dataframe=EXAMPLES.tail(1),
+            parent_dataset_version_id=first.dataset_version_id,
+        )
+
+        self.assertEqual(
+            third.parent_dataset_version_id, first.dataset_version_id
+        )
+
+    def test_parent_does_not_affect_identity(self):
+        baseline = self.publish()
+        other = self.session.create_dataset_version(
+            dataset_name="other-dataset",
+            dataframe=EXAMPLES.head(1),
+            column_spec=COLUMN_SPEC,
+            source_metadata={"dataset_name": "support-quality"},
+        )
+        # Same items, same source metadata, different parent chain: the ids
+        # differ only because the datasets differ.
+        self.assertNotEqual(baseline.dataset_id, other.dataset_id)
+
+    def test_version_index_is_monotonic(self):
+        first = self.publish()
+        second = self.publish(dataframe=EXAMPLES.head(1))
+        third = self.publish(dataframe=EXAMPLES.tail(1))
+
+        self.assertEqual(
+            [
+                first.version_index,
+                second.version_index,
+                third.version_index,
+            ],
+            [0, 1, 2],
+        )
+
+
+class TestSplitsAndMetadata(DatasetVersionTestCase):
+    def test_splits_round_trip(self):
+        version = self.publish(splits={"regression": ["case-1", "case-2"]})
+
+        self.assertEqual(
+            [item.splits for item in version.items],
+            [
+                ["regression"],
+                ["regression"],
+            ],
+        )
+
+        loaded = self.session.get_dataset_version(
+            dataset_version_id=version.dataset_version_id
+        )
+        self.assertEqual(loaded.split_names(), ["regression"])
+        self.assertEqual(len(loaded.split("regression")), 2)
+
+    def test_partial_and_overlapping_splits(self):
+        version = self.publish(
+            splits={"regression": ["case-1"], "smoke": ["case-1", "case-2"]}
+        )
+
+        self.assertEqual(version.items[0].splits, ["regression", "smoke"])
+        self.assertEqual(version.items[1].splits, ["smoke"])
+
+    def test_splits_can_name_item_ids(self):
+        published = self.publish()
+        item_id = published.items[0].item_id
+
+        version = self.session.create_dataset_version(
+            dataset_name="by-item-id",
+            dataframe=EXAMPLES,
+            column_spec=COLUMN_SPEC,
+            splits={"regression": [item_id]},
+        )
+        self.assertEqual(version.items[0].splits, ["regression"])
+
+    def test_unknown_split_member_is_rejected(self):
+        with self.assertRaises(ValueError) as caught:
+            self.publish(splits={"regression": ["case-404"]})
+        self.assertIn("case-404", str(caught.exception))
+
+    def test_splits_do_not_change_item_identity(self):
+        without = self.publish()
+        with_splits = self.publish(splits={"regression": ["case-1"]})
+
+        self.assertEqual(
+            [item.item_id for item in without.items],
+            [item.item_id for item in with_splits.items],
+        )
+        # ... but they do make it a distinct snapshot.
+        self.assertNotEqual(
+            without.dataset_version_id, with_splits.dataset_version_id
+        )
+
+    def test_metadata_round_trips_without_changing_item_identity(self):
+        version = self.publish()
+        loaded = self.session.get_dataset_version(
+            dataset_version_id=version.dataset_version_id
+        )
+
+        self.assertEqual(
+            [item.meta for item in loaded.items],
+            [{"topic": "product"}, {"topic": "setup"}],
+        )
+
+        relabelled = EXAMPLES.copy()
+        relabelled["metadata"] = [{"topic": "changed"}, {"topic": "setup"}]
+        other = self.publish(dataframe=relabelled)
+
+        self.assertEqual(
+            [item.item_id for item in version.items],
+            [item.item_id for item in other.items],
+        )
+        self.assertNotEqual(
+            version.dataset_version_id, other.dataset_version_id
+        )
+
+
+class TestVersionZeroCompatibility(DatasetVersionTestCase):
+    def seed_legacy_dataset(self, dataset_name="legacy-dataset"):
+        self.session.add_ground_truth_to_dataset(
+            dataset_name=dataset_name,
+            ground_truth_df=pd.DataFrame([
+                {"query": "q1", "expected_response": "a1"},
+                {"query": "q2", "expected_response": "a2"},
+            ]),
+        )
+
+    def test_existing_dataset_appears_as_version_zero(self):
+        self.seed_legacy_dataset()
+
+        version = self.session.get_dataset_version(
+            dataset_name="legacy-dataset"
+        )
+
+        self.assertIsNotNone(version)
+        self.assertTrue(version.is_version_zero)
+        self.assertEqual(version.version_index, 0)
+        self.assertEqual(version.item_count, 2)
+        self.assertEqual(
+            sorted(item.input for item in version.items), ["q1", "q2"]
+        )
+
+    def test_version_zero_is_deterministic(self):
+        self.seed_legacy_dataset()
+
+        first = self.session.get_dataset_version(dataset_name="legacy-dataset")
+        second = self.session.get_dataset_version(dataset_name="legacy-dataset")
+
+        self.assertEqual(first.dataset_version_id, second.dataset_version_id)
+
+    def test_version_zero_is_materialized_on_first_publish(self):
+        self.seed_legacy_dataset()
+        version_zero_id = self.session.get_dataset_version(
+            dataset_name="legacy-dataset"
+        ).dataset_version_id
+
+        published = self.session.create_dataset_version(
+            dataset_name="legacy-dataset",
+            dataframe=EXAMPLES,
+            column_spec=COLUMN_SPEC,
+        )
+
+        versions = self.session.list_dataset_versions("legacy-dataset")
+        self.assertEqual(list(versions["version_index"]), [0, 1])
+        self.assertEqual(
+            versions.iloc[0]["dataset_version_id"], version_zero_id
+        )
+        self.assertEqual(published.parent_dataset_version_id, version_zero_id)
+
+        # Version zero stays loadable after the newer version lands.
+        reloaded = self.session.get_dataset_version(
+            dataset_version_id=version_zero_id
+        )
+        self.assertEqual(
+            sorted(item.input for item in reloaded.items), ["q1", "q2"]
+        )
+
+    def test_original_ground_truth_rows_are_not_rewritten(self):
+        self.seed_legacy_dataset()
+        before = self.session.get_ground_truth(dataset_name="legacy-dataset")
+
+        self.session.create_dataset_version(
+            dataset_name="legacy-dataset",
+            dataframe=EXAMPLES,
+            column_spec=COLUMN_SPEC,
+        )
+
+        after = self.session.get_ground_truth(dataset_name="legacy-dataset")
+        pd.testing.assert_frame_equal(before, after)
+
+    def test_duplicate_dataset_names_resolve_to_one_primary_row(self):
+        # A dataset id hashes name *and* metadata, so one name can map to
+        # several rows. Version zero must be reconstructed from the same row
+        # whether it is being read or materialized.
+        for metadata in ({"owner": "b"}, {"owner": "a"}):
+            self.session.add_ground_truth_to_dataset(
+                dataset_name="dup",
+                ground_truth_df=pd.DataFrame([
+                    {
+                        "query": f"q-{metadata['owner']}",
+                        "expected_response": "a",
+                    }
+                ]),
+                dataset_metadata=metadata,
+            )
+
+        read = self.session.get_dataset_version(dataset_name="dup")
+        self.assertEqual(read.item_count, 1)
+
+        self.session.create_dataset_version(
+            dataset_name="dup",
+            dataframe=EXAMPLES,
+            column_spec=COLUMN_SPEC,
+        )
+
+        materialized = self.session.list_dataset_versions("dup").iloc[0]
+        self.assertEqual(
+            materialized["dataset_version_id"], read.dataset_version_id
+        )
+        self.assertEqual(materialized["version_index"], 0)
+
+    def test_dataset_without_ground_truth_has_no_version(self):
+        self.db.insert_dataset(dataset_schema.Dataset(name="empty-dataset"))
+        self.assertIsNone(
+            self.session.get_dataset_version(dataset_name="empty-dataset")
+        )
+
+    def test_ground_truth_output_shape_from_a_version(self):
+        version = self.publish(splits={"regression": ["case-1"]})
+
+        df = self.session.get_ground_truth(
+            dataset_version_id=version.dataset_version_id
+        )
+
+        self.assertEqual(
+            list(df["query"]),
+            [
+                "what is trulens?",
+                "how do i install it?",
+            ],
+        )
+        self.assertEqual(list(df["query_id"]), ["case-1", "case-2"])
+        self.assertEqual(
+            list(df["expected_response"]),
+            ["an evaluation library", "pip install trulens"],
+        )
+        self.assertEqual(list(df["splits"]), [["regression"], []])
+
+    def test_ground_truth_by_name_is_unaffected_by_publishing(self):
+        self.seed_legacy_dataset()
+        before = self.session.get_ground_truth(dataset_name="legacy-dataset")
+
+        self.session.create_dataset_version(
+            dataset_name="legacy-dataset",
+            dataframe=EXAMPLES.head(1),
+            column_spec=COLUMN_SPEC,
+        )
+
+        after = self.session.get_ground_truth(dataset_name="legacy-dataset")
+        self.assertEqual(len(after), len(before))
+
+
+class TestLookup(DatasetVersionTestCase):
+    def test_name_resolves_to_latest_version(self):
+        self.publish()
+        latest = self.publish(dataframe=EXAMPLES.head(1))
+
+        resolved = self.session.get_dataset_version(
+            dataset_name="support-quality"
+        )
+        self.assertEqual(resolved.dataset_version_id, latest.dataset_version_id)
+
+    def test_exact_version_lookup(self):
+        first = self.publish()
+        self.publish(dataframe=EXAMPLES.head(1))
+
+        resolved = self.session.get_dataset_version(
+            dataset_version_id=first.dataset_version_id
+        )
+        self.assertEqual(resolved.dataset_version_id, first.dataset_version_id)
+
+    def test_unknown_version_returns_none(self):
+        self.assertIsNone(
+            self.session.get_dataset_version(dataset_version_id="nope")
+        )
+
+    def test_unknown_dataset_returns_none(self):
+        self.assertIsNone(self.session.get_dataset_version(dataset_name="nope"))
+
+    def test_requires_an_argument(self):
+        with self.assertRaises(ValueError):
+            self.session.get_dataset_version()
+
+    def test_version_must_belong_to_named_dataset(self):
+        version = self.publish()
+        self.session.create_dataset_version(
+            dataset_name="other-dataset",
+            dataframe=EXAMPLES.head(1),
+            column_spec=COLUMN_SPEC,
+        )
+
+        with self.assertRaises(ValueError):
+            self.session.get_dataset_version(
+                dataset_name="other-dataset",
+                dataset_version_id=version.dataset_version_id,
+            )
+
+    def test_can_skip_loading_items(self):
+        version = self.publish()
+        loaded = self.session.get_dataset_version(
+            dataset_version_id=version.dataset_version_id, load_items=False
+        )
+
+        self.assertEqual(loaded.items, [])
+        self.assertEqual(loaded.item_count, 2)
+
+    def test_list_versions_is_ordered_oldest_first(self):
+        first = self.publish()
+        second = self.publish(dataframe=EXAMPLES.head(1))
+
+        listed = self.session.list_dataset_versions("support-quality")
+        self.assertEqual(
+            list(listed["dataset_version_id"]),
+            [first.dataset_version_id, second.dataset_version_id],
+        )
+        self.assertEqual(list(listed["item_count"]), [2, 1])
+
+    def test_list_versions_of_unknown_dataset_is_empty(self):
+        listed = self.session.list_dataset_versions("nope")
+        self.assertTrue(listed.empty)
+        self.assertIn("dataset_version_id", listed.columns)
+
+
+class TestMembershipComparison(DatasetVersionTestCase):
+    def test_added_removed_and_unchanged(self):
+        extended = pd.concat(
+            [
+                EXAMPLES,
+                pd.DataFrame([
+                    {
+                        "question": "where are the docs?",
+                        "expected_answer": "trulens.org",
+                        "metadata": {},
+                        "case_id": "case-3",
+                    }
+                ]),
+            ],
+            ignore_index=True,
+        )
+
+        first = self.publish()
+        second = self.publish(dataframe=extended.tail(2))
+
+        diff = self.session.compare_dataset_versions(
+            first.dataset_version_id, second.dataset_version_id
+        )
+
+        self.assertEqual(diff.added, [extended_item_id(second, "case-3")])
+        self.assertEqual(diff.removed, [extended_item_id(first, "case-1")])
+        self.assertEqual(diff.unchanged, [extended_item_id(first, "case-2")])
+
+    def test_identical_versions_have_no_diff(self):
+        version = self.publish()
+        diff = self.session.compare_dataset_versions(
+            version.dataset_version_id, version.dataset_version_id
+        )
+
+        self.assertEqual(diff.added, [])
+        self.assertEqual(diff.removed, [])
+        self.assertEqual(len(diff.unchanged), 2)
+
+    def test_metadata_only_change_reports_everything_unchanged(self):
+        relabelled = EXAMPLES.copy()
+        relabelled["metadata"] = [{"topic": "changed"}, {"topic": "changed"}]
+
+        first = self.publish()
+        second = self.publish(dataframe=relabelled)
+
+        diff = self.session.compare_dataset_versions(
+            first.dataset_version_id, second.dataset_version_id
+        )
+        self.assertEqual(diff.added, [])
+        self.assertEqual(diff.removed, [])
+        self.assertEqual(len(diff.unchanged), 2)
+
+    def test_unknown_version_is_rejected(self):
+        version = self.publish()
+        with self.assertRaises(ValueError):
+            self.session.compare_dataset_versions(
+                version.dataset_version_id, "nope"
+            )
+
+
+def extended_item_id(version, input_id):
+    """The item id of the example carrying `input_id` in `version`."""
+
+    for item in version.items:
+        if item.input_id == input_id:
+            return item.item_id
+    raise AssertionError(f"No item with input_id {input_id}.")
+
+
+class TestPersistenceContract(DatasetVersionTestCase):
+    """The version tables must survive a reconnect, not just a live session."""
+
+    def test_versions_survive_a_reconnect(self):
+        version = self.publish(splits={"regression": ["case-1"]})
+
+        reopened = db_sqlalchemy.SQLAlchemyDB.from_db_url(
+            str(self.db.engine.url)
+        )
+        loaded = reopened.get_dataset_version(
+            dataset_version_id=version.dataset_version_id
+        )
+
+        self.assertEqual(loaded.item_count, 2)
+        self.assertEqual(loaded.content_hash, version.content_hash)
+        self.assertEqual(loaded.items[0].splits, ["regression"])
+        self.assertEqual(loaded.items[0].meta, {"topic": "product"})
+
+    def test_migration_creates_the_version_tables(self):
+        table_names = set(self.db.orm.metadata.tables)
+        self.assertIn("trulens_dataset_version", table_names)
+        self.assertIn("trulens_dataset_version_item", table_names)
+        self.assertEqual(self.db.get_db_revision(), "13")
+
+
+class TestRunProvenance(DatasetVersionTestCase):
+    """A run must be able to pin, report and read one exact snapshot."""
+
+    def setUp(self):
+        super().setUp()
+        self.dao = default_run_dao.DefaultRunDao(db=self.db)
+
+    def make_run(self, dataset_version_id=None, run_name="run_1"):
+        metadata_df = self.dao.create_new_run(
+            object_name="test_app",
+            object_type="APP",
+            object_version="v1",
+            run_name=run_name,
+            dataset_name="support-quality",
+            source_type="DATAFRAME",
+            dataset_spec=COLUMN_SPEC,
+            dataset_version_id=dataset_version_id,
+        )
+        return core_run.Run.from_metadata_df(
+            metadata_df,
+            {
+                "app": mock.MagicMock(),
+                "main_method_name": "invoke",
+                "run_dao": self.dao,
+                "tru_session": self.session,
+            },
+        )
+
+    def test_run_config_carries_a_version(self):
+        config = core_run.RunConfig(
+            run_name="r",
+            dataset_name="support-quality",
+            dataset_spec=COLUMN_SPEC,
+            dataset_version_id="dataset_version_hash_abc",
+        )
+        self.assertEqual(config.dataset_version_id, "dataset_version_hash_abc")
+
+    def test_run_config_version_is_optional(self):
+        config = core_run.RunConfig(
+            run_name="r",
+            dataset_name="support-quality",
+            dataset_spec=COLUMN_SPEC,
+        )
+        self.assertIsNone(config.dataset_version_id)
+
+    def test_pinned_version_is_persisted_and_reported(self):
+        version = self.publish()
+        run = self.make_run(dataset_version_id=version.dataset_version_id)
+
+        self.assertEqual(
+            run.source_info.dataset_version_id, version.dataset_version_id
+        )
+        self.assertEqual(
+            run.describe()["source_info"]["dataset_version_id"],
+            version.dataset_version_id,
+        )
+
+    def test_unpinned_run_source_info_is_unchanged(self):
+        run = self.make_run()
+
+        self.assertIsNone(run.source_info.dataset_version_id)
+        self.assertNotIn("dataset_version_id", run.describe()["source_info"])
+
+    def test_run_reads_the_pinned_snapshot(self):
+        version = self.publish()
+        run = self.make_run(dataset_version_id=version.dataset_version_id)
+
+        input_df = run._fetch_dataset_version_input_df()
+
+        self.assertEqual(
+            list(input_df["question"]),
+            ["what is trulens?", "how do i install it?"],
+        )
+        self.assertEqual(
+            list(input_df["expected_answer"]),
+            ["an evaluation library", "pip install trulens"],
+        )
+        self.assertEqual(list(input_df["case_id"]), ["case-1", "case-2"])
+
+    def test_pinned_snapshot_does_not_follow_later_versions(self):
+        pinned = self.publish()
+        run = self.make_run(dataset_version_id=pinned.dataset_version_id)
+
+        self.publish(dataframe=EXAMPLES.head(1))  # a newer version lands
+
+        self.assertEqual(len(run._fetch_dataset_version_input_df()), 2)
+
+    def test_missing_pinned_version_is_reported(self):
+        run = self.make_run(dataset_version_id="dataset_version_hash_missing")
+
+        with self.assertRaises(ValueError) as caught:
+            run._fetch_dataset_version_input_df()
+        self.assertIn("dataset_version_hash_missing", str(caught.exception))
+
+    def test_run_diff_exposes_both_versions(self):
+        diff = core_run.RunDiff(
+            run_a_name="a",
+            run_b_name="b",
+            dataset_version_id_a="dataset_version_hash_a",
+            dataset_version_id_b="dataset_version_hash_b",
+        )
+
+        provenance = diff.provenance()
+        self.assertEqual(list(provenance["run"]), ["a", "b"])
+        self.assertEqual(
+            list(provenance["dataset_version_id"]),
+            ["dataset_version_hash_a", "dataset_version_hash_b"],
+        )
+
+    def test_provenance_of_a_run_without_source_info(self):
+        # Comparison accepts anything run-shaped, including the minimal stubs
+        # used by the run-comparison tests, so a missing source info means "no
+        # pinned version" rather than an error.
+        self.assertIsNone(core_run._dataset_version_id_of(object()))
+        self.assertIsNone(
+            core_run._dataset_version_id_of(mock.MagicMock(spec=core_run.Run))
+        )
+
+    def test_run_diff_defaults_to_no_versions(self):
+        diff = core_run.RunDiff(run_a_name="a", run_b_name="b")
+
+        self.assertIsNone(diff.dataset_version_id_a)
+        self.assertIsNone(diff.dataset_version_id_b)
+        self.assertTrue(diff.provenance()["dataset_version_id"].isna().all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_dataset_versions.py
+++ b/tests/unit/test_dataset_versions.py
@@ -8,10 +8,13 @@ version lookup, membership comparison, and run source provenance.
 
 import os
 import tempfile
+import threading
+import time
 import unittest
 from unittest import mock
 
 import pandas as pd
+from sqlalchemy import exc as sa_exc
 from trulens.core import run as core_run
 from trulens.core import session as core_session
 from trulens.core.dao import default_run as default_run_dao
@@ -225,7 +228,8 @@ class TestContentAddressing(DatasetVersionTestCase):
 
     def test_missing_values_normalize_to_none(self):
         without = (
-            EXAMPLES.head(1)
+            EXAMPLES
+            .head(1)
             .drop(columns=["expected_answer"])
             .assign(expected_answer=None)
         )
@@ -666,6 +670,112 @@ def extended_item_id(version, input_id):
         if item.input_id == input_id:
             return item.item_id
     raise AssertionError(f"No item with input_id {input_id}.")
+
+
+class TestConcurrentPublishing(DatasetVersionTestCase):
+    """Concurrent publishes must serialize into a clean version history.
+
+    Picking the next `version_index` is a read-increment-write, so this races
+    it for real rather than asserting the intent.
+    """
+
+    def publish_from_threads(self, payloads):
+        """Publish each payload from its own thread, against its own db."""
+
+        db_path = os.path.join(self._tempdir.name, "trulens.sqlite")
+        barrier = threading.Barrier(len(payloads))
+        results = [None] * len(payloads)
+        errors = [None] * len(payloads)
+
+        def worker(index, dataframe):
+            # A separate engine per thread, so the publishes contend through
+            # the database rather than through one shared session.
+            db = db_sqlalchemy.SQLAlchemyDB.from_db_url(f"sqlite:///{db_path}")
+            version = dataset_schema.DatasetVersion(
+                dataset_id=self.dataset_id,
+                items=self.session._dataset_version_items_of_dataframe(
+                    dataframe, COLUMN_SPEC
+                ),
+                source_meta={"dataset_name": "support-quality"},
+                created_at=time.time(),
+            )
+            try:
+                barrier.wait(timeout=30)
+                results[index] = db.insert_dataset_version(version)
+            except Exception as e:  # noqa: BLE001 - reported via `errors`
+                errors[index] = e
+
+        threads = [
+            threading.Thread(target=worker, args=(i, payload))
+            for i, payload in enumerate(payloads)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+
+        return results, errors
+
+    def setUp(self):
+        super().setUp()
+        # Establish the dataset (and version zero) before racing.
+        self.publish()
+        self.dataset_id = self.db.get_dataset("support-quality").dataset_id
+
+    def _variant(self, answer: str) -> pd.DataFrame:
+        edited = EXAMPLES.copy()
+        edited.loc[0, "expected_answer"] = answer
+        return edited
+
+    def test_concurrent_distinct_publishes_all_succeed(self):
+        payloads = [self._variant(f"answer {i}") for i in range(4)]
+
+        results, errors = self.publish_from_threads(payloads)
+
+        self.assertEqual([e for e in errors if e is not None], [])
+        self.assertEqual(len([r for r in results if r]), len(payloads))
+
+    def test_concurrent_publishes_produce_a_gapless_history(self):
+        payloads = [self._variant(f"answer {i}") for i in range(4)]
+
+        self.publish_from_threads(payloads)
+
+        versions = self.session.list_dataset_versions(
+            dataset_name="support-quality"
+        )
+        indexes = sorted(versions["version_index"])
+        # Version zero plus one index per publish, each assigned exactly once.
+        self.assertEqual(indexes, list(range(len(indexes))))
+        self.assertEqual(len(set(indexes)), len(indexes))
+
+    def test_concurrent_identical_publishes_are_idempotent(self):
+        # Same content from every thread: one version, no duplicates, no error.
+        payloads = [self._variant("same answer") for _ in range(4)]
+
+        results, errors = self.publish_from_threads(payloads)
+
+        self.assertEqual([e for e in errors if e is not None], [])
+        self.assertEqual(len(set(r for r in results if r)), 1)
+
+        versions = self.session.list_dataset_versions(
+            dataset_name="support-quality"
+        )
+        self.assertEqual(len(versions), 2)  # version zero and the new one
+
+    def test_retry_budget_is_bounded(self):
+        # A publish that never wins its race must give up rather than spin.
+        with mock.patch.object(
+            self.db,
+            "_insert_dataset_version_once",
+            side_effect=sa_exc.IntegrityError("stmt", {}, Exception("dup")),
+        ) as attempt:
+            with self.assertRaises(sa_exc.IntegrityError):
+                self.publish(dataframe=self._variant("never lands"))
+
+        self.assertEqual(
+            attempt.call_count,
+            db_sqlalchemy._DATASET_VERSION_INSERT_ATTEMPTS,
+        )
 
 
 class TestPersistenceContract(DatasetVersionTestCase):


### PR DESCRIPTION
Closes #2701

## Problem

`Dataset` holds a stable identity while `GroundTruth` rows point straight at it, so adding or replacing examples changes the effective test set in place. An evaluation cannot be reproduced, and two runs cannot be compared with any confidence that they saw the same examples.

## What this adds

Immutable, content-addressed snapshots alongside the existing mutable tables.

- **`DatasetVersion` / `DatasetVersionItem`** (`schema/dataset.py`). A version id hashes the dataset, the ordered contents and the source metadata, so publishing identical content is idempotent and returns the existing version rather than duplicating or updating it. `description` and `parent_dataset_version_id` are provenance annotations and stay out of the hash.
- **Storage**: `dataset_version` and `dataset_version_item` tables, alembic revision `13`. `(dataset_id, version_index)` is unique so version history cannot fork, and `version_index` is the deterministic ordering key for latest-version resolution.
- **SDK**: `TruSession.create_dataset_version`, `get_dataset_version`, `list_dataset_versions`, `compare_dataset_versions`. Publishing accepts a DataFrame with a `column_spec`, or a `GroundTruth` sequence.
- **Run provenance**: optional `dataset_version_id` on `RunConfig` and `Run.SourceInfo`, persisted into run source info by both the OSS and Snowflake DAOs, read back by `run.start()`, and surfaced by `RunDiff.provenance()` — which warns when the two runs read different versions, since the deltas then mix app changes with test-set changes.
- **Docs**: a Dataset Versions component guide, plus updated schema and migration tables in `contributing/database.md`. API reference is generated from docstrings.

## Backward compatibility

Existing `Dataset` and `GroundTruth` rows are untouched. A dataset that predates versioning is exposed as **version zero**, reconstructed from its ground truth rows by a compatibility loader that reads but never rewrites the original payloads. Version zero is materialized as a real row on the first publish for that dataset, so it stays loadable afterwards and becomes the parent of the first published version.

The Snowflake `source_info` payload only carries `dataset_version_id` when a version is actually pinned, so unversioned runs send an unchanged payload.

## Three judgment calls worth reviewing

The issue left these underdetermined. Each is documented in the code; happy to flip any of them.

1. **Item identity excludes `meta` and `splits`.** The issue asks for ids from "normalized example content" but also that metadata "round-trip without changing item identity unexpectedly". If metadata were part of identity, re-tagging an example would show up in a diff as removed *and* added. So identity is `input` + `expected_response` + `expected_contexts` + `input_id`. To stop that from silently dropping annotations, the **version** hash covers the full per-item payload rather than only the ordered item ids as the issue literally specifies.

2. **`get_ground_truth(dataset_name=...)` is deliberately unchanged.** The issue says name-only calls should resolve to the latest version, but the acceptance criteria also require that current APIs keep working. Resolving to the latest version would mean that publishing a version of a *subset* silently narrows what existing callers read. Legacy semantics are kept and `dataset_version_id` is an opt-in parameter; latest-resolution applies to the new version-aware APIs.

3. **A dataset name can map to several rows**, because `dataset_id` hashes name *and* metadata. Versions hang off the primary row (lowest id) so that reading version zero and materializing it cannot disagree.

## Tests

58 unit tests in `tests/unit/test_dataset_versions.py` covering version creation from DataFrames and `GroundTruth` sequences, content hashing, idempotency, immutability, parent provenance, split and metadata round trips, version-zero compatibility, latest and exact lookup, membership comparison, and run source provenance.

A persistence-contract helper is wired into `tests/integration/test_database.py` for sqlite, postgres and mysql, asserting that a version round-trips to the same content hash it was stored under.

Verified locally: the new unit suite plus the existing run/DAO/dashboard tests pass, as does the sqlite persistence contract. Postgres and mysql need the `docker/test-database.yaml` services and will run in CI. `ruff format` and `ruff check` are clean.

## Unrelated bug noticed

`SQLAlchemyDB.get_datasets()` raises `AttributeError: 'Dataset' object has no attribute 'name'` — it reads `ds.name`/`ds.meta` off the ORM row, but those live inside `dataset_json`. This is broken on `main` today and is left alone here; this PR uses its own resolution path. Worth a separate fix.
