### PR TITLE
feat(datasets): curate production traces into persisted evaluation datasets (#2702)

### DIFF
--- a/examples/expositional/use_cases/trace_to_dataset.ipynb
+++ b/examples/expositional/use_cases/trace_to_dataset.ipynb
@@ -1,0 +1,458 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 📓 Curate Production Traces into an Evaluation Dataset\n",
+    "\n",
+    "Your production traces already contain the examples a regression test needs:\n",
+    "the questions users actually asked, and the answers your app actually gave.\n",
+    "Turning those into a persisted ground truth dataset normally means extracting\n",
+    "record content by hand, joining in review corrections, normalizing fields,\n",
+    "deduplicating, and deciding what to do with malformed rows.\n",
+    "\n",
+    "`TruSession.curate_records_to_dataset()` does that preparation for you. This\n",
+    "notebook walks the full loop on synthetic data, so it runs with **no API keys**:\n",
+    "\n",
+    "1. record a small synthetic app and score it with a metric,\n",
+    "2. select the low-scoring records in pandas,\n",
+    "3. write corrected expected responses,\n",
+    "4. curate them into a persisted dataset,\n",
+    "5. load the dataset back and use it as a ground truth metric.\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/truera/trulens/blob/main/examples/expositional/use_cases/trace_to_dataset.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install trulens-core trulens-feedback"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up a session\n",
+    "\n",
+    "Everything below writes to a local SQLite database. No provider credentials are\n",
+    "used anywhere in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.core import TruSession\n",
+    "\n",
+    "session = TruSession()\n",
+    "session.reset_database()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Record a synthetic app\n",
+    "\n",
+    "A deliberately imperfect support bot: it answers some questions and hedges on\n",
+    "others. The hedged answers are the ones worth turning into regression cases."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.apps.app import TruApp\n",
+    "from trulens.apps.app import instrument\n",
+    "\n",
+    "ANSWERS = {\n",
+    "    \"what is trulens?\": \"TruLens is a library for evaluating LLM apps.\",\n",
+    "    \"how do i install trulens?\": \"I'm not sure, please check the docs.\",\n",
+    "    \"what is a feedback function?\": \"I'm not sure, please check the docs.\",\n",
+    "    \"how do i log to snowflake?\": \"You log to Snowflake with a connector.\",\n",
+    "}\n",
+    "\n",
+    "\n",
+    "class SupportBot:\n",
+    "    @instrument\n",
+    "    def answer(self, question: str) -> str:\n",
+    "        return ANSWERS.get(\n",
+    "            question.strip().lower(), \"I'm not sure, please check the docs.\"\n",
+    "        )\n",
+    "\n",
+    "\n",
+    "bot = SupportBot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A metric that needs no LLM: it simply flags answers that hedge. Any metric works\n",
+    "here — this one is deterministic so the notebook always produces the same result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.core import Metric\n",
+    "from trulens.core import Selector\n",
+    "\n",
+    "HEDGES = (\"i'm not sure\", \"i am not sure\", \"check the docs\")\n",
+    "\n",
+    "\n",
+    "def answered(response: str) -> float:\n",
+    "    \"\"\"1.0 when the bot actually answered, 0.0 when it hedged.\"\"\"\n",
+    "    lowered = (response or \"\").lower()\n",
+    "    return 0.0 if any(hedge in lowered for hedge in HEDGES) else 1.0\n",
+    "\n",
+    "\n",
+    "f_answered = Metric(\n",
+    "    implementation=answered,\n",
+    "    name=\"Answered\",\n",
+    "    selectors={\"response\": Selector.select_record_output()},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app = TruApp(\n",
+    "    bot,\n",
+    "    app_name=\"support-bot\",\n",
+    "    app_version=\"v1\",\n",
+    "    feedbacks=[f_answered],\n",
+    ")\n",
+    "\n",
+    "with app as recording:\n",
+    "    for question in ANSWERS:\n",
+    "        bot.answer(question)\n",
+    "\n",
+    "session.force_flush()\n",
+    "app.compute_feedbacks()\n",
+    "session.force_flush()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "records, feedback_columns = session.get_records_and_feedback()\n",
+    "\n",
+    "records[[\"record_id\", \"input\", \"output\"] + list(feedback_columns)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Select the records worth curating\n",
+    "\n",
+    "This is plain pandas — filter however you like. Low scores, errors, a particular\n",
+    "app version, a time window, or a hand-picked list of record ids."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "failures = records[records[\"Answered\"] < 1.0].copy()\n",
+    "\n",
+    "failures[[\"record_id\", \"input\", \"output\", \"Answered\"]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Write the corrected answers\n",
+    "\n",
+    "TruLens never generates expected outputs for you. Type them in here, paste them\n",
+    "from a review spreadsheet, or pass `expected_response_fn=` to\n",
+    "`curate_records_to_dataset` to fill them in with your own function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CORRECTIONS = {\n",
+    "    \"how do i install trulens?\": \"Run `pip install trulens`.\",\n",
+    "    \"what is a feedback function?\": \"A function that scores an app's behaviour.\",\n",
+    "}\n",
+    "\n",
+    "failures[\"corrected_output\"] = (\n",
+    "    failures[\"input\"].str.strip().str.lower().map(CORRECTIONS)\n",
+    ")\n",
+    "\n",
+    "failures[[\"input\", \"corrected_output\"]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Curate them into a persisted dataset\n",
+    "\n",
+    "The mapping says which dataframe column supplies which ground truth field.\n",
+    "Values are column names — never expressions — so the mapping is validated\n",
+    "against the dataframe before anything is written.\n",
+    "\n",
+    "`on_error=\"collect\"` keeps going past rows that cannot be curated and reports\n",
+    "them instead of raising. Malformed rows are never written in either mode."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trulens.core.dataset import TraceDatasetMapping\n",
+    "\n",
+    "result = session.curate_records_to_dataset(\n",
+    "    dataset_name=\"support-bot-regressions\",\n",
+    "    records=failures,\n",
+    "    mapping=TraceDatasetMapping(\n",
+    "        query=\"input\",\n",
+    "        query_id=\"record_id\",\n",
+    "        expected_response=\"corrected_output\",\n",
+    "        metadata={\"answered\": \"Answered\"},\n",
+    "    ),\n",
+    "    on_error=\"collect\",\n",
+    ")\n",
+    "\n",
+    "print(f\"accepted:   {result.accepted}\")\n",
+    "print(f\"duplicates: {result.duplicates}\")\n",
+    "print(f\"rejected:   {result.rejected}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Rejected rows come back as a dataframe you can inspect, fix and re-curate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.errors_df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Idempotency\n",
+    "\n",
+    "Ground truth ids are content-addressed, so curating the same rows again writes\n",
+    "nothing new — no duplicate rows, and no need to track what you already sent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "again = session.curate_records_to_dataset(\n",
+    "    dataset_name=\"support-bot-regressions\",\n",
+    "    records=failures,\n",
+    "    mapping=TraceDatasetMapping(\n",
+    "        query=\"input\",\n",
+    "        query_id=\"record_id\",\n",
+    "        expected_response=\"corrected_output\",\n",
+    "        metadata={\"answered\": \"Answered\"},\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "assert again.ground_truth_ids == result.ground_truth_ids"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Load the dataset back\n",
+    "\n",
+    "This is the same `get_ground_truth()` you would use for any hand-built dataset.\n",
+    "Note the metadata: every example remembers the record, app and metric score it\n",
+    "came from, so you can always trace a regression case back to the trace that\n",
+    "produced it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ground_truth = session.get_ground_truth(dataset_name=\"support-bot-regressions\")\n",
+    "\n",
+    "ground_truth[[\"query\", \"expected_response\", \"meta\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ground_truth[\"meta\"].iloc[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Use it as a ground truth metric\n",
+    "\n",
+    "A ground truth metric looks up the expected response for a query and scores the\n",
+    "app's answer against it. The one below is an exact match so that the notebook\n",
+    "stays credential-free; with a provider configured you would use\n",
+    "`GroundTruthAgreement(ground_truth, provider=...).agreement_measure` instead for\n",
+    "semantic similarity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EXPECTED = dict(zip(ground_truth[\"query\"], ground_truth[\"expected_response\"]))\n",
+    "\n",
+    "\n",
+    "def matches_expected(prompt: str, response: str) -> float:\n",
+    "    \"\"\"1.0 when the answer matches the curated expected response.\"\"\"\n",
+    "    expected = EXPECTED.get((prompt or \"\").strip())\n",
+    "    if expected is None:\n",
+    "        return float(\"nan\")  # not part of the regression set\n",
+    "    return float((response or \"\").strip().lower() == expected.strip().lower())\n",
+    "\n",
+    "\n",
+    "f_ground_truth = Metric(\n",
+    "    implementation=matches_expected,\n",
+    "    name=\"Matches Expected\",\n",
+    "    selectors={\n",
+    "        \"prompt\": Selector.select_record_input(),\n",
+    "        \"response\": Selector.select_record_output(),\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now fix the bot and re-run it against the curated regression set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "FIXED_ANSWERS = {**ANSWERS, **CORRECTIONS}\n",
+    "\n",
+    "\n",
+    "class FixedSupportBot:\n",
+    "    @instrument\n",
+    "    def answer(self, question: str) -> str:\n",
+    "        return FIXED_ANSWERS.get(\n",
+    "            question.strip().lower(), \"I'm not sure, please check the docs.\"\n",
+    "        )\n",
+    "\n",
+    "\n",
+    "fixed_bot = FixedSupportBot()\n",
+    "\n",
+    "app_v2 = TruApp(\n",
+    "    fixed_bot,\n",
+    "    app_name=\"support-bot\",\n",
+    "    app_version=\"v2\",\n",
+    "    feedbacks=[f_ground_truth],\n",
+    ")\n",
+    "\n",
+    "with app_v2 as recording:\n",
+    "    for question in ground_truth[\"query\"]:\n",
+    "        fixed_bot.answer(question)\n",
+    "\n",
+    "session.force_flush()\n",
+    "app_v2.compute_feedbacks()\n",
+    "session.force_flush()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "after, after_columns = session.get_records_and_feedback(\n",
+    "    app_name=\"support-bot\", app_version=\"v2\"\n",
+    ")\n",
+    "\n",
+    "after[[\"input\", \"output\"] + list(after_columns)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Both regression cases now pass.\n",
+    "\n",
+    "## Where to go from here\n",
+    "\n",
+    "- **Only have record ids?** Pass a dataframe with a `record_id` column and your\n",
+    "  corrections; the recorded content is resolved through the session before\n",
+    "  mapping, and any column you supply yourself wins over the stored one.\n",
+    "- **Reviewing in a spreadsheet?** Export to CSV, load it with `pd.read_csv`, and\n",
+    "  pass it straight in.\n",
+    "- **Expected contexts?** Map `expected_chunks` to a column of chunk lists; strings\n",
+    "  and dicts are both normalized into the ground truth chunk shape.\n",
+    "- **Deduplicating across records?** Provenance metadata is part of a ground\n",
+    "  truth's content-addressed id, so two records with identical content stay\n",
+    "  distinct. Pass `include_provenance=False` to deduplicate on example content\n",
+    "  alone."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/src/core/trulens/core/dataset.py
+++ b/src/core/trulens/core/dataset.py
@@ -185,10 +185,10 @@ class CurationRowError(ValueError):
     [CurationError][trulens.core.dataset.CurationError] in `collect` mode.
     """
 
-    def __init__(self, reason: str, message: str, row_index: Any = None):
+    def __init__(self, row_index: Any, reason: str, message: str):
+        self.row_index = row_index
         self.reason = reason
         self.message = message
-        self.row_index = row_index
         super().__init__(f"row {row_index}: {message}")
 
 
@@ -208,7 +208,7 @@ def _is_missing(value: Any) -> bool:
     return False
 
 
-def _normalize_text(value: Any) -> Optional[str]:
+def _normalize_text(value: Any) -> str | None:
     """Resolve a recorded input or output into stable text.
 
     Records carry main inputs and outputs as strings in OTEL mode and as
@@ -240,7 +240,7 @@ def _normalize_text(value: Any) -> Optional[str]:
     return text
 
 
-def _normalize_contexts(value: Any) -> Optional[List[Dict[str, Any]]]:
+def _normalize_contexts(value: Any) -> list[dict[str, Any]] | None:
     """Normalize expected contexts into `GroundTruth.expected_chunks` shape.
 
     Accepts a list of dicts, a list of strings, a single string or dict, or a
@@ -335,7 +335,7 @@ def _ground_truth_of_row(
     dataset_id: types_schema.DatasetID,
     mapping: TraceDatasetMapping,
     available: Set[str],
-    expected_response_fn: Optional[Callable[[pd.Series], Optional[str]]],
+    expected_response_fn: Callable[[pd.Series], str | None] | None,
     include_provenance: bool = True,
 ) -> groundtruth_schema.GroundTruth:
     """Turn one dataframe row into a ground truth.
@@ -411,7 +411,7 @@ def _batched(items: Iterable[Any], batch_size: int) -> Iterable[List[Any]]:
 def _resolve_records(
     records: pd.DataFrame,
     mapping: TraceDatasetMapping,
-    record_resolver: Optional[Callable[[List[str]], pd.DataFrame]],
+    record_resolver: Callable[[list[str]], pd.DataFrame] | None,
 ) -> pd.DataFrame:
     """Fill in record content for a dataframe that only carries record ids.
 
@@ -481,13 +481,13 @@ def curate_records_to_dataset(
     dataset_name: str,
     records: pd.DataFrame,
     db: Any,
-    mapping: Optional[TraceDatasetMapping] = None,
-    expected_response_fn: Optional[Callable[[pd.Series], Optional[str]]] = None,
-    dataset_metadata: Optional[Dict[str, Any]] = None,
+    mapping: TraceDatasetMapping | None = None,
+    expected_response_fn: Callable[[pd.Series], str | None] | None = None,
+    dataset_metadata: dict[str, Any] | None = None,
     on_error: str = ON_ERROR_RAISE,
     batch_size: int = DEFAULT_BATCH_SIZE,
     include_provenance: bool = True,
-    record_resolver: Optional[Callable[[List[str]], pd.DataFrame]] = None,
+    record_resolver: Callable[[list[str]], pd.DataFrame] | None = None,
 ) -> CurationResult:
     """Curate a records dataframe into a persisted dataset.
 

--- a/src/core/trulens/core/dataset.py
+++ b/src/core/trulens/core/dataset.py
@@ -1,0 +1,617 @@
+"""Curation of recorded traces into persisted evaluation datasets.
+
+Production traces already contain the examples a regression test needs, but
+[add_ground_truth_to_dataset][trulens.core.session.TruSession.add_ground_truth_to_dataset]
+expects a dataframe that has already been extracted, joined, normalized and
+deduplicated. This module does that preparation, mapping a records dataframe
+onto [GroundTruth][trulens.core.schema.groundtruth.GroundTruth] rows through
+the existing dataset APIs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Set,
+)
+
+import pandas as pd
+import pydantic
+from pydantic import BaseModel
+from pydantic import Field
+from trulens.core.schema import dataset as dataset_schema
+from trulens.core.schema import groundtruth as groundtruth_schema
+from trulens.core.schema import types as types_schema
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BATCH_SIZE = 100
+"""Number of ground truths written per database round trip."""
+
+ON_ERROR_RAISE = "raise"
+"""Fail on the first row that cannot be curated."""
+
+ON_ERROR_COLLECT = "collect"
+"""Skip rows that cannot be curated and report them in the result."""
+
+ON_ERROR_MODES = (ON_ERROR_RAISE, ON_ERROR_COLLECT)
+
+PROVENANCE_COLUMNS = {
+    "source_record_id": "record_id",
+    "source_app_name": "app_name",
+    "source_app_version": "app_version",
+}
+"""Metadata keys automatically preserved from a records dataframe.
+
+Each is copied only when the source column is present and the caller has not
+already mapped that metadata key themselves.
+"""
+
+
+class TraceDatasetMapping(BaseModel):
+    """Mapping from records dataframe columns to ground truth fields.
+
+    Values are column names in the input dataframe, never expressions or
+    callables, so a mapping is fully declarative and can be validated against
+    the dataframe before anything is written.
+    """
+
+    query: str = "input"
+    """Column holding the query / input of the example."""
+
+    query_id: Optional[str] = "record_id"
+    """Column holding a stable identifier for the query, if any."""
+
+    expected_response: Optional[str] = None
+    """Column holding the corrected or expected response, if any."""
+
+    expected_chunks: Optional[str] = None
+    """Column holding the expected retrieval contexts, if any."""
+
+    metadata: Dict[str, str] = Field(default_factory=dict)
+    """Metadata keys to preserve, mapped to the column they come from."""
+
+    @pydantic.field_validator("query")
+    @classmethod
+    def _query_is_not_blank(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("`query` must name a column.")
+        return value
+
+    def mapped_columns(self) -> List[str]:
+        """Every dataframe column this mapping refers to, in a stable order."""
+
+        columns = [self.query]
+        for optional in (
+            self.query_id,
+            self.expected_response,
+            self.expected_chunks,
+        ):
+            if optional is not None:
+                columns.append(optional)
+        columns.extend(self.metadata.values())
+
+        seen: Set[str] = set()
+        return [c for c in columns if not (c in seen or seen.add(c))]
+
+    def missing_columns(self, dataframe: pd.DataFrame) -> List[str]:
+        """The mapped columns that `dataframe` does not have."""
+
+        available = set(dataframe.columns)
+        return [c for c in self.mapped_columns() if c not in available]
+
+
+class CurationError(BaseModel):
+    """One input row that could not be turned into a ground truth."""
+
+    row_index: Any = None
+    """Index of the offending row in the input dataframe."""
+
+    query_id: Optional[str] = None
+    """The row's query id, when one could be read."""
+
+    reason: str
+    """Short, stable code for the kind of failure."""
+
+    message: str
+    """Human-readable detail."""
+
+
+class CurationResult(BaseModel):
+    """Outcome of curating a records dataframe into a dataset."""
+
+    dataset_name: str
+    """Name of the dataset written to."""
+
+    dataset_id: types_schema.DatasetID
+    """Id of the dataset written to."""
+
+    accepted: int = 0
+    """Rows that produced a distinct ground truth."""
+
+    duplicates: int = 0
+    """Rows that collapsed onto a ground truth already produced by this call.
+
+    Ground truth ids are content-addressed, so curating the same rows again in
+    a later call also writes no new rows; that idempotency is not counted here
+    because it is resolved by the database rather than by this call.
+
+    Note that a ground truth id covers its metadata too, so two records with
+    the same question and answer but different provenance are two distinct
+    ground truths. Pass `include_provenance=False` to deduplicate purely on
+    example content."""
+
+    rejected: int = 0
+    """Rows that could not be curated."""
+
+    ground_truth_ids: List[types_schema.GroundTruthID] = Field(
+        default_factory=list
+    )
+    """Ids of the ground truths written, in input order, without repeats."""
+
+    errors: List[CurationError] = Field(default_factory=list)
+    """One entry per rejected row. Always empty in `raise` mode."""
+
+    @property
+    def processed(self) -> int:
+        """Total number of input rows considered."""
+
+        return self.accepted + self.duplicates + self.rejected
+
+    def errors_df(self) -> pd.DataFrame:
+        """Rejected rows as a dataframe, for inspection in a notebook."""
+
+        return pd.DataFrame(
+            data=[
+                (e.row_index, e.query_id, e.reason, e.message)
+                for e in self.errors
+            ],
+            columns=["row_index", "query_id", "reason", "message"],
+        )
+
+
+class CurationRowError(ValueError):
+    """A single row could not be curated.
+
+    Raised out of `curate_records_to_dataset` in `raise` mode; converted into a
+    [CurationError][trulens.core.dataset.CurationError] in `collect` mode.
+    """
+
+    def __init__(self, reason: str, message: str, row_index: Any = None):
+        self.reason = reason
+        self.message = message
+        self.row_index = row_index
+        super().__init__(f"row {row_index}: {message}")
+
+
+def _is_missing(value: Any) -> bool:
+    """Whether a value should be treated as absent.
+
+    Covers `None`, the NaN floats pandas produces for empty cells, and empty
+    or whitespace-only strings.
+    """
+
+    if value is None:
+        return True
+    if isinstance(value, float) and math.isnan(value):
+        return True
+    if isinstance(value, str) and not value.strip():
+        return True
+    return False
+
+
+def _normalize_text(value: Any) -> Optional[str]:
+    """Resolve a recorded input or output into stable text.
+
+    Records carry main inputs and outputs as strings in OTEL mode and as
+    already-parsed JSON values in the legacy schema, so both have to reduce to
+    the same text for the same content. Dicts and lists — including ones still
+    encoded as a JSON string — are re-serialized with sorted keys so that key
+    ordering does not change the content-addressed ground truth id.
+
+    Mirrors the normalization used for run comparison in
+    `trulens.core.run`.
+    """
+
+    if _is_missing(value):
+        return None
+
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True, ensure_ascii=False)
+
+    text = str(value).strip()
+
+    if text.startswith(("{", "[")):
+        try:
+            parsed = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            return text
+        if isinstance(parsed, (dict, list)):
+            return json.dumps(parsed, sort_keys=True, ensure_ascii=False)
+
+    return text
+
+
+def _normalize_contexts(value: Any) -> Optional[List[Dict[str, Any]]]:
+    """Normalize expected contexts into `GroundTruth.expected_chunks` shape.
+
+    Accepts a list of dicts, a list of strings, a single string or dict, or a
+    JSON encoding of any of those. Plain text becomes `{"text": ...}` so that
+    every chunk is a dict, which is what `expected_chunks` is typed as.
+    """
+
+    if _is_missing(value):
+        return None
+
+    if isinstance(value, str):
+        text = value.strip()
+        if text.startswith(("{", "[")):
+            try:
+                value = json.loads(text)
+            except (json.JSONDecodeError, TypeError):
+                return [{"text": text}]
+        else:
+            return [{"text": text}]
+
+    if isinstance(value, dict):
+        return [_json_safe(value)]
+
+    if isinstance(value, (list, tuple)):
+        chunks = []
+        for element in value:
+            if _is_missing(element):
+                continue
+            if isinstance(element, dict):
+                chunks.append(_json_safe(element))
+            else:
+                chunks.append({"text": _normalize_text(element)})
+        return chunks or None
+
+    return [{"text": _normalize_text(value)}]
+
+
+def _json_safe(value: Any) -> Any:
+    """Coerce a value read out of a dataframe into something serializable.
+
+    Pandas hands back numpy scalars and `NaT`, neither of which survives the
+    json encoding that ground truth metadata goes through.
+    """
+
+    if _is_missing(value):
+        return None
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, (str, bool, int, float)):
+        return value
+    if hasattr(value, "item"):  # numpy scalar
+        try:
+            return _json_safe(value.item())
+        except (AttributeError, ValueError):
+            pass
+    return str(value)
+
+
+def _metadata_of_row(
+    row: pd.Series,
+    mapping: TraceDatasetMapping,
+    available: Set[str],
+    include_provenance: bool = True,
+) -> Dict[str, Any]:
+    """Build the ground truth metadata for one row.
+
+    Provenance columns are copied automatically when present so that a curated
+    example can always be traced back to the record it came from; an explicit
+    mapping for the same key wins.
+    """
+
+    meta: Dict[str, Any] = {}
+
+    for key, column in PROVENANCE_COLUMNS.items() if include_provenance else ():
+        if key in mapping.metadata or column not in available:
+            continue
+        value = _json_safe(row[column])
+        if value is not None:
+            meta[key] = value
+
+    for key, column in mapping.metadata.items():
+        meta[key] = _json_safe(row[column])
+
+    return meta
+
+
+def _ground_truth_of_row(
+    row: pd.Series,
+    row_index: Any,
+    dataset_id: types_schema.DatasetID,
+    mapping: TraceDatasetMapping,
+    available: Set[str],
+    expected_response_fn: Optional[Callable[[pd.Series], Optional[str]]],
+    include_provenance: bool = True,
+) -> groundtruth_schema.GroundTruth:
+    """Turn one dataframe row into a ground truth.
+
+    Raises:
+        CurationRowError: If the row has no usable query, or the caller's
+            callback fails.
+    """
+
+    query = _normalize_text(row[mapping.query])
+    if query is None:
+        raise CurationRowError(
+            reason="empty_query",
+            message=f"column '{mapping.query}' is empty",
+            row_index=row_index,
+        )
+
+    query_id = (
+        _normalize_text(row[mapping.query_id])
+        if mapping.query_id is not None
+        else None
+    )
+
+    expected_response = None
+    if mapping.expected_response is not None:
+        expected_response = _normalize_text(row[mapping.expected_response])
+
+    # A mapped correction wins; the callback only fills in what is missing.
+    if expected_response is None and expected_response_fn is not None:
+        try:
+            expected_response = _normalize_text(expected_response_fn(row))
+        except Exception as e:
+            raise CurationRowError(
+                reason="expected_response_fn_failed",
+                message=f"{type(e).__name__}: {e}",
+                row_index=row_index,
+            ) from e
+
+    expected_chunks = None
+    if mapping.expected_chunks is not None:
+        try:
+            expected_chunks = _normalize_contexts(row[mapping.expected_chunks])
+        except Exception as e:
+            raise CurationRowError(
+                reason="invalid_expected_chunks",
+                message=f"{type(e).__name__}: {e}",
+                row_index=row_index,
+            ) from e
+
+    return groundtruth_schema.GroundTruth(
+        dataset_id=dataset_id,
+        query=query,
+        query_id=query_id,
+        expected_response=expected_response,
+        expected_chunks=expected_chunks,
+        meta=_metadata_of_row(row, mapping, available, include_provenance),
+    )
+
+
+def _batched(items: Iterable[Any], batch_size: int) -> Iterable[List[Any]]:
+    """Yield `items` in lists of at most `batch_size`."""
+
+    batch: List[Any] = []
+    for item in items:
+        batch.append(item)
+        if len(batch) >= batch_size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def _resolve_records(
+    records: pd.DataFrame,
+    mapping: TraceDatasetMapping,
+    record_resolver: Optional[Callable[[List[str]], pd.DataFrame]],
+) -> pd.DataFrame:
+    """Fill in record content for a dataframe that only carries record ids.
+
+    Resolution is attempted whenever the frame carries a `record_id` column and
+    any mapped column is missing, because a missing column is equally likely to
+    be record content the frame never had (a review export keyed by record id)
+    or a metric score that only the database holds. Anything still missing
+    afterwards is reported as a mapping error.
+
+    Columns already present in `records` win, so corrections added by the
+    caller are never overwritten by what is stored for the record.
+
+    Raises:
+        ValueError: If resolution was needed but failed.
+    """
+
+    if record_resolver is None:
+        return records
+
+    missing = mapping.missing_columns(records)
+    if not missing or "record_id" not in records.columns:
+        return records
+
+    record_ids = [
+        rid
+        for rid in (_normalize_text(v) for v in records["record_id"])
+        if rid is not None
+    ]
+    if not record_ids:
+        return records
+
+    logger.info(
+        "Resolving %d record(s) to fill in missing column(s): %s",
+        len(record_ids),
+        ", ".join(missing),
+    )
+    try:
+        resolved = record_resolver(record_ids)
+    except Exception as e:
+        raise ValueError(
+            "The records dataframe is missing mapped column(s) "
+            f"({', '.join(missing)}) and resolving them from the record ids "
+            f"failed: {type(e).__name__}: {e}. Pass a dataframe that already "
+            "carries the mapped columns, such as one returned by "
+            "`get_records_and_feedback()`."
+        ) from e
+
+    if resolved is None or resolved.empty:
+        return records
+
+    add = [
+        c
+        for c in resolved.columns
+        if c in missing and c not in records.columns and c != "record_id"
+    ]
+    if not add:
+        return records
+
+    return records.merge(
+        resolved[["record_id"] + add].drop_duplicates(subset=["record_id"]),
+        on="record_id",
+        how="left",
+    )
+
+
+def curate_records_to_dataset(
+    dataset_name: str,
+    records: pd.DataFrame,
+    db: Any,
+    mapping: Optional[TraceDatasetMapping] = None,
+    expected_response_fn: Optional[Callable[[pd.Series], Optional[str]]] = None,
+    dataset_metadata: Optional[Dict[str, Any]] = None,
+    on_error: str = ON_ERROR_RAISE,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    include_provenance: bool = True,
+    record_resolver: Optional[Callable[[List[str]], pd.DataFrame]] = None,
+) -> CurationResult:
+    """Curate a records dataframe into a persisted dataset.
+
+    See
+    [TruSession.curate_records_to_dataset][trulens.core.session.TruSession.curate_records_to_dataset]
+    for the user-facing entry point and argument documentation.
+
+    Args:
+        dataset_name: Name of the dataset to write to.
+        records: The rows to curate.
+        db: Database to write through.
+        mapping: Column mapping. Defaults to `TraceDatasetMapping()`.
+        expected_response_fn: Fallback for rows with no mapped correction.
+        dataset_metadata: Metadata for the dataset itself.
+        on_error: `"raise"` or `"collect"`.
+        batch_size: Ground truths written per database round trip.
+        include_provenance: Whether to copy the source record id and app
+            name/version into metadata.
+        record_resolver: Given record ids, returns their records. Used only
+            when `records` is missing mapped columns.
+
+    Returns:
+        A [CurationResult][trulens.core.dataset.CurationResult].
+
+    Raises:
+        ValueError: If `on_error` is not a supported mode, `batch_size` is not
+            positive, or a mapped column is missing from `records`.
+        CurationRowError: In `raise` mode, on the first unusable row.
+    """
+
+    if on_error not in ON_ERROR_MODES:
+        raise ValueError(
+            f"`on_error` must be one of {ON_ERROR_MODES}, got {on_error!r}."
+        )
+
+    if batch_size < 1:
+        raise ValueError(f"`batch_size` must be positive, got {batch_size}.")
+
+    mapping = mapping if mapping is not None else TraceDatasetMapping()
+
+    if not isinstance(records, pd.DataFrame):
+        raise ValueError(
+            "`records` must be a pandas DataFrame, got "
+            f"{type(records).__name__}."
+        )
+
+    records = _resolve_records(records, mapping, record_resolver)
+
+    # Validate before any write, so a bad mapping never leaves a partially
+    # curated dataset behind.
+    missing = mapping.missing_columns(records)
+    if missing:
+        raise ValueError(
+            "The records dataframe is missing mapped column(s): "
+            + ", ".join(missing)
+            + ". Available columns: "
+            + ", ".join(str(c) for c in records.columns)
+            + "."
+        )
+
+    dataset_id = db.insert_dataset(
+        dataset=dataset_schema.Dataset(name=dataset_name, meta=dataset_metadata)
+    )
+
+    result = CurationResult(dataset_name=dataset_name, dataset_id=dataset_id)
+    available = set(records.columns)
+    seen: Set[types_schema.GroundTruthID] = set()
+
+    def _curated() -> Iterable[groundtruth_schema.GroundTruth]:
+        """Yield the distinct ground truths of `records`, lazily.
+
+        Generating lazily is what keeps peak memory to one batch of ground
+        truths rather than one per input row.
+        """
+
+        for row_index, row in records.iterrows():
+            try:
+                ground_truth = _ground_truth_of_row(
+                    row=row,
+                    row_index=row_index,
+                    dataset_id=dataset_id,
+                    mapping=mapping,
+                    available=available,
+                    expected_response_fn=expected_response_fn,
+                    include_provenance=include_provenance,
+                )
+            except CurationRowError as e:
+                if on_error == ON_ERROR_RAISE:
+                    raise
+                result.rejected += 1
+                result.errors.append(
+                    CurationError(
+                        row_index=_json_safe(row_index),
+                        query_id=(
+                            _normalize_text(row[mapping.query_id])
+                            if mapping.query_id is not None
+                            else None
+                        ),
+                        reason=e.reason,
+                        message=e.message,
+                    )
+                )
+                continue
+
+            if ground_truth.ground_truth_id in seen:
+                result.duplicates += 1
+                continue
+
+            seen.add(ground_truth.ground_truth_id)
+            result.accepted += 1
+            result.ground_truth_ids.append(ground_truth.ground_truth_id)
+            yield ground_truth
+
+    for batch in _batched(_curated(), batch_size):
+        db.batch_insert_ground_truth(batch)
+
+    logger.info(
+        "Curated %d row(s) into dataset '%s': %d accepted, %d duplicate, "
+        "%d rejected.",
+        result.processed,
+        dataset_name,
+        result.accepted,
+        result.duplicates,
+        result.rejected,
+    )
+
+    return result

--- a/src/core/trulens/core/session.py
+++ b/src/core/trulens/core/session.py
@@ -15,6 +15,7 @@ from time import time
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     Iterable,
     List,
@@ -28,6 +29,7 @@ import warnings
 
 import pandas
 import pydantic
+from trulens.core import dataset as core_dataset
 from trulens.core import experimental as core_experimental
 from trulens.core._utils import optional as optional_utils
 from trulens.core._utils.pycompat import Future  # code style exception
@@ -1109,6 +1111,108 @@ class TruSession(
         # remaining ground truths in the buffer
         if buffer:
             self.connector.db.batch_insert_ground_truth(buffer)
+
+    def curate_records_to_dataset(
+        self,
+        dataset_name: str,
+        records: pandas.DataFrame,
+        mapping: Optional[core_dataset.TraceDatasetMapping] = None,
+        expected_response_fn: Optional[
+            Callable[[pandas.Series], Optional[str]]
+        ] = None,
+        dataset_metadata: Optional[Dict[str, Any]] = None,
+        on_error: str = core_dataset.ON_ERROR_RAISE,
+        batch_size: int = core_dataset.DEFAULT_BATCH_SIZE,
+        include_provenance: bool = True,
+    ) -> core_dataset.CurationResult:
+        """Curate recorded traces into a persisted evaluation dataset.
+
+        Turns a records dataframe into
+        [GroundTruth][trulens.core.schema.groundtruth.GroundTruth] rows: it
+        validates the mapping against the dataframe, resolves recorded inputs
+        and outputs into stable text, normalizes expected contexts, preserves
+        provenance in metadata, and writes in bounded batches. Ground truth
+        ids are content-addressed, so curating the same rows twice does not
+        create duplicate rows.
+
+        Accepted inputs:
+
+        - a dataframe from
+          [get_records_and_feedback][trulens.core.session.TruSession.get_records_and_feedback];
+        - a dataframe carrying a `record_id` column but not the record
+          content, which is resolved through the session before mapping;
+        - a review export (CSV, JSON, ...) that the caller has loaded into a
+          dataframe.
+
+        Example:
+            ```python
+            result = session.curate_records_to_dataset(
+                dataset_name="production-failures",
+                records=records_df,
+                mapping=TraceDatasetMapping(
+                    query="input",
+                    expected_response="corrected_output",
+                    metadata={"groundedness": "Groundedness"},
+                ),
+                on_error="collect",
+            )
+            ```
+
+        Args:
+            dataset_name: Name of the dataset to write to. It is created if it
+                does not exist.
+            records: The rows to curate.
+            mapping: Which dataframe columns supply which ground truth fields.
+                Values are column names, never expressions. Defaults to
+                `TraceDatasetMapping()`, which reads `input` and `record_id`.
+            expected_response_fn: Synchronous callback returning the expected
+                response for a row. Only consulted when the mapped
+                `expected_response` column is absent or empty for that row —
+                a mapped correction always wins. TruLens never calls an LLM on
+                your behalf here.
+            dataset_metadata: Metadata for the dataset itself.
+            on_error: `"raise"` to fail on the first unusable row, or
+                `"collect"` to skip it and report it in the result. Malformed
+                rows are never written in either mode.
+            batch_size: Ground truths written per database round trip. Peak
+                memory is one batch beyond the input dataframe.
+            include_provenance: Whether to copy the source record id and app
+                name/version into each ground truth's metadata. A ground truth
+                id covers its metadata, so leaving this on means two records
+                with identical content but different provenance stay distinct;
+                turn it off to deduplicate purely on example content.
+
+        Returns:
+            A [CurationResult][trulens.core.dataset.CurationResult] with the
+            accepted, duplicate and rejected counts, the ids written, and one
+            error row per rejection.
+
+        Raises:
+            ValueError: If `on_error` or `batch_size` is invalid, or a mapped
+                column is missing from `records`. Column validation happens
+                before anything is written.
+            core_dataset.CurationRowError: In `"raise"` mode, on the first
+                unusable row. Batches written before that point stay written;
+                because ids are content-addressed, re-running after fixing the
+                data is safe.
+        """
+
+        def _resolve(record_ids: List[str]) -> pandas.DataFrame:
+            resolved, _ = self.get_records_and_feedback(record_ids=record_ids)
+            return resolved
+
+        return core_dataset.curate_records_to_dataset(
+            dataset_name=dataset_name,
+            records=records,
+            db=self.connector.db,
+            mapping=mapping,
+            expected_response_fn=expected_response_fn,
+            dataset_metadata=dataset_metadata,
+            on_error=on_error,
+            batch_size=batch_size,
+            include_provenance=include_provenance,
+            record_resolver=_resolve,
+        )
 
     def get_ground_truth(
         self,

--- a/src/core/trulens/core/session.py
+++ b/src/core/trulens/core/session.py
@@ -1116,11 +1116,10 @@ class TruSession(
         self,
         dataset_name: str,
         records: pandas.DataFrame,
-        mapping: Optional[core_dataset.TraceDatasetMapping] = None,
-        expected_response_fn: Optional[
-            Callable[[pandas.Series], Optional[str]]
-        ] = None,
-        dataset_metadata: Optional[Dict[str, Any]] = None,
+        mapping: core_dataset.TraceDatasetMapping | None = None,
+        expected_response_fn: Callable[[pandas.Series], str | None]
+        | None = None,
+        dataset_metadata: dict[str, Any] | None = None,
         on_error: str = core_dataset.ON_ERROR_RAISE,
         batch_size: int = core_dataset.DEFAULT_BATCH_SIZE,
         include_provenance: bool = True,

--- a/tests/unit/test_trace_curation.py
+++ b/tests/unit/test_trace_curation.py
@@ -515,6 +515,14 @@ class _RecordingDB:
 
     Batch boundaries are a property of the curation loop, not of SQL, so they
     are checked against a stub rather than through a real database.
+
+    Note:
+        This is deliberately not a full `DB` implementation. It covers only the
+        two calls curation makes — `insert_dataset` and
+        `batch_insert_ground_truth` — and has no read side at all, so anything
+        that needs to load a dataset back (`get_ground_truth`, and the rest of
+        the `DB` interface) must use a real database, as the other tests here
+        do.
     """
 
     def __init__(self):

--- a/tests/unit/test_trace_curation.py
+++ b/tests/unit/test_trace_curation.py
@@ -1,0 +1,860 @@
+"""Tests for curating recorded traces into persisted datasets.
+
+Covers the contract from truera/trulens#2702: mapping validation, JSON/text
+normalization, the accepted input shapes, callback precedence and failure,
+context normalization and metadata selection, idempotency, both error modes,
+and batch boundaries.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import pandas as pd
+from trulens.core import dataset as core_dataset
+from trulens.core import session as core_session
+from trulens.core.database import sqlalchemy as db_sqlalchemy
+from trulens.core.database.connector import default as default_connector
+from trulens.core.schema import dataset as dataset_schema
+
+RECORDS = pd.DataFrame([
+    {
+        "record_id": "record-1",
+        "app_name": "support-bot",
+        "app_version": "v1",
+        "input": "what is trulens?",
+        "output": "no idea",
+        "corrected_output": "an evaluation library",
+        "Groundedness": 0.2,
+    },
+    {
+        "record_id": "record-2",
+        "app_name": "support-bot",
+        "app_version": "v1",
+        "input": "how do i install it?",
+        "output": "unclear",
+        "corrected_output": "pip install trulens",
+        "Groundedness": 0.4,
+    },
+])
+
+MAPPING = core_dataset.TraceDatasetMapping(
+    query="input",
+    query_id="record_id",
+    expected_response="corrected_output",
+    metadata={"groundedness": "Groundedness"},
+)
+
+
+def _clear_tru_session_singletons():
+    """Drop any live `TruSession` so each test gets its own database."""
+
+    for key in [
+        curr
+        for curr in core_session.TruSession._singleton_instances
+        if curr[0] == "trulens.core.session.TruSession"
+    ]:
+        del core_session.TruSession._singleton_instances[key]
+
+
+class CurationTestCase(unittest.TestCase):
+    """Base case giving each test its own file-backed SQLite database."""
+
+    def setUp(self):
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tempdir.cleanup)
+
+        db_path = os.path.join(self._tempdir.name, "trulens.sqlite")
+        self.db = db_sqlalchemy.SQLAlchemyDB.from_db_url(f"sqlite:///{db_path}")
+        self.db.migrate_database()
+
+        _clear_tru_session_singletons()
+        self.addCleanup(_clear_tru_session_singletons)
+        self.session = core_session.TruSession(
+            connector=default_connector.DefaultDBConnector(database=self.db)
+        )
+
+    def curate(self, **kwargs) -> core_dataset.CurationResult:
+        """Curate `RECORDS` under the default mapping, overriding as needed."""
+
+        kwargs.setdefault("dataset_name", "production-failures")
+        kwargs.setdefault("records", RECORDS)
+        kwargs.setdefault("mapping", MAPPING)
+        return self.session.curate_records_to_dataset(**kwargs)
+
+    def ground_truths(self, dataset_name="production-failures"):
+        return self.session.get_ground_truth(dataset_name=dataset_name)
+
+
+class TestMappingValidation(CurationTestCase):
+    def test_defaults_read_input_and_record_id(self):
+        mapping = core_dataset.TraceDatasetMapping()
+        self.assertEqual(mapping.query, "input")
+        self.assertEqual(mapping.query_id, "record_id")
+        self.assertIsNone(mapping.expected_response)
+        self.assertEqual(mapping.metadata, {})
+
+    def test_mapped_columns_are_deduplicated_in_order(self):
+        mapping = core_dataset.TraceDatasetMapping(
+            query="input",
+            query_id="input",
+            metadata={"a": "input", "b": "Groundedness"},
+        )
+        self.assertEqual(mapping.mapped_columns(), ["input", "Groundedness"])
+
+    def test_blank_query_column_is_rejected(self):
+        with self.assertRaises(ValueError):
+            core_dataset.TraceDatasetMapping(query="   ")
+
+    def test_missing_columns_are_reported_before_any_write(self):
+        with self.assertRaises(ValueError) as caught:
+            self.curate(
+                records=RECORDS.drop(columns=["record_id"]),
+                mapping=core_dataset.TraceDatasetMapping(
+                    query="not_a_column", query_id=None
+                ),
+            )
+        self.assertIn("not_a_column", str(caught.exception))
+
+        # Nothing was written: the dataset has no ground truths.
+        self.assertIsNone(self.ground_truths())
+
+    def test_missing_metadata_column_is_reported(self):
+        with self.assertRaises(ValueError) as caught:
+            self.curate(
+                mapping=core_dataset.TraceDatasetMapping(
+                    query="input", metadata={"score": "NotAMetric"}
+                )
+            )
+        self.assertIn("NotAMetric", str(caught.exception))
+
+    def test_invalid_on_error_mode_is_rejected(self):
+        with self.assertRaises(ValueError):
+            self.curate(on_error="ignore")
+
+    def test_invalid_batch_size_is_rejected(self):
+        with self.assertRaises(ValueError):
+            self.curate(batch_size=0)
+
+    def test_non_dataframe_records_are_rejected(self):
+        with self.assertRaises(ValueError):
+            self.curate(records=[{"input": "q"}])
+
+
+class TestNormalization(unittest.TestCase):
+    def test_text_passthrough_and_stripping(self):
+        self.assertEqual(core_dataset._normalize_text("  hi\n"), "hi")
+
+    def test_missing_values_become_none(self):
+        for value in (None, float("nan"), "", "   "):
+            self.assertIsNone(core_dataset._normalize_text(value))
+
+    def test_dicts_serialize_with_sorted_keys(self):
+        self.assertEqual(
+            core_dataset._normalize_text({"b": 1, "a": 2}),
+            '{"a": 2, "b": 1}',
+        )
+
+    def test_json_strings_are_renormalized(self):
+        # The legacy schema hands back parsed values while OTEL hands back
+        # strings; both must reduce to the same text.
+        self.assertEqual(
+            core_dataset._normalize_text('{"b": 1, "a": 2}'),
+            core_dataset._normalize_text({"a": 2, "b": 1}),
+        )
+
+    def test_malformed_json_is_left_alone(self):
+        self.assertEqual(core_dataset._normalize_text("{not json"), "{not json")
+
+    def test_scalar_json_literals_are_left_alone(self):
+        self.assertEqual(core_dataset._normalize_text("123"), "123")
+
+    def test_non_string_scalars_become_text(self):
+        self.assertEqual(core_dataset._normalize_text(7), "7")
+
+    def test_contexts_from_list_of_dicts(self):
+        self.assertEqual(
+            core_dataset._normalize_contexts([{"text": "a"}, {"text": "b"}]),
+            [{"text": "a"}, {"text": "b"}],
+        )
+
+    def test_contexts_from_list_of_strings(self):
+        self.assertEqual(
+            core_dataset._normalize_contexts(["a", "b"]),
+            [{"text": "a"}, {"text": "b"}],
+        )
+
+    def test_contexts_from_plain_string(self):
+        self.assertEqual(
+            core_dataset._normalize_contexts("a chunk"),
+            [{"text": "a chunk"}],
+        )
+
+    def test_contexts_from_json_string(self):
+        self.assertEqual(
+            core_dataset._normalize_contexts('["a", "b"]'),
+            [{"text": "a"}, {"text": "b"}],
+        )
+
+    def test_contexts_from_single_dict(self):
+        self.assertEqual(
+            core_dataset._normalize_contexts({"text": "a"}), [{"text": "a"}]
+        )
+
+    def test_contexts_drop_missing_elements(self):
+        self.assertEqual(
+            core_dataset._normalize_contexts(["a", None, float("nan")]),
+            [{"text": "a"}],
+        )
+
+    def test_contexts_missing_becomes_none(self):
+        for value in (None, float("nan"), "", []):
+            self.assertIsNone(core_dataset._normalize_contexts(value))
+
+    def test_json_safe_coerces_numpy_scalars(self):
+        value = core_dataset._json_safe(pd.Series([1.5]).iloc[0])
+        self.assertIsInstance(value, float)
+        self.assertEqual(value, 1.5)
+        # The result must survive a json round trip.
+        self.assertEqual(json.loads(json.dumps({"v": value}))["v"], 1.5)
+
+    def test_json_safe_maps_nan_to_none(self):
+        self.assertIsNone(core_dataset._json_safe(float("nan")))
+
+
+class TestCuration(CurationTestCase):
+    def test_every_accepted_row_becomes_a_ground_truth(self):
+        result = self.curate()
+
+        self.assertEqual(result.accepted, 2)
+        self.assertEqual(result.duplicates, 0)
+        self.assertEqual(result.rejected, 0)
+        self.assertEqual(result.processed, 2)
+        self.assertEqual(len(result.ground_truth_ids), 2)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.dataset_name, "production-failures")
+
+        df = self.ground_truths()
+        self.assertEqual(len(df), 2)
+        self.assertEqual(
+            sorted(df["query"]),
+            ["how do i install it?", "what is trulens?"],
+        )
+        self.assertEqual(
+            sorted(df["expected_response"]),
+            ["an evaluation library", "pip install trulens"],
+        )
+        self.assertEqual(sorted(df["query_id"]), ["record-1", "record-2"])
+
+    def test_corrected_output_round_trips(self):
+        self.curate()
+        df = self.ground_truths()
+        row = df[df["query_id"] == "record-1"].iloc[0]
+        self.assertEqual(row["expected_response"], "an evaluation library")
+
+    def test_provenance_is_preserved_in_metadata(self):
+        self.curate()
+        df = self.ground_truths()
+        meta = df[df["query_id"] == "record-1"].iloc[0]["meta"]
+
+        self.assertEqual(meta["source_record_id"], "record-1")
+        self.assertEqual(meta["source_app_name"], "support-bot")
+        self.assertEqual(meta["source_app_version"], "v1")
+        self.assertEqual(meta["groundedness"], 0.2)
+
+    def test_explicit_metadata_overrides_provenance_default(self):
+        self.curate(
+            mapping=core_dataset.TraceDatasetMapping(
+                query="input",
+                query_id="record_id",
+                metadata={"source_app_name": "app_version"},
+            )
+        )
+        meta = self.ground_truths().iloc[0]["meta"]
+        self.assertEqual(meta["source_app_name"], "v1")
+
+    def test_provenance_skipped_when_columns_absent(self):
+        records = RECORDS.drop(columns=["app_name", "app_version"])
+        self.curate(
+            records=records,
+            mapping=core_dataset.TraceDatasetMapping(
+                query="input", query_id="record_id"
+            ),
+        )
+        meta = self.ground_truths().iloc[0]["meta"]
+        self.assertEqual(meta, {"source_record_id": "record-1"})
+
+    def test_dataset_metadata_is_stored(self):
+        result = self.curate(dataset_metadata={"owner": "eval-team"})
+
+        # A dataset id hashes the name and the metadata, so matching the id
+        # proves the metadata reached the stored dataset.
+        expected = dataset_schema.Dataset(
+            name="production-failures", meta={"owner": "eval-team"}
+        )
+        self.assertEqual(result.dataset_id, expected.dataset_id)
+        self.assertEqual(
+            set(self.ground_truths()["dataset_id"]), {expected.dataset_id}
+        )
+
+    def test_json_inputs_are_resolved_to_text(self):
+        # The legacy schema hands back a parsed value while OTEL hands back a
+        # string; both spellings must collapse onto one ground truth.
+        records = pd.DataFrame([
+            {"input": {"question": "what is trulens?"}},
+            {"input": '{"question": "what is trulens?"}'},
+        ])
+        result = self.curate(
+            records=records,
+            mapping=core_dataset.TraceDatasetMapping(
+                query="input", query_id=None
+            ),
+        )
+        self.assertEqual(result.accepted, 1)
+        self.assertEqual(result.duplicates, 1)
+
+    def test_provenance_keeps_identical_content_distinct(self):
+        # A ground truth id covers its metadata, so two records with the same
+        # question stay distinct while their provenance differs.
+        records = pd.DataFrame([
+            {"record_id": "r1", "input": "same question"},
+            {"record_id": "r2", "input": "same question"},
+        ])
+        mapping = core_dataset.TraceDatasetMapping(query="input", query_id=None)
+
+        result = self.curate(records=records, mapping=mapping)
+        self.assertEqual(result.accepted, 2)
+
+    def test_provenance_can_be_turned_off_to_deduplicate_on_content(self):
+        records = pd.DataFrame([
+            {"record_id": "r1", "input": "same question"},
+            {"record_id": "r2", "input": "same question"},
+        ])
+        mapping = core_dataset.TraceDatasetMapping(query="input", query_id=None)
+
+        result = self.curate(
+            records=records, mapping=mapping, include_provenance=False
+        )
+
+        self.assertEqual(result.accepted, 1)
+        self.assertEqual(result.duplicates, 1)
+        self.assertEqual(self.ground_truths().iloc[0]["meta"], {})
+
+
+class TestExpectedContexts(CurationTestCase):
+    def test_contexts_round_trip(self):
+        records = RECORDS.assign(
+            contexts=[["chunk a", "chunk b"], [{"text": "chunk c"}]]
+        )
+        self.curate(
+            records=records,
+            mapping=core_dataset.TraceDatasetMapping(
+                query="input",
+                query_id="record_id",
+                expected_chunks="contexts",
+            ),
+        )
+
+        df = self.ground_truths()
+        first = df[df["query_id"] == "record-1"].iloc[0]
+        second = df[df["query_id"] == "record-2"].iloc[0]
+
+        self.assertEqual(
+            first["expected_chunks"], [{"text": "chunk a"}, {"text": "chunk b"}]
+        )
+        self.assertEqual(second["expected_chunks"], [{"text": "chunk c"}])
+
+
+class TestExpectedResponseCallback(CurationTestCase):
+    def test_callback_fills_in_missing_corrections(self):
+        records = RECORDS.assign(corrected_output=[None, "pip install trulens"])
+
+        self.curate(
+            records=records,
+            expected_response_fn=lambda row: (
+                f"generated for {row['record_id']}"
+            ),
+        )
+
+        df = self.ground_truths()
+        self.assertEqual(
+            df[df["query_id"] == "record-1"].iloc[0]["expected_response"],
+            "generated for record-1",
+        )
+
+    def test_mapped_correction_takes_precedence_over_callback(self):
+        callback = mock.MagicMock(return_value="from callback")
+
+        self.curate(expected_response_fn=callback)
+
+        df = self.ground_truths()
+        self.assertEqual(
+            sorted(df["expected_response"]),
+            ["an evaluation library", "pip install trulens"],
+        )
+        callback.assert_not_called()
+
+    def test_callback_is_not_called_without_a_mapped_column(self):
+        # With no expected_response mapping at all, the callback supplies
+        # every value.
+        self.curate(
+            mapping=core_dataset.TraceDatasetMapping(
+                query="input", query_id="record_id"
+            ),
+            expected_response_fn=lambda row: "always",
+        )
+        df = self.ground_truths()
+        self.assertEqual(list(df["expected_response"]), ["always", "always"])
+
+    def test_callback_failure_fails_fast(self):
+        def boom(row):
+            raise RuntimeError("no correction available")
+
+        records = RECORDS.assign(corrected_output=[None, None])
+
+        with self.assertRaises(core_dataset.CurationRowError) as caught:
+            self.curate(records=records, expected_response_fn=boom)
+        self.assertEqual(caught.exception.reason, "expected_response_fn_failed")
+        self.assertIn("no correction available", caught.exception.message)
+
+    def test_callback_failure_can_be_collected(self):
+        def boom(row):
+            raise RuntimeError("no correction available")
+
+        records = RECORDS.assign(corrected_output=[None, "pip install trulens"])
+
+        result = self.curate(
+            records=records, expected_response_fn=boom, on_error="collect"
+        )
+
+        self.assertEqual(result.accepted, 1)
+        self.assertEqual(result.rejected, 1)
+        self.assertEqual(result.errors[0].reason, "expected_response_fn_failed")
+        self.assertEqual(result.errors[0].query_id, "record-1")
+        self.assertEqual(len(self.ground_truths()), 1)
+
+
+class TestErrorModes(CurationTestCase):
+    def bad_records(self):
+        return RECORDS.assign(input=["what is trulens?", None])
+
+    def test_fail_fast_is_the_default(self):
+        with self.assertRaises(core_dataset.CurationRowError) as caught:
+            self.curate(records=self.bad_records())
+        self.assertEqual(caught.exception.reason, "empty_query")
+
+    def test_collect_does_not_publish_malformed_rows(self):
+        result = self.curate(records=self.bad_records(), on_error="collect")
+
+        self.assertEqual(result.accepted, 1)
+        self.assertEqual(result.rejected, 1)
+        self.assertEqual(len(result.errors), 1)
+        self.assertEqual(result.errors[0].reason, "empty_query")
+        self.assertEqual(result.errors[0].query_id, "record-2")
+
+        df = self.ground_truths()
+        self.assertEqual(len(df), 1)
+        self.assertEqual(df.iloc[0]["query"], "what is trulens?")
+
+    def test_errors_df_is_inspectable(self):
+        result = self.curate(records=self.bad_records(), on_error="collect")
+        errors = result.errors_df()
+
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(
+            list(errors.columns),
+            [
+                "row_index",
+                "query_id",
+                "reason",
+                "message",
+            ],
+        )
+        self.assertEqual(errors.iloc[0]["reason"], "empty_query")
+
+    def test_whitespace_only_query_is_rejected(self):
+        records = RECORDS.assign(input=["what is trulens?", "   "])
+        result = self.curate(records=records, on_error="collect")
+        self.assertEqual(result.rejected, 1)
+
+
+class TestIdempotency(CurationTestCase):
+    def test_curating_identical_rows_twice_adds_nothing(self):
+        first = self.curate()
+        second = self.curate()
+
+        self.assertEqual(first.ground_truth_ids, second.ground_truth_ids)
+        self.assertEqual(len(self.ground_truths()), 2)
+
+    def test_duplicate_rows_within_one_call_are_counted(self):
+        records = pd.concat([RECORDS, RECORDS], ignore_index=True)
+
+        result = self.curate(records=records)
+
+        self.assertEqual(result.accepted, 2)
+        self.assertEqual(result.duplicates, 2)
+        self.assertEqual(result.processed, 4)
+        self.assertEqual(len(self.ground_truths()), 2)
+
+    def test_changing_a_correction_adds_a_new_ground_truth(self):
+        self.curate()
+        self.curate(
+            records=RECORDS.assign(
+                corrected_output=["a better answer", "pip install trulens"]
+            )
+        )
+        # Ids are content-addressed, so the edited example is a new row rather
+        # than an in-place edit of the old one.
+        self.assertEqual(len(self.ground_truths()), 3)
+
+
+class _RecordingDB:
+    """Minimal db stand-in that records the batches it is handed.
+
+    Batch boundaries are a property of the curation loop, not of SQL, so they
+    are checked against a stub rather than through a real database.
+    """
+
+    def __init__(self):
+        self.batch_sizes = []
+        self.inserted = []
+
+    def insert_dataset(self, dataset):
+        return dataset.dataset_id
+
+    def batch_insert_ground_truth(self, ground_truths):
+        self.batch_sizes.append(len(ground_truths))
+        self.inserted.extend(ground_truths)
+        return [gt.ground_truth_id for gt in ground_truths]
+
+
+class TestBatching(unittest.TestCase):
+    def make_records(self, count: int) -> pd.DataFrame:
+        return pd.DataFrame([
+            {"record_id": f"r{i}", "input": f"question {i}"}
+            for i in range(count)
+        ])
+
+    def curate_many(self, count: int, batch_size: int, **kwargs):
+        db = _RecordingDB()
+        result = core_dataset.curate_records_to_dataset(
+            dataset_name="batched",
+            records=self.make_records(count),
+            db=db,
+            mapping=core_dataset.TraceDatasetMapping(
+                query="input", query_id="record_id"
+            ),
+            batch_size=batch_size,
+            **kwargs,
+        )
+        return result, db
+
+    def test_exact_batch_boundary(self):
+        result, db = self.curate_many(count=10, batch_size=5)
+        self.assertEqual(result.accepted, 10)
+        self.assertEqual(db.batch_sizes, [5, 5])
+
+    def test_partial_final_batch(self):
+        result, db = self.curate_many(count=7, batch_size=3)
+        self.assertEqual(result.accepted, 7)
+        self.assertEqual(db.batch_sizes, [3, 3, 1])
+
+    def test_single_batch_when_smaller_than_batch_size(self):
+        _, db = self.curate_many(count=2, batch_size=100)
+        self.assertEqual(db.batch_sizes, [2])
+
+    def test_batch_size_of_one(self):
+        _, db = self.curate_many(count=3, batch_size=1)
+        self.assertEqual(db.batch_sizes, [1, 1, 1])
+
+    def test_every_row_is_written_exactly_once(self):
+        _, db = self.curate_many(count=25, batch_size=4)
+        self.assertEqual(sum(db.batch_sizes), 25)
+        self.assertEqual(len({gt.ground_truth_id for gt in db.inserted}), 25)
+
+    def test_no_write_when_every_row_is_rejected(self):
+        db = _RecordingDB()
+        core_dataset.curate_records_to_dataset(
+            dataset_name="batched",
+            records=pd.DataFrame([{"record_id": "r1", "input": None}]),
+            db=db,
+            mapping=core_dataset.TraceDatasetMapping(
+                query="input", query_id="record_id"
+            ),
+            on_error="collect",
+        )
+        self.assertEqual(db.batch_sizes, [])
+
+    def test_rows_are_curated_lazily(self):
+        # Peak memory is one batch: rows must not all be materialized before
+        # the first write.
+        db = _RecordingDB()
+        seen = []
+
+        core_dataset.curate_records_to_dataset(
+            dataset_name="batched",
+            records=self.make_records(6),
+            db=db,
+            mapping=core_dataset.TraceDatasetMapping(
+                query="input", query_id="record_id"
+            ),
+            expected_response_fn=lambda row: (
+                seen.append((row["record_id"], len(db.batch_sizes))) or "ok"
+            ),
+            batch_size=2,
+        )
+
+        # The 5th row is only visited after two batches have been written.
+        self.assertEqual(seen[4][1], 2)
+
+
+class TestRecordIdInput(CurationTestCase):
+    def curate_with_resolver(
+        self, records, resolver, mapping_override=None, **kwargs
+    ):
+        return core_dataset.curate_records_to_dataset(
+            dataset_name="production-failures",
+            records=records,
+            db=self.db,
+            mapping=mapping_override
+            if mapping_override is not None
+            else MAPPING,
+            record_resolver=resolver,
+            **kwargs,
+        )
+
+    def test_record_ids_are_resolved(self):
+        # A review export that carries only record ids and corrections must be
+        # joined against the recorded content before mapping.
+        review = pd.DataFrame([
+            {
+                "record_id": "record-1",
+                "corrected_output": "an evaluation library",
+            }
+        ])
+        calls = []
+
+        result = self.curate_with_resolver(
+            review, lambda ids: calls.append(ids) or RECORDS
+        )
+
+        self.assertEqual(calls, [["record-1"]])
+        self.assertEqual(result.accepted, 1)
+
+        df = self.ground_truths()
+        self.assertEqual(df.iloc[0]["query"], "what is trulens?")
+        self.assertEqual(
+            df.iloc[0]["expected_response"], "an evaluation library"
+        )
+
+    def test_export_columns_win_over_resolved_ones(self):
+        review = pd.DataFrame([
+            {
+                "record_id": "record-1",
+                "input": "an edited question",
+                "corrected_output": "an evaluation library",
+            }
+        ])
+
+        self.curate_with_resolver(review, lambda ids: RECORDS)
+
+        self.assertEqual(
+            self.ground_truths().iloc[0]["query"], "an edited question"
+        )
+
+    def test_resolution_is_skipped_when_nothing_is_missing(self):
+        calls = []
+
+        self.curate_with_resolver(
+            RECORDS, lambda ids: calls.append(ids) or RECORDS
+        )
+
+        self.assertEqual(calls, [])
+
+    def test_metric_columns_are_resolved_for_an_export_with_text(self):
+        # A review export can carry the question text and still need metric
+        # scores that only the database holds.
+        review = pd.DataFrame([
+            {
+                "record_id": "record-1",
+                "input": "what is trulens?",
+                "corrected_output": "an evaluation library",
+            }
+        ])
+
+        result = self.curate_with_resolver(review, lambda ids: RECORDS)
+
+        self.assertEqual(result.accepted, 1)
+        self.assertEqual(
+            self.ground_truths().iloc[0]["meta"]["groundedness"], 0.2
+        )
+
+    def test_column_still_missing_after_resolution_is_reported(self):
+        with self.assertRaises(ValueError) as caught:
+            self.curate_with_resolver(
+                RECORDS,
+                lambda ids: RECORDS,
+                mapping_override=core_dataset.TraceDatasetMapping(
+                    query="input", metadata={"score": "NotAMetric"}
+                ),
+            )
+        self.assertIn("NotAMetric", str(caught.exception))
+
+    def test_resolver_failure_is_reported_clearly(self):
+        review = pd.DataFrame([{"record_id": "record-1"}])
+
+        def boom(ids):
+            raise NotImplementedError("`record_ids` is not supported")
+
+        with self.assertRaises(ValueError) as caught:
+            self.curate_with_resolver(review, boom)
+
+        message = str(caught.exception)
+        self.assertIn("input", message)
+        self.assertIn("`record_ids` is not supported", message)
+        self.assertIn("get_records_and_feedback", message)
+
+    def test_unresolvable_ids_still_report_missing_columns(self):
+        review = pd.DataFrame([{"record_id": "record-404"}])
+
+        with self.assertRaises(ValueError) as caught:
+            self.curate_with_resolver(review, lambda ids: pd.DataFrame())
+        self.assertIn("input", str(caught.exception))
+
+    def test_session_wires_the_resolver_to_get_records_and_feedback(self):
+        review = pd.DataFrame([
+            {
+                "record_id": "record-1",
+                "corrected_output": "an evaluation library",
+            }
+        ])
+
+        with mock.patch.object(
+            core_session.TruSession,
+            "get_records_and_feedback",
+            return_value=(RECORDS, []),
+        ) as spy:
+            result = self.curate(records=review)
+
+        spy.assert_called_once_with(record_ids=["record-1"])
+        self.assertEqual(result.accepted, 1)
+        self.assertEqual(
+            self.ground_truths().iloc[0]["query"], "what is trulens?"
+        )
+
+
+class TestCsvAndJsonInputs(CurationTestCase):
+    def test_csv_export(self):
+        path = os.path.join(self._tempdir.name, "review.csv")
+        RECORDS.to_csv(path, index=False)
+
+        result = self.curate(records=pd.read_csv(path))
+
+        self.assertEqual(result.accepted, 2)
+        self.assertEqual(len(self.ground_truths()), 2)
+
+    def test_json_export(self):
+        path = os.path.join(self._tempdir.name, "review.json")
+        RECORDS.to_json(path, orient="records")
+
+        result = self.curate(records=pd.read_json(path))
+
+        self.assertEqual(result.accepted, 2)
+
+    def test_csv_and_dataframe_produce_the_same_ground_truths(self):
+        path = os.path.join(self._tempdir.name, "review.csv")
+        RECORDS.to_csv(path, index=False)
+
+        from_df = self.curate()
+        from_csv = self.curate(records=pd.read_csv(path))
+
+        self.assertEqual(
+            sorted(from_df.ground_truth_ids),
+            sorted(from_csv.ground_truth_ids),
+        )
+
+
+class TestCookbookFlow(CurationTestCase):
+    """The loop the cookbook notebook walks, without the tracing machinery.
+
+    Guards the narrative in `examples/expositional/use_cases/trace_to_dataset.ipynb`
+    against drifting away from the API.
+    """
+
+    def test_records_to_ground_truth_metric(self):
+        # 1. records as `get_records_and_feedback` returns them, scored by a
+        #    metric that flags hedged answers.
+        records = pd.DataFrame([
+            {
+                "record_id": "record-1",
+                "app_name": "support-bot",
+                "app_version": "v1",
+                "input": "what is trulens?",
+                "output": "TruLens is a library for evaluating LLM apps.",
+                "Answered": 1.0,
+            },
+            {
+                "record_id": "record-2",
+                "app_name": "support-bot",
+                "app_version": "v1",
+                "input": "how do i install trulens?",
+                "output": "I'm not sure, please check the docs.",
+                "Answered": 0.0,
+            },
+        ])
+
+        # 2. select the low-scoring rows in pandas.
+        failures = records[records["Answered"] < 1.0].copy()
+        self.assertEqual(len(failures), 1)
+
+        # 3. write the corrected answer.
+        failures["corrected_output"] = ["Run `pip install trulens`."]
+
+        # 4. curate.
+        result = self.session.curate_records_to_dataset(
+            dataset_name="support-bot-regressions",
+            records=failures,
+            mapping=core_dataset.TraceDatasetMapping(
+                query="input",
+                query_id="record_id",
+                expected_response="corrected_output",
+                metadata={"answered": "Answered"},
+            ),
+            on_error="collect",
+        )
+        self.assertEqual((result.accepted, result.rejected), (1, 0))
+
+        # 5. load it back and score an answer against it.
+        ground_truth = self.session.get_ground_truth(
+            dataset_name="support-bot-regressions"
+        )
+        expected = dict(
+            zip(ground_truth["query"], ground_truth["expected_response"])
+        )
+
+        def matches_expected(prompt: str, response: str) -> float:
+            want = expected.get(prompt.strip())
+            if want is None:
+                return float("nan")
+            return float(response.strip().lower() == want.strip().lower())
+
+        self.assertEqual(
+            matches_expected(
+                "how do i install trulens?", "Run `pip install trulens`."
+            ),
+            1.0,
+        )
+        self.assertEqual(
+            matches_expected("how do i install trulens?", "no idea"), 0.0
+        )
+
+        # Provenance survives the whole trip.
+        meta = ground_truth.iloc[0]["meta"]
+        self.assertEqual(meta["source_record_id"], "record-2")
+        self.assertEqual(meta["answered"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2702

## Problem

Production traces already hold the examples a regression test needs, but `add_ground_truth_to_dataset` only accepts an already-prepared DataFrame. Getting from one to the other means manually extracting record content, joining in review corrections, normalizing fields, deduplicating, and deciding what to do with malformed rows.

## What this adds

`TruSession.curate_records_to_dataset()`, built entirely on the `Dataset` and `GroundTruth` APIs that exist today — no dataset versioning, no review queues.

- **`TraceDatasetMapping`** names which dataframe column supplies which ground truth field. Values are column names, never expressions, so the mapping is validated against the dataframe before anything is written.
- **Normalization**: recorded inputs and outputs resolve to stable text whether they arrive as strings (OTEL) or as already-parsed JSON (legacy schema), with dicts re-serialized under sorted keys so key ordering cannot change a content-addressed id. Expected contexts normalize into the `expected_chunks` shape from lists, strings, dicts, or a JSON encoding of any of those.
- **Accepted inputs**: a `get_records_and_feedback()` frame; a frame carrying only record ids, resolved through the session before mapping (columns the caller supplies always win over the stored ones); or a CSV/JSON review export loaded with pandas.
- **Expected outputs**: a mapped correction always wins; an optional synchronous callback fills in only what is missing. TruLens never calls an LLM on your behalf.
- **Provenance**: source record id and app name/version are preserved in ground truth metadata, alongside any metric scores you map explicitly.
- **Bounded work**: rows are curated lazily and written in batches through the existing `batch_insert_ground_truth`, so peak memory is one batch beyond the input frame.
- **Error handling**: `on_error="raise"` fails on the first unusable row, `on_error="collect"` skips and reports it. Malformed rows are never written in either mode. The result carries accepted / duplicate / rejected counts, the ids written, and an `errors_df()` for inspection.

## Cookbook

`examples/expositional/use_cases/trace_to_dataset.ipynb` walks the whole loop on synthetic data with **no API keys**: record a deliberately imperfect support bot, score it with a deterministic metric, select the low-scoring records in pandas, write corrections, curate them, load the dataset back through `get_ground_truth()`, and use it as a ground truth metric against a fixed version of the bot.

Note that `docs/cookbook` is a symlink to `examples/expositional`, so the two notebook paths named in the issue are the same file.

## One addition beyond the issue

`include_provenance=False`. A `GroundTruth` id hashes its metadata, so automatically attaching `source_record_id` means two records with identical content never deduplicate — the issue asks for both provenance in metadata and deduplication, and these pull against each other. Provenance stays on by default (it is the explicit acceptance criterion); this is the escape hatch for callers who want to deduplicate on example content alone. It is documented on the `duplicates` field.

## Tests

65 unit tests in `tests/unit/test_trace_curation.py`, covering every bullet on the issue's test list: mapping validation, JSON/text normalization, all four input shapes, callback precedence and callback failure, context normalization and metadata selection, duplicate/idempotency behavior, both error modes, batch boundaries, and an end-to-end test mirroring the cookbook so the notebook's narrative cannot silently drift from the API.

The notebook itself was executed end to end with nbclient and runs clean with no credentials.

Verified locally: the full non-OTEL unit suite goes from 317 to 382 passing with no new failures — the remaining failures are byte-identical on a clean tree. Formatting and lint are clean under the ruff version pinned in `.pre-commit-config.yaml`.

## Notes for review

- `src/core/trulens/core/schema/groundtruth.py` is listed among the issue's critical files but is unchanged here: curation constructs `GroundTruth` through its existing constructor and nothing in the schema needed to move. Happy to relocate the conversion helpers there if that is the preferred home.
- Duplicate counting is scoped to a single call. Cross-call idempotency is guaranteed by content-addressed ids plus the existing upsert (and tested), but reporting it would have needed a new batched-existence query on the database, which the issue rules out by asking that this go "through existing database methods".
