### PR TITLE
fix(feedback): stop reading a judge's stated scale as its rating

### DIFF
--- a/src/feedback/trulens/feedback/generated.py
+++ b/src/feedback/trulens/feedback/generated.py
@@ -39,6 +39,35 @@ PATTERN_INTEGER: re.Pattern = re.compile(r"([+-]?[1-9][0-9]*|0)")
 """Regex that matches integers."""
 
 
+def _ratings_in_range(
+    s: str, min_score_val: int, max_score_val: int, allow_decimal: bool
+) -> set:
+    """Every number in ``s`` that falls inside the rating scale.
+
+    Args:
+        s: String to read numbers from.
+
+        min_score_val: Minimum value of the rating scale.
+
+        max_score_val: Maximum value of the rating scale.
+
+        allow_decimal: Whether to capture decimal numbers rather than truncate.
+
+    Returns:
+        set: The in-range values. Out-of-range numbers are logged and dropped.
+    """
+    found = set()
+    for match in PATTERN_NUMBER.findall(s):
+        rating = float(match) if allow_decimal else int(float(match))
+        if min_score_val <= rating <= max_score_val:
+            found.add(rating)
+        else:
+            logger.warning(
+                "Rating must be in [%s, %s].", min_score_val, max_score_val
+            )
+    return found
+
+
 def _strip_scale_statement(
     s: str, min_score_val: int, max_score_val: int
 ) -> str:
@@ -104,39 +133,28 @@ def re_configured_rating(
     if max_score_val <= min_score_val:
         raise ValueError("Max score must be greater than min score.")
 
-    matches = PATTERN_NUMBER.findall(s)
-    if not matches:
+    if not PATTERN_NUMBER.search(s):
         raise ParseError("int or float number", s, pattern=PATTERN_NUMBER)
 
-    def in_range(text: str) -> set:
-        found = set()
-        for match in PATTERN_NUMBER.findall(text):
-            rating = float(match) if allow_decimal else int(float(match))
-            if min_score_val <= rating <= max_score_val:
-                found.add(rating)
-        return found
-
-    # A judge that repeats its own scale ("on a scale of 0 to 3, I rate this 3")
-    # is naming the bounds, not scoring. Those bounds are in range, so they end up
-    # as candidate ratings and the min() below returns the floor instead of the
-    # rating. Drop an explicit scale statement first, and if exactly one candidate
-    # survives, that is the rating. Anything else falls through unchanged, so
-    # "N out of M" phrasing keeps its existing behaviour.
+    # A judge that repeats its own scale ("on a scale of 0 to 3, I rate this 3") is
+    # naming the bounds, not scoring. Those bounds are in range, so without this they
+    # become candidate ratings and the min() below returns the floor instead of the
+    # rating. Drop an explicit scale statement and read the rest, so the bounds cannot
+    # be re-injected further down. "N out of M" contains no scale statement, so it is
+    # untouched and keeps its existing behaviour.
     without_scale = _strip_scale_statement(s, min_score_val, max_score_val)
-    if without_scale != s:
-        narrowed = in_range(without_scale)
-        if len(narrowed) == 1:
-            return narrowed.pop()
+    considered = without_scale if without_scale != s else s
 
-    vals = set()
-    for match in matches:
-        rating = float(match) if allow_decimal else int(float(match))
-        if min_score_val <= rating <= max_score_val:
-            vals.add(rating)
-        else:
-            logger.warning(
-                "Rating must be in [%s, %s].", min_score_val, max_score_val
-            )
+    vals = _ratings_in_range(
+        considered, min_score_val, max_score_val, allow_decimal
+    )
+    if not vals and considered is not s:
+        # Stripping took the only numbers with it, so fall back to the whole string
+        # rather than raising on text the old behaviour could read.
+        considered = s
+        vals = _ratings_in_range(
+            considered, min_score_val, max_score_val, allow_decimal
+        )
 
     if not vals:
         raise ParseError(f"{min_score_val}-{max_score_val} rating", s)

--- a/src/feedback/trulens/feedback/generated.py
+++ b/src/feedback/trulens/feedback/generated.py
@@ -39,6 +39,39 @@ PATTERN_INTEGER: re.Pattern = re.compile(r"([+-]?[1-9][0-9]*|0)")
 """Regex that matches integers."""
 
 
+def _strip_scale_statement(
+    s: str, min_score_val: int, max_score_val: int
+) -> str:
+    """Remove an explicit statement of the rating scale from a judge's answer.
+
+    Covers the two shapes judges actually produce: a range ("0 to 3", "0-3",
+    "between 0 and 3") and a legend ("0 = irrelevant, 3 = highly relevant").
+    Only the configured bounds are removed, so a number that happens to equal a
+    bound but is the actual rating is left alone unless it appears inside one of
+    those shapes.
+
+    Args:
+        s: String to strip.
+
+        min_score_val: Minimum value of the rating scale.
+
+        max_score_val: Maximum value of the rating scale.
+
+    Returns:
+        str: The string with any scale statement removed.
+    """
+    lo = re.escape(str(min_score_val))
+    hi = re.escape(str(max_score_val))
+    patterns = (
+        rf"\b{lo}\s*(?:to|through|and|up to|\.\.\.?|[-‒-―])\s*{hi}\b",
+        rf"\b{lo}\s*=",
+        rf"\b{hi}\s*=",
+    )
+    for pattern in patterns:
+        s = re.sub(pattern, " ", s, flags=re.IGNORECASE)
+    return s
+
+
 def re_configured_rating(
     s: str,
     min_score_val: int = 0,
@@ -74,6 +107,26 @@ def re_configured_rating(
     matches = PATTERN_NUMBER.findall(s)
     if not matches:
         raise ParseError("int or float number", s, pattern=PATTERN_NUMBER)
+
+    def in_range(text: str) -> set:
+        found = set()
+        for match in PATTERN_NUMBER.findall(text):
+            rating = float(match) if allow_decimal else int(float(match))
+            if min_score_val <= rating <= max_score_val:
+                found.add(rating)
+        return found
+
+    # A judge that repeats its own scale ("on a scale of 0 to 3, I rate this 3")
+    # is naming the bounds, not scoring. Those bounds are in range, so they end up
+    # as candidate ratings and the min() below returns the floor instead of the
+    # rating. Drop an explicit scale statement first, and if exactly one candidate
+    # survives, that is the rating. Anything else falls through unchanged, so
+    # "N out of M" phrasing keeps its existing behaviour.
+    without_scale = _strip_scale_statement(s, min_score_val, max_score_val)
+    if without_scale != s:
+        narrowed = in_range(without_scale)
+        if len(narrowed) == 1:
+            return narrowed.pop()
 
     vals = set()
     for match in matches:

--- a/tests/unit/test_feedback_score_generation.py
+++ b/tests/unit/test_feedback_score_generation.py
@@ -80,6 +80,28 @@ def test_re_configured_rating_ignores_a_stated_scale(test_input, expected):
     )
 
 
+# Raised in review on #2726: when stripping the scale leaves MORE than one candidate,
+# the old code fell back to the un-stripped string and re-injected the bounds, so the
+# floor won anyway. The stripped text is now used consistently.
+multi_candidate_data = [
+    ("scale of 0 to 3, I give 2 or 3", 2),
+    ("Rating 0 to 3: between 2 and 3, call it 3", 2),
+]
+
+
+@pytest.mark.parametrize("test_input,expected", multi_candidate_data)
+def test_re_configured_rating_stripped_text_used_throughout(
+    test_input, expected
+):
+    """The stated bounds do not come back when several candidates remain."""
+
+    result = feedback_generated.re_configured_rating(test_input)
+
+    assert result == expected, (
+        f"Failed on {test_input}: expected {expected}, got {result}"
+    )
+
+
 out_of_data = [
     ("The rating is 1 out of 3.", 1),
 ]

--- a/tests/unit/test_feedback_score_generation.py
+++ b/tests/unit/test_feedback_score_generation.py
@@ -9,8 +9,7 @@ from trulens.feedback import generated as feedback_generated
 test_data = [
     ("The relevance score is 7.", 7),
     ("I rate this an 8 out of 10.", 8),
-    ("In the range of 0-10, I give this a 9.", 0),
-    # Currently does not have ideal handling as it returns the minimum integer found.
+    ("In the range of 0-10, I give this a 9.", 9),
     ("This should be a 10!", 10),
     ("The score is 5", 5),
     ("A perfect score: 10.", 10),
@@ -33,6 +32,64 @@ def test_re_0_10_rating(test_input, expected):
         result = feedback_generated.re_0_10_rating(test_input)
     except feedback_generated.ParseError:
         result = None
+
+    assert result == expected, (
+        f"Failed on {test_input}: expected {expected}, got {result}"
+    )
+
+
+# A judge that states its own scale before answering used to have those bounds
+# read as candidate ratings, so the minimum was returned instead of the rating.
+scale_statement_data = [
+    ("On a scale of 0 to 10, I rate this 8", 8),
+    ("Using a 0 to 10 scale, the answer deserves a 7.", 7),
+    ("Rate from 0-10. Score: 9", 9),
+    ("Between 0 and 10, this is a 6.", 6),
+    ("Scoring 0 through 10, I give it a 4.", 4),
+    ("Legend: 0 = irrelevant, 10 = perfect. I give this a 8.", 8),
+]
+
+
+@pytest.mark.parametrize("test_input,expected", scale_statement_data)
+def test_re_0_10_rating_ignores_a_stated_scale(test_input, expected):
+    """The stated bounds are not candidate ratings."""
+
+    result = feedback_generated.re_0_10_rating(test_input)
+
+    assert result == expected, (
+        f"Failed on {test_input}: expected {expected}, got {result}"
+    )
+
+
+configured_scale_data = [
+    ("On a scale of 0 to 3, I rate this 3", 3),
+    ("Score 0-3: the context is fully relevant, so 3", 3),
+    ("Rating scale 0 to 3. My rating: 2", 2),
+    ("Given the criteria (0 = irrelevant, 3 = highly relevant), I give 3", 3),
+]
+
+
+@pytest.mark.parametrize("test_input,expected", configured_scale_data)
+def test_re_configured_rating_ignores_a_stated_scale(test_input, expected):
+    """Same, on the 0-3 scale re_configured_rating defaults to."""
+
+    result = feedback_generated.re_configured_rating(test_input)
+
+    assert result == expected, (
+        f"Failed on {test_input}: expected {expected}, got {result}"
+    )
+
+
+out_of_data = [
+    ("The rating is 1 out of 3.", 1),
+]
+
+
+@pytest.mark.parametrize("test_input,expected", out_of_data)
+def test_re_configured_rating_keeps_out_of_phrasing(test_input, expected):
+    """ "N out of M" is not a scale statement and keeps its existing handling."""
+
+    result = feedback_generated.re_configured_rating(test_input)
 
     assert result == expected, (
         f"Failed on {test_input}: expected {expected}, got {result}"


### PR DESCRIPTION
## The bug

`re_configured_rating` collects every number in the judge's answer, keeps the ones inside the
configured scale, and returns `min()` of them. So when a judge states its own scale before
answering, the bounds it quoted are themselves in range and the minimum wins.

On the default 0-3 scale, against released `trulens-feedback 2.13.1`:

| judge's answer | parsed | the judge meant |
|---|---|---|
| `On a scale of 0 to 3, I rate this 3` | **0** | 3 |
| `Score 0-3: the context is fully relevant, so 3` | **0** | 3 |
| `Rating scale 0 to 3. My rating: 2` | **0** | 2 |
| `Given the criteria (0=irrelevant, 3=highly relevant), I give 3` | **0** | 3 |
| `The answer is fully supported. Score: 3` | 3 | 3 |

Nothing raises. `0.0` is a real score on that scale, so from the outside a floored score and a
genuinely bad one look the same. The only signal is a `logger.warning`.

This is already written down in the repo. `tests/unit/test_feedback_score_generation.py` has:

```python
("In the range of 0-10, I give this a 9.", 0),
# Currently does not have ideal handling as it returns the minimum integer found.
```

## How this differs from #2631

#2631 and its fix in #2636 were about the OpenAI provider not recognising `custom_tool_call`, so
the whole response JSON was handed to the parser. That fix stopped the blob arriving. It did not
change the parser, and this needs no tool calls and no gpt-5: plain text is enough.

## The change

A new `_strip_scale_statement` removes an explicit scale statement in the two shapes judges
actually produce, a range (`0 to 3`, `0-3`, `between 0 and 3`, `0 through 3`) and a legend
(`0 = irrelevant`, `3 = highly relevant`). Only the configured bounds are removed. If exactly one
candidate survives, that is the rating.

I kept it deliberately narrow. Anything else falls through to the existing code path untouched, so
`N out of M` phrasing keeps its current behaviour. That matters because
`tests/integration/test_score_parsing_pipeline.py` pins `"I rate this an 8 out of 10." -> 0.8` and
the unit tests pin `"The rating is 1 out of 3." -> 1`. Both still pass.

I did not change the `-> int` return annotation, which is already inaccurate when
`allow_decimal=True`. That felt like a separate change and I did not want to widen this one.

## Tests

11 new cases covering both scales and both shapes. All 11 fail on `main` and pass here. The
existing pinned case above is updated from `0` to `9` and its comment removed, since the handling
it describes is what this fixes.

```
new + existing unit tests                                   25 passed
test_score_parsing_normalization / _pipeline / _range_validation   46 passed
                                                            71 passed total
ruff check .                                                All checks passed
ruff format --check .                                       2 files already formatted
```
