### PR TITLE
fix: keep temperature positional on conversation metrics

### DIFF
--- a/src/feedback/trulens/feedback/llm_provider.py
+++ b/src/feedback/trulens/feedback/llm_provider.py
@@ -4400,8 +4400,9 @@ class LLMProvider(core_provider.Provider):
     def conversation_helpfulness(
         self,
         records: Union[List[Any], str],
-        additional_instructions: Optional[str] = None,
         temperature: float = 0.0,
+        *,
+        additional_instructions: Optional[str] = None,
     ) -> float:
         """
         Uses chat completion model. A function that completes a template to
@@ -4419,8 +4420,8 @@ class LLMProvider(core_provider.Provider):
 
         Args:
             records (Union[List[Any], str]): The ordered conversation records, or a transcript string.
-            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
             temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
 
         Returns:
             float: A value between 0.0 (not helpful) and 1.0 (helpful).
@@ -4449,8 +4450,9 @@ class LLMProvider(core_provider.Provider):
     def conversation_helpfulness_with_cot_reasons(
         self,
         records: Union[List[Any], str],
-        additional_instructions: Optional[str] = None,
         temperature: float = 0.0,
+        *,
+        additional_instructions: Optional[str] = None,
     ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A function that completes a template to
@@ -4469,8 +4471,8 @@ class LLMProvider(core_provider.Provider):
 
         Args:
             records (Union[List[Any], str]): The ordered conversation records, or a transcript string.
-            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
             temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
 
         Returns:
             Tuple[float, Dict]: A tuple containing a value between 0.0 (not helpful) and 1.0 (helpful) and a dictionary containing the reasons for the evaluation.
@@ -4503,8 +4505,9 @@ class LLMProvider(core_provider.Provider):
         self,
         records: Union[List[Any], str],
         reference_topics: List[str],
-        additional_instructions: Optional[str] = None,
         temperature: float = 0.0,
+        *,
+        additional_instructions: Optional[str] = None,
     ) -> float:
         """
         Uses chat completion model. A function that completes a template to
@@ -4523,8 +4526,8 @@ class LLMProvider(core_provider.Provider):
         Args:
             records (Union[List[Any], str]): The ordered conversation records, or a transcript string.
             reference_topics (List[str]): The topics the conversation is expected to adhere to.
-            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
             temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
 
         Returns:
             float: A value between 0.0 (off topic) and 1.0 (on topic).
@@ -4553,8 +4556,9 @@ class LLMProvider(core_provider.Provider):
         self,
         records: Union[List[Any], str],
         reference_topics: List[str],
-        additional_instructions: Optional[str] = None,
         temperature: float = 0.0,
+        *,
+        additional_instructions: Optional[str] = None,
     ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A function that completes a template to
@@ -4574,8 +4578,8 @@ class LLMProvider(core_provider.Provider):
         Args:
             records (Union[List[Any], str]): The ordered conversation records, or a transcript string.
             reference_topics (List[str]): The topics the conversation is expected to adhere to.
-            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
             temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
 
         Returns:
             Tuple[float, Dict]: A tuple containing a value between 0.0 (off topic) and 1.0 (on topic) and a dictionary containing the reasons for the evaluation.
@@ -4605,8 +4609,9 @@ class LLMProvider(core_provider.Provider):
         self,
         records: Union[List[Any], str],
         reference_goal: Optional[str] = None,
-        additional_instructions: Optional[str] = None,
         temperature: float = 0.0,
+        *,
+        additional_instructions: Optional[str] = None,
     ) -> float:
         """
         Uses chat completion model. A function that completes a template to
@@ -4625,8 +4630,8 @@ class LLMProvider(core_provider.Provider):
         Args:
             records (Union[List[Any], str]): The ordered conversation records, or a transcript string.
             reference_goal (Optional[str]): The goal the agent was expected to fulfill. Defaults to None, in which case the goal is inferred from the conversation.
-            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
             temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
 
         Returns:
             float: A value of 0.0 (goal not achieved) or 1.0 (goal achieved).
@@ -4656,8 +4661,9 @@ class LLMProvider(core_provider.Provider):
         self,
         records: Union[List[Any], str],
         reference_goal: Optional[str] = None,
-        additional_instructions: Optional[str] = None,
         temperature: float = 0.0,
+        *,
+        additional_instructions: Optional[str] = None,
     ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A function that completes a template to
@@ -4677,8 +4683,8 @@ class LLMProvider(core_provider.Provider):
         Args:
             records (Union[List[Any], str]): The ordered conversation records, or a transcript string.
             reference_goal (Optional[str]): The goal the agent was expected to fulfill. Defaults to None, in which case the goal is inferred from the conversation.
-            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
             temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
 
         Returns:
             Tuple[float, Dict]: A tuple containing a value of 0.0 (goal not achieved) or 1.0 (goal achieved) and a dictionary containing the reasons for the evaluation.
@@ -4708,8 +4714,9 @@ class LLMProvider(core_provider.Provider):
     def coherence_across_turns(
         self,
         records: Union[List[Any], str],
-        additional_instructions: Optional[str] = None,
         temperature: float = 0.0,
+        *,
+        additional_instructions: Optional[str] = None,
     ) -> float:
         """
         Uses chat completion model. A function that completes a template to
@@ -4727,8 +4734,8 @@ class LLMProvider(core_provider.Provider):
 
         Args:
             records (Union[List[Any], str]): The ordered conversation records, or a transcript string.
-            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
             temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
 
         Returns:
             float: A value between 0.0 (not coherent) and 1.0 (coherent).
@@ -4754,8 +4761,9 @@ class LLMProvider(core_provider.Provider):
     def coherence_across_turns_with_cot_reasons(
         self,
         records: Union[List[Any], str],
-        additional_instructions: Optional[str] = None,
         temperature: float = 0.0,
+        *,
+        additional_instructions: Optional[str] = None,
     ) -> Tuple[float, Dict]:
         """
         Uses chat completion model. A function that completes a template to
@@ -4774,8 +4782,8 @@ class LLMProvider(core_provider.Provider):
 
         Args:
             records (Union[List[Any], str]): The ordered conversation records, or a transcript string.
-            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
             temperature (float): The temperature for the LLM response, which might have impact on the confidence level of the evaluation. Defaults to 0.0.
+            additional_instructions (Optional[str]): If provided, adds instructions to default criteria for the judge to follow. Defaults to None.
 
         Returns:
             Tuple[float, Dict]: A tuple containing a value between 0.0 (not coherent) and 1.0 (coherent) and a dictionary containing the reasons for the evaluation.

--- a/tests/unit/test_feedback_criteria_and_additional_instructions.py
+++ b/tests/unit/test_feedback_criteria_and_additional_instructions.py
@@ -21,6 +21,7 @@ class MockLLMProvider(llm_provider.LLMProvider):
     # Declare test tracking fields as optional Pydantic fields
     last_system_prompt: Optional[str] = None
     last_user_prompt: Optional[str] = None
+    last_temperature: Optional[float] = None
 
     def __init__(self, **kwargs):
         # Initialize with minimal required fields
@@ -61,6 +62,7 @@ class MockLLMProvider(llm_provider.LLMProvider):
         """Mock generate_score that captures prompts."""
         self.last_system_prompt = system_prompt
         self.last_user_prompt = user_prompt
+        self.last_temperature = temperature
         return 0.67  # Normalized 2/3
 
     def generate_score_and_reasons(
@@ -74,6 +76,7 @@ class MockLLMProvider(llm_provider.LLMProvider):
         """Mock generate_score_and_reasons that captures prompts."""
         self.last_system_prompt = system_prompt
         self.last_user_prompt = user_prompt
+        self.last_temperature = temperature
         return 0.67, {"reason": "Test reason"}
 
 
@@ -354,6 +357,14 @@ class TestConversationAdditionalInstructions(TestCase):
             {"input": "What is 2+2?", "output": "Four."},
             {"input": "Why?", "output": "Two pairs total four items."},
         ]
+
+    def test_positional_nonzero_temperature_does_not_raise(self):
+        """Existing callers passed temperature positionally after records."""
+        result = self.provider.conversation_helpfulness(self.records, 0.7)
+
+        self.assertIsInstance(result, float)
+        self.assertEqual(self.provider.last_temperature, 0.7)
+        self.assertNotIn("0.7", self.provider.last_system_prompt or "")
 
     def test_coherence_across_turns_default_no_additional_instructions(self):
         """Test coherence across turns without additional instructions."""

--- a/tests/unit/test_templates_conversation.py
+++ b/tests/unit/test_templates_conversation.py
@@ -2,8 +2,73 @@
 
 from unittest import mock
 
+import pytest
 from trulens.feedback import llm_provider
 from trulens.feedback.templates import conversation as templates_conversation
+
+_RECORDS = [{"input": "Help", "output": "Done"}]
+
+# Pre-#2710, temperature was the next positional after records (and any domain
+# parameter). Inserting additional_instructions before it bound a positional
+# temperature to additional_instructions and raised TypeError.
+_POSITIONAL_TEMPERATURE_CASES = [
+    (
+        "conversation_helpfulness",
+        (_RECORDS, 0.7),
+        "generate_score",
+        0,
+        3,
+    ),
+    (
+        "conversation_helpfulness_with_cot_reasons",
+        (_RECORDS, 0.7),
+        "generate_score_and_reasons",
+        0,
+        3,
+    ),
+    (
+        "coherence_across_turns",
+        (_RECORDS, 0.7),
+        "generate_score",
+        0,
+        3,
+    ),
+    (
+        "coherence_across_turns_with_cot_reasons",
+        (_RECORDS, 0.7),
+        "generate_score_and_reasons",
+        0,
+        3,
+    ),
+    (
+        "topic_adherence",
+        (_RECORDS, ["support"], 0.7),
+        "generate_score",
+        0,
+        3,
+    ),
+    (
+        "topic_adherence_with_cot_reasons",
+        (_RECORDS, ["support"], 0.7),
+        "generate_score_and_reasons",
+        0,
+        3,
+    ),
+    (
+        "agent_goal_accuracy",
+        (_RECORDS, "resolve the issue", 0.7),
+        "generate_score",
+        0,
+        1,
+    ),
+    (
+        "agent_goal_accuracy_with_cot_reasons",
+        (_RECORDS, "resolve the issue", 0.7),
+        "generate_score_and_reasons",
+        0,
+        1,
+    ),
+]
 
 
 def test_conversation_to_prompt_records() -> None:
@@ -83,3 +148,59 @@ def test_agent_goal_accuracy_requests_score_only() -> None:
     prompt = templates_conversation.AgentGoalAccuracy.system_prompt_template
     assert "Reason:" not in prompt
     assert "Respond ONLY" in prompt
+
+
+@pytest.mark.parametrize(
+    "method_name, args, score_attr, min_score_val, max_score_val",
+    _POSITIONAL_TEMPERATURE_CASES,
+    ids=[case[0] for case in _POSITIONAL_TEMPERATURE_CASES],
+)
+def test_positional_temperature_is_forwarded_for_conversation_metrics(
+    method_name: str,
+    args: tuple,
+    score_attr: str,
+    min_score_val: int,
+    max_score_val: int,
+) -> None:
+    provider = mock.create_autospec(llm_provider.LLMProvider, instance=True)
+    if score_attr == "generate_score":
+        provider.generate_score.return_value = 1.0
+    else:
+        provider.generate_score_and_reasons.return_value = (
+            1.0,
+            {"reason": "ok"},
+        )
+
+    getattr(llm_provider.LLMProvider, method_name)(provider, *args)
+
+    getattr(provider, score_attr).assert_called_once_with(
+        system_prompt=mock.ANY,
+        user_prompt=mock.ANY,
+        min_score_val=min_score_val,
+        max_score_val=max_score_val,
+        temperature=0.7,
+    )
+
+
+def test_positional_temperature_keeps_keyword_additional_instructions() -> None:
+    provider = mock.create_autospec(llm_provider.LLMProvider, instance=True)
+    provider.generate_score.return_value = 1.0
+    extra = "Treat structured rows as coherent."
+
+    llm_provider.LLMProvider.conversation_helpfulness(
+        provider, _RECORDS, 0.7, additional_instructions=extra
+    )
+
+    provider.generate_score.assert_called_once_with(
+        system_prompt=mock.ANY,
+        user_prompt=mock.ANY,
+        min_score_val=0,
+        max_score_val=3,
+        temperature=0.7,
+    )
+    assert (
+        provider._build_criteria_with_instructions.call_args.kwargs[
+            "additional_instructions"
+        ]
+        == extra
+    )


### PR DESCRIPTION
## Summary

PR #2710 inserted `additional_instructions` before `temperature` on the eight conversation metrics. Existing callers that passed temperature positionally (e.g. `provider.conversation_helpfulness(records, 0.7)`) then bound the float to `additional_instructions` and raised `TypeError` inside `_build_criteria_with_instructions`.

Restore `temperature` to its original positional slot and make `additional_instructions` keyword-only on:

- `conversation_helpfulness` / `_with_cot_reasons`
- `topic_adherence` / `_with_cot_reasons`
- `agent_goal_accuracy` / `_with_cot_reasons`
- `coherence_across_turns` / `_with_cot_reasons`

## Test plan

- [x] `pytest tests/unit/test_templates_conversation.py tests/unit/test_feedback_criteria_and_additional_instructions.py` (42 passed)
- [x] Positional temperature is forwarded to `_create_chat_completion_score`
- [x] Keyword `additional_instructions` still reaches `_build_criteria_with_instructions`

Fixes #2727