### PR TITLE
fix(dashboard): match Topic Adherence score between results table and conversation metrics (#2725)

### DIFF
--- a/src/dashboard/trulens/dashboard/tabs/Records.py
+++ b/src/dashboard/trulens/dashboard/tabs/Records.py
@@ -856,6 +856,7 @@ def _build_thread_summary(
         df["is_match"] = True
 
     rows = []
+    conversation_cols, _ = _partition_feedback_scopes(df, feedback_col_names)
     for thread_key, group in df.groupby("_thread_key", dropna=False):
         group_sorted = group.sort_values("ts")
         first = group_sorted.iloc[0]
@@ -898,7 +899,18 @@ def _build_thread_summary(
                     worst_index, "record_id"
                 ]
         for fcol in feedback_col_names:
-            if fcol in ranking_group.columns:
+            if fcol not in ranking_group.columns:
+                continue
+            if fcol in conversation_cols:
+                # Conversation-scoped metrics describe the whole thread, not a
+                # single turn, so averaging across the thread's records is wrong
+                # (e.g. records of [1.0, 0.0] would surface as 0.5 here while the
+                # conversation-metrics detail view shows 0.0). Use the latest
+                # recorded value, matching _conversation_metric_row.
+                conv_values = group_sorted[fcol].dropna()
+                if not conv_values.empty:
+                    row[fcol] = conv_values.iloc[-1]
+            else:
                 row[fcol] = ranking_group[fcol].mean(skipna=True)
         rows.append(row)
 

--- a/tests/unit/streamlit/test_streamlit_records.py
+++ b/tests/unit/streamlit/test_streamlit_records.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from trulens.dashboard.tabs.Records import _build_thread_summary
 from trulens.dashboard.tabs.Records import _conversation_metric_row
 from trulens.dashboard.tabs.Records import _conversation_turn_html
 from trulens.dashboard.tabs.Records import _partition_feedback_scopes
@@ -118,3 +119,80 @@ def test_split_short_conversation_keeps_all_turns_visible():
     assert first["record_id"].tolist() == ["turn-0", "turn-1"]
     assert middle.empty
     assert last.empty
+
+
+def _conversation_thread_records() -> pd.DataFrame:
+    """A two-turn thread whose conversation-scoped Topic Adherence metric is
+    recorded as 1.0 on one turn and 0.0 on the latest turn."""
+    base = {
+        "app_id": ["app", "app"],
+        "app_name": ["Test App", "Test App"],
+        "app_version": ["v1", "v1"],
+        "conversation_id": ["conv-1", "conv-1"],
+        "record_id": ["turn-1", "turn-2"],
+        "input": ["hi", "still off topic"],
+        "output": ["reply", "reply"],
+        "ts": pd.to_datetime(["2026-01-01", "2026-01-02"]),
+        "total_tokens": [1, 1],
+        "total_cost": [0.0, 0.0],
+        "cost_currency": ["USD", "USD"],
+        "latency": [1.0, 1.0],
+        "is_match": [True, True],
+        "Topic Adherence": [1.0, 0.0],
+        "Topic Adherence_calls": [
+            [
+                {
+                    "span_type": "eval_root",
+                    "args_span_attribute": {"records": "conversation.records"},
+                }
+            ],
+            [
+                {
+                    "span_type": "eval_root",
+                    "args_span_attribute": {"records": "conversation.records"},
+                }
+            ],
+        ],
+    }
+    return pd.DataFrame(base)
+
+
+def test_thread_summary_conversation_metric_matches_detail_view():
+    """Regression for #2725: the thread table must not average a
+    conversation-scoped metric across the thread's records. Averaging [1.0, 0.0]
+    surfaced 0.5 in the table while the conversation-metrics detail view showed
+    0.0 for the same thread. Both must agree on the latest recorded value."""
+    df = _conversation_thread_records()
+
+    conversation_metrics, _ = _partition_feedback_scopes(
+        df, ["Topic Adherence"]
+    )
+    assert conversation_metrics == ["Topic Adherence"]
+
+    detail_value = _conversation_metric_row(df, "Topic Adherence")[
+        "Topic Adherence"
+    ]
+    assert detail_value == 0.0
+
+    summary = _build_thread_summary(df, ["Topic Adherence"])
+    assert len(summary) == 1
+    table_value = summary.iloc[0]["Topic Adherence"]
+
+    # Must be the latest recorded value (0.0), not the mean (0.5).
+    assert table_value == detail_value
+    assert table_value == 0.0
+
+
+def test_thread_summary_turn_metric_still_averaged():
+    """Turn-scoped metrics must keep their per-turn mean; only conversation
+    metrics change."""
+    df = _conversation_thread_records()
+    df = df.drop(columns=["Topic Adherence", "Topic Adherence_calls"])
+    df["Answer Relevance"] = [1.0, 0.0]
+    df["Answer Relevance_calls"] = [
+        [{"span_type": "eval"}],
+        [{"span_type": "eval"}],
+    ]
+
+    summary = _build_thread_summary(df, ["Answer Relevance"])
+    assert summary.iloc[0]["Answer Relevance"] == 0.5


### PR DESCRIPTION
Closes #2725

## Problem

The Topic Adherence score shown in the top-level results table does not match the score under **Conversation metrics** for the same thread, the table shows `0.5` while the detail view shows `0.00`. As the reporter noted, this only happens when the conversation is completely off topic.

## Root cause

Topic Adherence is a **conversation-scoped** metric (`.on_conversation()`): the value describes the whole thread, but it is recorded across the thread's records. The two dashboard views select it differently:

- **Results table** - `_build_thread_summary` averages *every* feedback column across the thread's records (`ranking_group[fcol].mean(skipna=True)`), with no scope check.
- **Conversation metrics detail** - `_conversation_metric_row` uses the latest recorded value (`sort_values("ts").iloc[-1]`).

When the per-record values diverge, e.g. `[1.0, 0.0]` for a fully off-topic conversation, the table surfaces the mean (`0.5`) while the detail view shows the latest value (`0.0`). In-topic conversations tend to have consistent per-record values, so `mean ≈ latest` and the discrepancy doesn't appear, which matches the "only when completely off topic" observation.

## Fix

`_build_thread_summary` now partitions feedback columns by scope (reusing `_partition_feedback_scopes`) and, for conversation-scoped metrics, uses the latest recorded value, matching `_conversation_metric_row`. Turn-scoped metrics keep their per-turn mean.

## Tests

- `test_thread_summary_conversation_metric_matches_detail_view`, a two-turn thread with Topic Adherence `[1.0, 0.0]`; asserts the table value equals the detail-view value (`0.0`), not the mean (`0.5`). Fails on `main`, passes here.
- `test_thread_summary_turn_metric_still_averaged`, 
- 
- a turn-scoped metric still averages to `0.5`, confirming only conversation metrics change.

All existing `tests/unit/streamlit/test_streamlit_records.py` tests pass; lint/format clean under the pinned ruff.
