### PR TITLE
fix(database): correct dataset and ground-truth read round-trips (#2734)

### DIFF
--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -2044,7 +2044,7 @@ class SQLAlchemyDB(core_db.DB):
                 .filter_by(ground_truth_id=ground_truth_id)
                 .first()
             ):
-                return json.loads(_ground_truth)
+                return json.loads(_ground_truth.ground_truth_json)
 
     def get_ground_truths_by_dataset(
         self, dataset_name: str
@@ -2171,8 +2171,18 @@ class SQLAlchemyDB(core_db.DB):
         with self.session.begin() as session:
             results = session.query(self.orm.Dataset)
 
+            def _row(ds):
+                # Dataset ORM stores everything except the id in dataset_json;
+                # name and meta are not columns.
+                dataset_json = json.loads(ds.dataset_json)
+                return (
+                    ds.dataset_id,
+                    dataset_json.get("name"),
+                    dataset_json.get("meta"),
+                )
+
             return pd.DataFrame(
-                data=((ds.dataset_id, ds.name, ds.meta) for ds in results),
+                data=[_row(ds) for ds in results],
                 columns=["dataset_id", "name", "meta"],
             )
 

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -494,16 +494,7 @@ def _populate_data(db: core_db.DB):
 
 
 class TestDatasetGroundTruthRoundTrip(TestCase):
-    """Round-trip persistence for datasets and ground truths.
-
-    Regression tests for two bugs where the read path referenced attributes
-    that do not exist on the ORM objects:
-
-    - ``get_ground_truth`` called ``json.loads`` on the ORM row instead of its
-      ``ground_truth_json`` column, raising ``TypeError``.
-    - ``get_datasets`` read ``ds.name`` / ``ds.meta``, which are not columns
-      (they live inside ``dataset_json``), raising ``AttributeError``.
-    """
+    """Round-trip persistence for datasets and ground truths."""
 
     def _seed(self, db: sqlalchemy_db.SQLAlchemyDB):
         from trulens.core.schema.dataset import Dataset
@@ -528,8 +519,8 @@ class TestDatasetGroundTruthRoundTrip(TestCase):
 
             datasets = db.get_datasets()
 
-            self.assertListEqual(
-                list(datasets.columns), ["dataset_id", "name", "meta"]
+            self.assertEqual(
+                datasets.columns.tolist(), ["dataset_id", "name", "meta"]
             )
             self.assertEqual(len(datasets), 1)
             row = datasets.iloc[0]

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -491,3 +491,70 @@ def _populate_data(db: core_db.DB):
         print("  ", res)
 
     return fb, app, rec
+
+
+class TestDatasetGroundTruthRoundTrip(TestCase):
+    """Round-trip persistence for datasets and ground truths.
+
+    Regression tests for two bugs where the read path referenced attributes
+    that do not exist on the ORM objects:
+
+    - ``get_ground_truth`` called ``json.loads`` on the ORM row instead of its
+      ``ground_truth_json`` column, raising ``TypeError``.
+    - ``get_datasets`` read ``ds.name`` / ``ds.meta``, which are not columns
+      (they live inside ``dataset_json``), raising ``AttributeError``.
+    """
+
+    def _seed(self, db: sqlalchemy_db.SQLAlchemyDB):
+        from trulens.core.schema.dataset import Dataset
+        from trulens.core.schema.groundtruth import GroundTruth
+
+        dataset_id = db.insert_dataset(
+            Dataset(name="support-quality", meta={"source": "prod"})
+        )
+        ground_truth_id = db.insert_ground_truth(
+            GroundTruth(
+                query="what is the refund window?",
+                dataset_id=dataset_id,
+                expected_response="30 days from purchase.",
+            )
+        )
+        return dataset_id, ground_truth_id
+
+    def test_get_datasets_round_trip(self) -> None:
+        with clean_db("sqlite_file") as db:
+            db.migrate_database()
+            dataset_id, _ = self._seed(db)
+
+            datasets = db.get_datasets()
+
+            self.assertListEqual(
+                list(datasets.columns), ["dataset_id", "name", "meta"]
+            )
+            self.assertEqual(len(datasets), 1)
+            row = datasets.iloc[0]
+            self.assertEqual(row["dataset_id"], dataset_id)
+            self.assertEqual(row["name"], "support-quality")
+            self.assertEqual(row["meta"], {"source": "prod"})
+
+    def test_get_ground_truth_round_trip(self) -> None:
+        with clean_db("sqlite_file") as db:
+            db.migrate_database()
+            dataset_id, ground_truth_id = self._seed(db)
+
+            ground_truth = db.get_ground_truth(ground_truth_id)
+
+            self.assertIsInstance(ground_truth, dict)
+            self.assertEqual(ground_truth["ground_truth_id"], ground_truth_id)
+            self.assertEqual(
+                ground_truth["query"], "what is the refund window?"
+            )
+            self.assertEqual(
+                ground_truth["expected_response"], "30 days from purchase."
+            )
+            self.assertEqual(ground_truth["dataset_id"], dataset_id)
+
+    def test_get_ground_truth_missing_id_returns_none(self) -> None:
+        with clean_db("sqlite_file") as db:
+            db.migrate_database()
+            self.assertIsNone(db.get_ground_truth("does-not-exist"))


### PR DESCRIPTION
Closes #2734

## Problem

Two read methods on `SQLAlchemyDB` crash because they reference attributes that do not exist on the ORM objects:

- `get_ground_truth(ground_truth_id=...)` calls `json.loads()` on the ORM row instead of its `ground_truth_json` column, raising `TypeError: the JSON object must be str, bytes or bytearray, not GroundTruth`.
- `get_datasets()` reads `ds.name` / `ds.meta`, which are not columns (they live inside `dataset_json`), raising `AttributeError: 'Dataset' object has no attribute 'name'`.

Both break the dataset and ground-truth read round-trip on any backend.

## Fix

Both methods now read from the JSON payload, matching the existing `get_ground_truths_by_dataset`, which already does `json.loads(dataset.dataset_json)`:

- `get_ground_truth` loads `_ground_truth.ground_truth_json`.
- `get_datasets` parses each row's `dataset_json` and reads `name` / `meta` from it.

## Tests

Neither method had any test coverage, which is why these shipped. Added regression tests in `tests/integration/test_database.py`:

- `test_get_datasets_round_trip`
- `test_get_ground_truth_round_trip`
- `test_get_ground_truth_missing_id_returns_none`

The first two fail on `main` with the exact `AttributeError` / `TypeError` above and pass with this change. No other tests regress (the pre-existing failures on a clean tree are byte-identical). Lint and format are clean under the pinned ruff.
