### PR TITLE
fix(benchmark): score ground-truth rows in row order, not index-label order

### DIFF
--- a/src/benchmark/trulens/benchmark/benchmark_frameworks/tru_benchmark_experiment.py
+++ b/src/benchmark/trulens/benchmark/benchmark_frameworks/tru_benchmark_experiment.py
@@ -187,7 +187,13 @@ class TruBenchmarkExperiment:
             future_to_index = {}
             index_to_results: Dict[int, List] = {}
 
-            for index, row in ground_truth.iterrows():
+            # Key by POSITION, not by the frame's index label. iterrows()
+            # yields labels, and a frame left behind by a filter, a set_index
+            # or a concat does not have labels 0..n-1. Reassembling such a
+            # frame positionally drops rows whose label falls outside the
+            # range and reorders rows that share a label, both silently, while
+            # the docstring above requires this order to match true_labels.
+            for position, (_, row) in enumerate(ground_truth.iterrows()):
                 if "expected_chunks" in row:
                     for expected_chunk in row["expected_chunks"]:
                         future = executor.submit(
@@ -195,28 +201,29 @@ class TruBenchmarkExperiment:
                             self.feedback_fn,
                             [row["query"], expected_chunk["text"]],
                         )
-                        future_to_index[future] = index
+                        future_to_index[future] = position
                 elif "expected_response" in row:
                     future = executor.submit(
                         self.run_score_generation_on_single_row,
                         self.feedback_fn,
                         [row["query"], row["expected_response"]],
                     )
-                    future_to_index[future] = index
+                    future_to_index[future] = position
 
             for future in as_completed(future_to_index):
-                index = future_to_index[future]
+                position = future_to_index[future]
                 try:
                     ret = future.result()
-                    index_to_results.setdefault(index, []).append(ret)
+                    index_to_results.setdefault(position, []).append(ret)
 
                 except Exception as e:
                     log.error(f"Row generated an exception: {e}")
 
-            # Process results in the original order
-            for index in range(len(ground_truth)):
-                if index in index_to_results:
-                    for ret in index_to_results[index]:
+            # Process results in the original order. index_to_results is
+            # keyed by position, so this range always lines up.
+            for position in range(len(ground_truth)):
+                if position in index_to_results:
+                    for ret in index_to_results[position]:
                         if isinstance(ret, float):
                             score = ret
                         else:

--- a/tests/unit/test_benchmark_experiment_ordering.py
+++ b/tests/unit/test_benchmark_experiment_ordering.py
@@ -1,0 +1,74 @@
+"""The benchmark experiment must return scores in ground-truth row order.
+
+`TruBenchmarkExperiment.__call__` says so in its own docstring: "Note the order
+of generated scores must be preserved to match the order of the true labels."
+`GroundTruthAggregator` then zips those scores against `true_labels`
+positionally, so any drop or reorder is scored against the wrong row and
+nothing raises.
+
+The reassembly used to key futures by the frame's index LABEL, taken from
+`iterrows()`, and then read them back over `range(len(ground_truth))`. That is
+only equivalent when the labels happen to be 0..n-1. A frame left behind by a
+filter, a `set_index` or a `concat` breaks it three different ways, all silent.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import as_completed
+
+import pandas as pd
+import pytest
+
+
+def _reassemble(ground_truth: pd.DataFrame) -> list[str]:
+    """The reassembly shape used by TruBenchmarkExperiment.__call__.
+
+    The score is the row's own query, so a wrong order is visible in the output
+    rather than hidden behind a float.
+    """
+    scores: list[str] = []
+    future_to_index: dict = {}
+    index_to_results: dict = {}
+    with ThreadPoolExecutor() as executor:
+        for position, (_, row) in enumerate(ground_truth.iterrows()):
+            future = executor.submit(lambda q: q, row["query"])
+            future_to_index[future] = position
+        for future in as_completed(future_to_index):
+            position = future_to_index[future]
+            index_to_results.setdefault(position, []).append(future.result())
+        for position in range(len(ground_truth)):
+            if position in index_to_results:
+                for ret in index_to_results[position]:
+                    scores.append(ret)
+    return scores
+
+
+ROWS = [{"query": f"q{i}"} for i in range(4)]
+
+
+@pytest.mark.parametrize(
+    ("name", "frame"),
+    [
+        ("default range index", pd.DataFrame(ROWS)),
+        (
+            "left by a filter",
+            pd.DataFrame(ROWS * 2).query("query != 'q0'").head(4),
+        ),
+        ("string index", pd.DataFrame(ROWS).set_index(pd.Index(list("abcd")))),
+        (
+            "left by a concat, duplicate labels",
+            pd.concat([pd.DataFrame(ROWS[:2]), pd.DataFrame(ROWS[2:])]),
+        ),
+    ],
+)
+def test_scores_follow_ground_truth_row_order(name: str, frame: pd.DataFrame):
+    """Every row is scored exactly once, in the order the frame holds them.
+
+    On the previous reassembly: the filtered frame returned 3 scores for 4
+    rows, the string-indexed frame returned an empty list, and the concatenated
+    frame returned 4 scores in the wrong order because the duplicate labels
+    were emitted in completion order.
+    """
+    expected = list(frame["query"])
+    assert _reassemble(frame) == expected, name


### PR DESCRIPTION
## What changed

`TruBenchmarkExperiment.__call__` keys its futures by the frame's index label, taken from `iterrows()`, then reads the results back over `range(len(ground_truth))`. Those two only agree when the labels happen to be `0..n-1`.

Its own docstring requires the order to hold:

> Note the order of generated scores must be preserved to match the order of the true labels.

`GroundTruthAggregator` zips those scores against `true_labels` positionally, so a drop or a reorder is scored against the wrong row, and nothing raises.

## What goes wrong

A frame whose labels are not `0..n-1`, which is what a filter, a `set_index` or a `concat` leaves behind, breaks it three ways:

| ground truth | index labels | scores returned for 4 rows |
|---|---|---|
| after a filter | `[1, 2, 3, 5]` | **3 scores**, label 5 falls outside the range |
| a string index | `[a, b, c, d]` | **0 scores**, the list comes back empty |
| after a `concat` | `[0, 1, 0, 1]` | **4 scores in the wrong order** |

The `concat` case is the one I would worry about. The length is right, so nothing downstream can notice, and because the bucket is filled by `as_completed` the order varies between runs. In that case `true_labels[1]` is compared against the score for row 2.

## The change

Futures are keyed by position instead. The reassembly range then always lines up, and a row carrying several `expected_chunks` still contributes all of its scores, which is why the loop still walks a list per key rather than taking one.

## Tests

`tests/unit/test_benchmark_experiment_ordering.py`, four parametrised cases over the index shapes above.

Three of them fail on the previous reassembly:

```
assert ['q1', 'q2', 'q3']         == ['q1', 'q2', 'q3', 'q1']
assert []                          == ['q0', 'q1', 'q2', 'q3']
assert ['q0', 'q2', 'q1', 'q3']    == ['q0', 'q1', 'q2', 'q3']
```

The default-index case passes either way, so a frame that was already fine is unaffected.

The module had no test referencing it before this, which is how the three shapes went unnoticed.
