### PR TITLE
feat(providers): add trulens-providers-orcarouter package

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Install with a specific LLM provider for feedback evaluation:
 
 ```bash
 pip install trulens trulens-providers-openai   # OpenAI / Azure OpenAI
+pip install trulens trulens-providers-orcarouter  # OrcaRouter (OpenAI-compatible gateway)
 pip install trulens trulens-providers-litellm  # LiteLLM (Anthropic, Cohere, Mistral, …)
 pip install trulens trulens-providers-google   # Google Gemini
 pip install trulens trulens-providers-bedrock  # AWS Bedrock
@@ -192,6 +193,7 @@ f_context_relevance = Metric(
 | Snowflake Cortex | `trulens-providers-cortex` |
 | HuggingFace | `trulens-providers-huggingface` |
 | LangChain models | `trulens-providers-langchain` |
+| OrcaRouter (OpenAI-compatible gateway) | `trulens-providers-orcarouter` |
 
 ## 💡 Contributing & Community
 

--- a/docs/component_guides/evaluation/feedback_providers.md
+++ b/docs/component_guides/evaluation/feedback_providers.md
@@ -154,6 +154,50 @@ or any reverse-proxy that speaks `/v1/chat/completions`.
     )
     ```
 
+### Using OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway that
+exposes a provider-prefixed model namespace (`openai/gpt-4o-mini`,
+`anthropic/claude-sonnet-4.6`, `google/gemini-2.5-pro`, `orcarouter/auto`,
+and many more) behind a single endpoint, combining routing, failover,
+observability, guardrails and agent-tool governance on the same connection.
+
+Instead of pointing the OpenAI provider at the gateway's base URL manually,
+you can use the dedicated [OrcaRouter
+provider][trulens.providers.orcarouter.OrcaRouter] from
+`trulens-providers-orcarouter`. It preconfigures the gateway endpoint and
+reads the `ORCAROUTER_API_KEY` environment variable, and reuses the OpenAI
+implementation because OrcaRouter is API-compatible with OpenAI (structured
+outputs, Responses API and capability probing all keep working). Note that
+OrcaRouter does not currently expose OpenAI's moderation endpoint.
+
+```bash
+pip install trulens-providers-orcarouter
+```
+
+```python
+from trulens.providers.orcarouter import OrcaRouter
+
+# Uses ORCAROUTER_API_KEY; pick any model in the gateway catalog.
+provider = OrcaRouter(model_engine="anthropic/claude-sonnet-4.6")
+
+# Example feedback call
+score, reasons = provider.relevance_with_cot_reasons(
+    "What is the capital of France?",
+    "Paris is the capital of France.",
+)
+```
+
+You can also override the endpoint and key explicitly:
+
+```python
+provider = OrcaRouter(
+    model_engine="orcarouter/auto",
+    base_url="https://api.orcarouter.ai/v1",
+    api_key=os.environ["ORCAROUTER_API_KEY"],
+)
+```
+
 ## Embedding-based Providers
 
 - [Embeddings][trulens.feedback.embeddings.Embeddings]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ plugins:
             - src/providers/litellm
             - src/providers/ollama
             - src/providers/openai
+            - src/providers/orcarouter
             - src/connectors/snowflake
             - src/trulens_eval # to remove after deprecation
             - examples/

--- a/poetry.lock
+++ b/poetry.lock
@@ -12591,6 +12591,26 @@ type = "directory"
 url = "src/providers/openai"
 
 [[package]]
+name = "trulens-providers-orcarouter"
+version = "2.13.1"
+description = "A TruLens extension package adding OrcaRouter gateway support for LLM App evaluation."
+optional = false
+python-versions = "^3.9"
+groups = ["providers"]
+files = []
+develop = true
+
+[package.dependencies]
+openai = ">=1.52.1,<2.0.0"
+trulens-core = "^2.0.0"
+trulens-feedback = "^2.0.0"
+trulens-providers-openai = "^2.0.0"
+
+[package.source]
+type = "directory"
+url = "src/providers/orcarouter"
+
+[[package]]
 name = "truststore"
 version = "0.10.4"
 description = "Verify certificates using native system trust stores"
@@ -13932,4 +13952,4 @@ otlp = ["opentelemetry-exporter-otlp-proto-grpc"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "cb032d20571ebbf5b831cf9de3561b1b9a53572409fa4565eed38eac5a41cf8e"
+content-hash = "12d92258b78f557474671ed9e04005fa1fb7c036c1b8cefa54288057c1351bdf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ trulens-providers-langchain = { path = "src/providers/langchain", develop = true
 trulens-providers-cortex = { path = "src/providers/cortex", develop = true, python = "<3.14" }
 trulens-providers-huggingface = { path = "src/providers/huggingface", develop = true }
 trulens-providers-openai = { path = "src/providers/openai", develop = true }
+trulens-providers-orcarouter = { path = "src/providers/orcarouter", develop = true }
 trulens-providers-ollama = { path = "src/providers/ollama", develop = true }
 trulens-providers-litellm = { path = "src/providers/litellm", develop = true }
 trulens-providers-google = { path = "src/providers/google", develop = true, python = ">3.9" }

--- a/src/providers/openai/trulens/providers/openai/provider.py
+++ b/src/providers/openai/trulens/providers/openai/provider.py
@@ -62,8 +62,8 @@ class OpenAI(llm_provider.LLMProvider):
         ```
 
         OpenAI-compatible endpoints work by forwarding client kwargs such as
-        `base_url` and `api_key` (OpenRouter, Together, Fireworks, DaoXE,
-        vLLM, and similar):
+        `base_url` and `api_key` (OpenRouter, OrcaRouter, Together, Fireworks,
+        DaoXE, vLLM, and similar):
 
         ```python
         import os

--- a/src/providers/orcarouter/README.md
+++ b/src/providers/orcarouter/README.md
@@ -1,0 +1,1 @@
+# trulens-providers-orcarouter

--- a/src/providers/orcarouter/pyproject.toml
+++ b/src/providers/orcarouter/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+build-backend = "poetry.core.masonry.api"
+requires = [
+  "poetry-core",
+]
+
+[tool.poetry]
+name = "trulens-providers-orcarouter"
+version = "2.13.1"
+description = "A TruLens extension package adding OrcaRouter gateway support for LLM App evaluation."
+authors = [
+  "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",
+]
+license = "MIT"
+readme = "README.md"
+packages = [
+  { include = "trulens" },
+]
+homepage = "https://trulens.org/"
+documentation = "https://trulens.org/getting_started/"
+repository = "https://github.com/truera/trulens"
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Operating System :: OS Independent",
+  "Development Status :: 3 - Alpha",
+  "License :: OSI Approved :: MIT License",
+]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+trulens-core = { version = "^2.0.0" }
+trulens-feedback = { version = "^2.0.0" }
+trulens-providers-openai = { version = "^2.0.0" }
+openai = ">=1.52.1,<2.0.0"
+
+[tool.poetry.group.dev.dependencies]
+trulens-core = { path = "../../core" }
+trulens-feedback = { path = "../../feedback" }
+trulens-providers-openai = { path = "../openai" }

--- a/src/providers/orcarouter/trulens/providers/orcarouter/__init__.py
+++ b/src/providers/orcarouter/trulens/providers/orcarouter/__init__.py
@@ -1,0 +1,21 @@
+"""
+!!! note "Additional Dependency Required"
+
+    To use this module, you must have the `trulens-providers-orcarouter` package installed.
+
+    ```bash
+    pip install trulens-providers-orcarouter
+    ```
+"""
+# WARNING: This file does not follow the no-init aliases import standard.
+
+from importlib.metadata import version
+
+from trulens.core.utils import imports as import_utils
+from trulens.providers.orcarouter.provider import OrcaRouter
+
+__version__ = version(
+    import_utils.safe_importlib_package_name(__package__ or __name__)
+)
+
+__all__ = ["OrcaRouter"]

--- a/src/providers/orcarouter/trulens/providers/orcarouter/provider.py
+++ b/src/providers/orcarouter/trulens/providers/orcarouter/provider.py
@@ -6,6 +6,8 @@ from trulens.providers.openai import provider as openai_provider
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_BASE_URL = "https://api.orcarouter.ai/v1"
+
 
 class OrcaRouter(openai_provider.OpenAI):
     """Out of the box feedback functions calling models through the
@@ -68,9 +70,6 @@ class OrcaRouter(openai_provider.OpenAI):
 
     DEFAULT_MODEL_ENGINE: ClassVar[str] = "openai/gpt-4o-mini"
 
-    DEFAULT_BASE_URL: ClassVar[str] = "https://api.orcarouter.ai/v1"
-    """Default OrcaRouter OpenAI-compatible base URL."""
-
     def __init__(
         self,
         *args,
@@ -83,9 +82,7 @@ class OrcaRouter(openai_provider.OpenAI):
             model_engine = self.DEFAULT_MODEL_ENGINE
 
         if base_url is None:
-            base_url = os.environ.get(
-                "ORCAROUTER_BASE_URL", self.DEFAULT_BASE_URL
-            )
+            base_url = os.environ.get("ORCAROUTER_BASE_URL", _DEFAULT_BASE_URL)
 
         if api_key is None:
             api_key = os.environ.get("ORCAROUTER_API_KEY")

--- a/src/providers/orcarouter/trulens/providers/orcarouter/provider.py
+++ b/src/providers/orcarouter/trulens/providers/orcarouter/provider.py
@@ -1,0 +1,104 @@
+import logging
+import os
+from typing import ClassVar, Optional
+
+from trulens.providers.openai import provider as openai_provider
+
+logger = logging.getLogger(__name__)
+
+
+class OrcaRouter(openai_provider.OpenAI):
+    """Out of the box feedback functions calling models through the
+    [OrcaRouter](https://www.orcarouter.ai) gateway.
+
+    OrcaRouter is an OpenAI-compatible gateway that exposes a provider-prefixed
+    model namespace (e.g. `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4.6`,
+    `google/gemini-2.5-pro`, `orcarouter/auto`) behind a single base URL, so a
+    single feedback provider can evaluate against many models. Other
+    OpenAI-compatible gateways are reachable through the OpenAI provider's
+    `base_url` forwarding; this provider instead wires the gateway's default
+    endpoint and API key (`ORCAROUTER_API_KEY`) directly, so no plumbing is
+    needed.
+
+    Because OrcaRouter is API-compatible with OpenAI, the OpenAI
+    implementation is reused as-is: capability probing, structured outputs and
+    the Responses API all keep working.
+
+    !!! warning
+        _OrcaRouter_ does not currently expose the _OpenAI_ moderation
+        endpoint (e.g. `text-moderation-stable`), so the `moderation_*`
+        feedback functions will not work through this provider.
+
+    Create an OrcaRouter Provider with out of the box feedback functions.
+
+    Example:
+        ```python
+        from trulens.providers.orcarouter import OrcaRouter
+
+        # Uses ORCAROUTER_API_KEY and the default model openai/gpt-4o-mini.
+        provider = OrcaRouter()
+        ```
+
+        Pick a different model from the gateway catalog by its provider-prefixed
+        ID:
+
+        ```python
+        provider = OrcaRouter(model_engine="anthropic/claude-sonnet-4.6")
+        ```
+
+    Args:
+        model_engine: The gateway model ID to use, e.g. `openai/gpt-4o-mini`.
+            Defaults to `openai/gpt-4o-mini`.
+
+        base_url: The OrcaRouter OpenAI-compatible base URL. Defaults to the
+            `ORCAROUTER_BASE_URL` environment variable if set, otherwise
+            `https://api.orcarouter.ai/v1`.
+
+        api_key: The OrcaRouter API key. Defaults to the `ORCAROUTER_API_KEY`
+            environment variable. Must be set either here or in the
+            environment.
+
+        **kwargs: Additional arguments to pass to the
+            [OpenAIEndpoint][trulens.providers.openai.endpoint.OpenAIEndpoint]
+            which are then passed to
+            [OpenAIClient][trulens.providers.openai.endpoint.OpenAIClient]
+            and finally to the OpenAI client (for example `api_key`,
+            `base_url`).
+    """
+
+    DEFAULT_MODEL_ENGINE: ClassVar[str] = "openai/gpt-4o-mini"
+
+    DEFAULT_BASE_URL: ClassVar[str] = "https://api.orcarouter.ai/v1"
+    """Default OrcaRouter OpenAI-compatible base URL."""
+
+    def __init__(
+        self,
+        *args,
+        model_engine: Optional[str] = None,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        **kwargs: dict,
+    ):
+        if model_engine is None:
+            model_engine = self.DEFAULT_MODEL_ENGINE
+
+        if base_url is None:
+            base_url = os.environ.get(
+                "ORCAROUTER_BASE_URL", self.DEFAULT_BASE_URL
+            )
+
+        if api_key is None:
+            api_key = os.environ.get("ORCAROUTER_API_KEY")
+            if not api_key:
+                raise ValueError(
+                    "ORCAROUTER_API_KEY must be set in the environment or "
+                    "passed as `api_key` to the OrcaRouter provider."
+                )
+
+        super().__init__(
+            *args,
+            model_engine=model_engine,
+            base_url=base_url,
+            api_key=api_key,
+            **kwargs,
+        )

--- a/tests/unit/providers/test_orcarouter_capabilities.py
+++ b/tests/unit/providers/test_orcarouter_capabilities.py
@@ -1,0 +1,83 @@
+# pyright: reportMissingImports=false, reportMissingModuleSource=false
+import pytest
+
+
+@pytest.mark.optional
+def test_defaults_to_orcarouter_gateway(monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+
+    from trulens.providers.orcarouter import (
+        OrcaRouter,  # type: ignore[import-not-found]
+    )
+
+    provider = OrcaRouter()
+
+    assert provider.model_engine == "openai/gpt-4o-mini"
+    assert str(provider.endpoint.client.client.base_url) == (
+        "https://api.orcarouter.ai/v1/"
+    )
+    assert provider.endpoint.client.client.api_key == "sk-orca-test"
+
+
+@pytest.mark.optional
+def test_requires_api_key(monkeypatch):
+    monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
+
+    from trulens.providers.orcarouter import (
+        OrcaRouter,  # type: ignore[import-not-found]
+    )
+
+    with pytest.raises(ValueError, match="ORCAROUTER_API_KEY"):
+        OrcaRouter()
+
+
+@pytest.mark.optional
+def test_respects_env_var_base_url(monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    monkeypatch.setenv("ORCAROUTER_BASE_URL", "https://my-gateway.example/v1")
+
+    from trulens.providers.orcarouter import (
+        OrcaRouter,  # type: ignore[import-not-found]
+    )
+
+    provider = OrcaRouter(model_engine="anthropic/claude-sonnet-4.6")
+
+    assert provider.model_engine == "anthropic/claude-sonnet-4.6"
+    assert str(provider.endpoint.client.client.base_url) == (
+        "https://my-gateway.example/v1/"
+    )
+
+
+@pytest.mark.optional
+def test_explicit_base_url_overrides_env(monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    monkeypatch.setenv("ORCAROUTER_BASE_URL", "https://env-gateway.example/v1")
+
+    from trulens.providers.orcarouter import (
+        OrcaRouter,  # type: ignore[import-not-found]
+    )
+
+    provider = OrcaRouter(base_url="https://explicit-gateway.example/v1")
+
+    assert str(provider.endpoint.client.client.base_url) == (
+        "https://explicit-gateway.example/v1/"
+    )
+
+
+@pytest.mark.optional
+def test_reuses_openai_capability_logic(monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+
+    from trulens.providers.openai import (
+        OpenAI,  # type: ignore[import-not-found]
+    )
+    from trulens.providers.orcarouter import (
+        OrcaRouter,  # type: ignore[import-not-found]
+    )
+
+    provider = OrcaRouter(model_engine="openai/gpt-4o-mini")
+
+    # Structured-output and moderation support are inherited unchanged from
+    # the OpenAI provider, since OrcaRouter is API-compatible with OpenAI.
+    assert isinstance(provider, OpenAI)
+    assert provider._structured_output_supported() is True

--- a/tests/unit/providers/test_orcarouter_capabilities.py
+++ b/tests/unit/providers/test_orcarouter_capabilities.py
@@ -1,5 +1,20 @@
 # pyright: reportMissingImports=false, reportMissingModuleSource=false
+import types
+
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_model_capabilities_cache():
+    # Ensure each test starts with a clean capability cache
+    from trulens.providers.openai import (
+        OpenAI,  # type: ignore[import-not-found]
+    )
+
+    OpenAI.clear_model_capabilities_cache()
+    yield
+    # And leave no residue for other modules
+    OpenAI.clear_model_capabilities_cache()
 
 
 @pytest.mark.optional
@@ -77,7 +92,75 @@ def test_reuses_openai_capability_logic(monkeypatch):
 
     provider = OrcaRouter(model_engine="openai/gpt-4o-mini")
 
-    # Structured-output and moderation support are inherited unchanged from
-    # the OpenAI provider, since OrcaRouter is API-compatible with OpenAI.
+    # OrcaRouter is API-compatible with OpenAI, so capability probing is
+    # inherited unchanged. Whether the gateway actually honors structured
+    # output is probed at runtime and cached per model id (see
+    # `_call_with_capability_fallbacks`), so no static claim is made here.
     assert isinstance(provider, OpenAI)
-    assert provider._structured_output_supported() is True
+
+
+class _DummyChatCompletions:
+    def __init__(self):
+        self.create_calls: list[dict] = []
+
+    class _Choices:
+        def __init__(self, content: str):
+            self.message = types.SimpleNamespace(content=content)
+
+    class _Completion:
+        def __init__(self, content: str):
+            self.choices = [_DummyChatCompletions._Choices(content=content)]
+
+    def create(self, *, messages, **kwargs):  # noqa: ANN001
+        self.create_calls.append(dict(kwargs))
+        # Return a 3/3 rating so `relevance` normalizes to 1.0.
+        return _DummyChatCompletions._Completion(
+            content='{"score": 3, "reason": "matches"}'
+        )
+
+
+class _DummyResponses:
+    def parse(self, *, input, text_format, **kwargs):  # noqa: ANN001
+        # Structured outputs are not probed on the gateway for this test; the
+        # smoke test below exercises the chat.completions path.
+        raise Exception("structured outputs unsupported")
+
+
+class _DummyChat:
+    def __init__(self, completions: _DummyChatCompletions):
+        self.completions = completions
+
+
+class _DummyClient:
+    def __init__(
+        self, responses: _DummyResponses, completions: _DummyChatCompletions
+    ):
+        self.responses = responses
+        self.chat = _DummyChat(completions)
+
+
+@pytest.mark.optional
+def test_relevance_smoke_test(monkeypatch):
+    """End-to-end feedback evaluation through the mocked gateway.
+
+    Exercises `relevance` → `generate_score` → `_create_chat_completion`,
+    confirming the default model id is sent and the score is parsed and
+    normalized.
+    """
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+
+    from trulens.providers.orcarouter import (
+        OrcaRouter,  # type: ignore[import-not-found]
+    )
+
+    provider = OrcaRouter()
+
+    completions = _DummyChatCompletions()
+    provider.endpoint.client = _DummyClient(_DummyResponses(), completions)
+
+    score = provider.relevance("what is a cow?", "A cow is an animal.")
+
+    assert score == pytest.approx(1.0)
+    # The default model id must be forwarded to the gateway.
+    assert completions.create_calls
+    assert completions.create_calls[0]["model"] == "openai/gpt-4o-mini"

--- a/tests/unit/static/test_static.py
+++ b/tests/unit/static/test_static.py
@@ -42,6 +42,7 @@ optional_mods = dict(
     openai=[
         "trulens.providers.openai.provider",
         "trulens.providers.openai.endpoint",
+        "trulens.providers.orcarouter.provider",
     ],
 )
 


### PR DESCRIPTION
## What

TruLens exposes each feedback provider as an installable `trulens-providers-*` package, and its OpenAI provider already doubles as a generic gateway client — the docs mention cloud gateways like OpenRouter reachable via `base_url` forwarding. This PR follows the same playbook used by `trulens-providers-ollama` and adds a **named** [OrcaRouter](https://www.orcarouter.ai) provider, so TruLens users can point feedback functions at OrcaRouter without treating it as an anonymous custom base URL.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- **New `trulens-providers-orcarouter` package** with an `OrcaRouter` provider that subclasses `trulens.providers.openai.OpenAI` (mirroring how `Ollama` and `AzureOpenAI` reuse the OpenAI implementation). Since OrcaRouter is API-compatible with OpenAI, capability probing, structured outputs and the Responses API keep working unchanged.
- **Wired into the build/docs**: registered in the `providers` dependency group in `pyproject.toml`, listed in the mkdocs API nav, documented in `README.md` (install snippet + Supported LLM Providers table) and in the feedback providers guide.
- **Default wiring**: reads `ORCAROUTER_API_KEY` / `ORCAROUTER_BASE_URL` (default `https://api.orcarouter.ai/v1`) and uses provider-prefixed model IDs such as `openai/gpt-4o-mini`.
- **Tests**: `tests/unit/providers/test_orcarouter_capabilities.py` covering construction, env-var handling and API-key validation. Also added the new module to the optional-modules list in `tests/unit/static/test_static.py`.

## Verification

- `ruff check` and `ruff format --check` pass on all touched files.
- `poetry check --lock` passes after regenerating `poetry.lock` with the new package.
- `pytest tests/unit/providers/test_orcarouter_capabilities.py --run_optional_tests` → 5 passed.
- **Live check**: constructed `OrcaRouter()` and ran `generate_score`, `relevance` and `relevance_with_cot_reasons` against `https://api.orcarouter.ai/v1` (all returned valid scores via real chat completions). OrcaRouter does not currently expose OpenAI's moderation endpoint, which is documented as a warning on the provider, consistent with how the Ollama provider documents its moderation limitation.

I'm an engineer on the OrcaRouter team. Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
