### PR TITLE
fix(database): persist feedback definition updates on re-insert (#2742)

### DIFF
--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -598,7 +598,9 @@ class SQLAlchemyDB(core_db.DB):
                 )
                 .first()
             ):
-                _fb_def.app_json = feedback_definition.model_dump_json()
+                _fb_def.feedback_json = self.orm.FeedbackDefinition.parse(
+                    feedback_definition, redact_keys=self.redact_keys
+                ).feedback_json
             else:
                 _fb_def = self.orm.FeedbackDefinition.parse(
                     feedback_definition, redact_keys=self.redact_keys

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -549,3 +549,36 @@ class TestDatasetGroundTruthRoundTrip(TestCase):
         with clean_db("sqlite_file") as db:
             db.migrate_database()
             self.assertIsNone(db.get_ground_truth("does-not-exist"))
+
+
+class TestFeedbackDefinitionUpsert(TestCase):
+    """Regression test for a silent update loss.
+
+    ``insert_feedback_definition`` is an upsert. Its update branch assigned the
+    serialized definition to ``app_json``, which is not a column on the
+    ``FeedbackDefinition`` ORM (its JSON column is ``feedback_json``), so the
+    stray attribute was accepted by SQLAlchemy and the real column was never
+    updated. Re-inserting an existing id therefore dropped the change silently.
+    """
+
+    def test_reinsert_updates_definition(self) -> None:
+        from trulens.core.schema.feedback import FeedbackDefinition
+
+        with clean_db("sqlite_file") as db:
+            db.migrate_database()
+
+            db.insert_feedback_definition(
+                FeedbackDefinition(
+                    feedback_definition_id="fd1", supplied_name="ORIGINAL"
+                )
+            )
+            db.insert_feedback_definition(
+                FeedbackDefinition(
+                    feedback_definition_id="fd1", supplied_name="UPDATED"
+                )
+            )
+
+            defs = db.get_feedback_defs(feedback_definition_id="fd1")
+            self.assertEqual(len(defs), 1)
+            stored = defs.iloc[0]["feedback_json"]
+            self.assertEqual(stored["supplied_name"], "UPDATED")


### PR DESCRIPTION
Closes #2742

## Problem

`SQLAlchemyDB.insert_feedback_definition` is an upsert. Its update branch assigned the serialized definition to `_fb_def.app_json`, which is not a column on the `FeedbackDefinition` ORM (its JSON column is `feedback_json`). SQLAlchemy accepts the stray instance attribute, so `feedback_json` is never written and re-inserting an existing id silently drops the change. No exception is raised.

## Fix

Serialize through the ORM `parse` path, matching the insert branch and every sibling upsert, which also applies key redaction:

```python
_fb_def.feedback_json = self.orm.FeedbackDefinition.parse(
    feedback_definition, redact_keys=self.redact_keys
).feedback_json
```

## Tests

Adds `TestFeedbackDefinitionUpsert.test_reinsert_updates_definition` in `tests/integration/test_database.py`: it inserts a definition, re-inserts the same id with a changed `supplied_name`, and asserts the stored value updated. It fails on `main` (reads back the original value) and passes with this change. Lint and format clean under the pinned ruff.
