### PR TITLE
fix(run): compute_metrics message builds from metric names, not raw objects (#2744)

### DIFF
--- a/src/core/trulens/core/run.py
+++ b/src/core/trulens/core/run.py
@@ -1357,7 +1357,7 @@ class Run(BaseModel):
         if computed_metrics:
             return (
                 f"Cannot compute metrics because the following metric(s) are already computed or in progress: "
-                f"{', '.join(computed_metrics)}. If you want to recompute, please cancel the run and start a new one."
+                f"{', '.join(m if isinstance(m, str) else m.name for m in computed_metrics)}. If you want to recompute, please cancel the run and start a new one."
             )
 
         # Separate client-side and server-side metrics

--- a/tests/unit/test_run_compute_metrics.py
+++ b/tests/unit/test_run_compute_metrics.py
@@ -73,12 +73,14 @@ class TestComputeMetricsMessage(unittest.TestCase):
         """Metric object passed to compute_metrics yields message when already
         computed (no TypeError)."""
         metric = _make_metric("my_metric")
-        with patch.object(
-            Run, "describe", return_value=self.metadata
-        ), patch.object(
-            Run, "get_status", return_value="INVOCATION_COMPLETED"
-        ), patch.object(
-            Run, "_can_start_new_metric_computation", return_value=True
+        with (
+            patch.object(Run, "describe", return_value=self.metadata),
+            patch.object(
+                Run, "get_status", return_value="INVOCATION_COMPLETED"
+            ),
+            patch.object(
+                Run, "_can_start_new_metric_computation", return_value=True
+            ),
         ):
             result = self.run.compute_metrics([metric])
         self.assertIsInstance(result, str)
@@ -86,12 +88,14 @@ class TestComputeMetricsMessage(unittest.TestCase):
         self.assertIn("my_metric", result)
 
     def test_already_computed_metric_string_still_works(self):
-        with patch.object(
-            Run, "describe", return_value=self.metadata
-        ), patch.object(
-            Run, "get_status", return_value="INVOCATION_COMPLETED"
-        ), patch.object(
-            Run, "_can_start_new_metric_computation", return_value=True
+        with (
+            patch.object(Run, "describe", return_value=self.metadata),
+            patch.object(
+                Run, "get_status", return_value="INVOCATION_COMPLETED"
+            ),
+            patch.object(
+                Run, "_can_start_new_metric_computation", return_value=True
+            ),
         ):
             result = self.run.compute_metrics(["my_metric"])
         self.assertIsInstance(result, str)

--- a/tests/unit/test_run_compute_metrics.py
+++ b/tests/unit/test_run_compute_metrics.py
@@ -1,0 +1,103 @@
+"""Regression test for Run.compute_metrics message building.
+
+compute_metrics accepts metrics as strings or as Metric/MetricConfig objects.
+When an already-computed metric was passed as an object, the skip-path message
+did ", ".join(computed_metrics) over the raw objects, which raised TypeError
+instead of returning the user-facing "already computed" message.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+try:
+    from trulens.core import Selector
+    from trulens.core.dao.run import RunDaoBase
+    from trulens.core.metric.metric import Metric
+    from trulens.core.run import Run
+except Exception:  # pragma: no cover
+    Run = None
+
+
+def _make_run() -> "Run":
+    return Run.model_validate({
+        "run_name": "test_run",
+        "object_name": "TEST_AGENT",
+        "object_type": "EXTERNAL AGENT",
+        "object_version": "v1",
+        "run_metadata": {},
+        "source_info": {
+            "name": "dummy_source",
+            "column_spec": {"input": "INPUT"},
+            "source_type": "TABLE",
+        },
+        "app": MagicMock(),
+        "main_method_name": "dummy_method",
+        "run_dao": MagicMock(spec=RunDaoBase),
+        "tru_session": MagicMock(),
+    })
+
+
+def _make_metric(name: str) -> "Metric":
+    def impl(output: str) -> float:
+        return 1.0
+
+    return Metric(
+        implementation=impl,
+        name=name,
+        selectors={"output": Selector.select_record_output()},
+    )
+
+
+class TestComputeMetricsMessage(unittest.TestCase):
+    def setUp(self):
+        if Run is None:
+            self.skipTest("Run not available.")
+        self.run = _make_run()
+
+    def _patches(self):
+        completed = {
+            "run_metadata": {
+                "metrics": {
+                    "m1": {
+                        "name": "my_metric",
+                        "completion_status": {
+                            "status": Run.CompletionStatusStatus.COMPLETED
+                        },
+                    }
+                }
+            }
+        }
+        return (
+            patch.object(Run, "describe", return_value=completed),
+            patch.object(
+                Run, "get_status", return_value="INVOCATION_COMPLETED"
+            ),
+            patch.object(
+                Run, "_can_start_new_metric_computation", return_value=True
+            ),
+        )
+
+    def test_already_computed_metric_object_returns_message(self):
+        """A Metric object that is already computed yields the message, not a
+        TypeError from joining objects."""
+        metric = _make_metric("my_metric")
+        p1, p2, p3 = self._patches()
+        with p1, p2, p3:
+            result = self.run.compute_metrics([metric])
+        self.assertIsInstance(result, str)
+        self.assertIn("already computed", result)
+        self.assertIn("my_metric", result)
+
+    def test_already_computed_metric_string_still_works(self):
+        p1, p2, p3 = self._patches()
+        with p1, p2, p3:
+            result = self.run.compute_metrics(["my_metric"])
+        self.assertIsInstance(result, str)
+        self.assertIn("my_metric", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_run_compute_metrics.py
+++ b/tests/unit/test_run_compute_metrics.py
@@ -56,9 +56,7 @@ class TestComputeMetricsMessage(unittest.TestCase):
         if Run is None:
             self.skipTest("Run not available.")
         self.run = _make_run()
-
-    def _patches(self):
-        completed = {
+        self.metadata = {
             "run_metadata": {
                 "metrics": {
                     "m1": {
@@ -70,30 +68,31 @@ class TestComputeMetricsMessage(unittest.TestCase):
                 }
             }
         }
-        return (
-            patch.object(Run, "describe", return_value=completed),
-            patch.object(
-                Run, "get_status", return_value="INVOCATION_COMPLETED"
-            ),
-            patch.object(
-                Run, "_can_start_new_metric_computation", return_value=True
-            ),
-        )
 
     def test_already_computed_metric_object_returns_message(self):
-        """A Metric object that is already computed yields the message, not a
-        TypeError from joining objects."""
+        """Metric object passed to compute_metrics yields message when already
+        computed (no TypeError)."""
         metric = _make_metric("my_metric")
-        p1, p2, p3 = self._patches()
-        with p1, p2, p3:
+        with patch.object(
+            Run, "describe", return_value=self.metadata
+        ), patch.object(
+            Run, "get_status", return_value="INVOCATION_COMPLETED"
+        ), patch.object(
+            Run, "_can_start_new_metric_computation", return_value=True
+        ):
             result = self.run.compute_metrics([metric])
         self.assertIsInstance(result, str)
         self.assertIn("already computed", result)
         self.assertIn("my_metric", result)
 
     def test_already_computed_metric_string_still_works(self):
-        p1, p2, p3 = self._patches()
-        with p1, p2, p3:
+        with patch.object(
+            Run, "describe", return_value=self.metadata
+        ), patch.object(
+            Run, "get_status", return_value="INVOCATION_COMPLETED"
+        ), patch.object(
+            Run, "_can_start_new_metric_computation", return_value=True
+        ):
             result = self.run.compute_metrics(["my_metric"])
         self.assertIsInstance(result, str)
         self.assertIn("my_metric", result)


### PR DESCRIPTION
Closes #2744

## Problem

`Run.compute_metrics` accepts metrics as strings or as `Metric`/`MetricConfig` objects. When an already-computed or in-progress metric is passed as an object, the skip-path message does `", ".join(computed_metrics)` over the raw objects and raises `TypeError: sequence item 0: expected str instance, Metric found`, instead of returning the "already computed" message.

`_should_skip_computation` already reads `.name` from non-string metrics, so any object that reaches `computed_metrics` has a `.name`; only the message builder assumed strings.

## Fix

Join on the metric name, mirroring `_should_skip_computation`:

```python
", ".join(m if isinstance(m, str) else m.name for m in computed_metrics)
```

## Tests

Adds `tests/unit/test_run_compute_metrics.py` covering both the object and string cases. The object case fails on `main` with the `TypeError` above and passes with this change. Lint and format clean under the pinned ruff.
