### PR TITLE
fix(groundtruth): bound recall_at_k and ndcg_at_k on duplicate retrieved chunks (#2746)

### DIFF
--- a/src/feedback/trulens/feedback/groundtruth.py
+++ b/src/feedback/trulens/feedback/groundtruth.py
@@ -367,12 +367,18 @@ class GroundTruthAgreement(
             rel_scores = [0.0] * len(
                 retrieved_context_chunks
             )  # Initialize with 0 relevance for all
+            # Credit each golden chunk at most once: a retriever that returns
+            # the same relevant chunk more than once must not earn its
+            # relevance repeatedly, which would push DCG above the ideal DCG
+            # and yield NDCG > 1.
+            consumed_golden = set()
             for i, chunk in enumerate(retrieved_context_chunks[:k]):
-                if chunk in golden_chunks:
+                if chunk in golden_chunks and chunk not in consumed_golden:
                     index_in_golden = golden_chunks.index(chunk)
                     rel_scores[i] = golden_scores[
                         index_in_golden
                     ]  # Use the true relevance score
+                    consumed_golden.add(chunk)
 
             # Step 5: Compute NDCG@k directly from the standard formula.
             # DCG discounts each retrieved chunk's golden relevance by the
@@ -495,10 +501,11 @@ class GroundTruthAgreement(
                 # If no relevance scores, use the top-k retrieved chunks as they are
                 retrieved_top_k = retrieved_context_chunks[:k]
 
-            # Calculate recall at k with tie handling
-            relevant_retrieved = len([
-                chunk for chunk in retrieved_top_k if chunk in golden_chunks
-            ])
+            # Count unique golden chunks that were retrieved. Counting
+            # occurrences instead would let a retriever that returns the same
+            # relevant chunk more than once exceed the number of golden
+            # chunks, yielding recall > 1.
+            relevant_retrieved = len(golden_chunks & set(retrieved_top_k))
             return (
                 relevant_retrieved / len(golden_chunks)
                 if len(golden_chunks) > 0

--- a/tests/unit/test_groundtruth_ir_metrics.py
+++ b/tests/unit/test_groundtruth_ir_metrics.py
@@ -1,0 +1,55 @@
+"""Regression tests for IR metric bounds on duplicate retrieved chunks.
+
+recall_at_k counted occurrences of golden chunks in the retrieved list while
+its denominator is the number of unique golden chunks, so a retriever that
+returned the same relevant chunk twice produced recall > 1. ndcg_at_k credited
+every duplicate retrieved position, pushing DCG above the ideal DCG and
+yielding NDCG > 1. Both metrics are ratios bounded to [0, 1].
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from trulens.feedback.dummy.provider import DummyProvider
+from trulens.feedback.groundtruth import GroundTruthAgreement
+
+
+def _agreement(expected_chunks):
+    return GroundTruthAgreement(
+        ground_truth=[
+            {
+                "query": "q",
+                "expected_response": "",
+                "expected_chunks": expected_chunks,
+            }
+        ],
+        provider=DummyProvider(),
+    )
+
+
+class TestIRMetricDuplicateChunks(unittest.TestCase):
+    def test_recall_at_k_bounded_on_duplicate_relevant_chunk(self):
+        a = _agreement([{"text": "A", "expect_score": 1}])
+        self.assertEqual(a.recall_at_k("q", ["A", "A", "X"], k=3), 1.0)
+
+    def test_recall_at_k_true_value_with_duplicates(self):
+        a = _agreement([{"text": "A"}, {"text": "B"}])
+        # One of two golden chunks retrieved (twice) -> recall 0.5, not 1.0.
+        self.assertEqual(a.recall_at_k("q", ["A", "A"], k=2), 0.5)
+
+    def test_recall_at_k_unchanged_without_duplicates(self):
+        a = _agreement([{"text": "A"}, {"text": "B"}])
+        self.assertEqual(a.recall_at_k("q", ["A", "B"], k=2), 1.0)
+
+    def test_ndcg_at_k_bounded_on_duplicate_relevant_chunk(self):
+        a = _agreement([{"text": "A", "expect_score": 1}])
+        self.assertLessEqual(a.ndcg_at_k("q", ["A", "A"], k=2), 1.0)
+
+    def test_ndcg_at_k_perfect_ranking_unchanged(self):
+        a = _agreement([{"text": "A"}, {"text": "B"}])
+        self.assertAlmostEqual(a.ndcg_at_k("q", ["A", "B"], k=2), 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2746

## Problem

`GroundTruthAgreement.recall_at_k` and `ndcg_at_k` can return values above 1.0 when the retriever returns the same relevant chunk more than once. Both are ratios bounded to `[0, 1]`.

- `recall_at_k` counts occurrences of golden chunks in the retrieved list while dividing by the number of unique golden chunks (`golden_chunks` is a set), so a duplicated relevant chunk makes the numerator exceed the denominator. It also reports the wrong value in the non-overshoot case: golden `{A, B}` with retrieved `["A", "A"]` returns `1.0` where the true recall is `0.5`.
- `ndcg_at_k` credits every duplicate retrieved position, so DCG exceeds the ideal DCG (which counts each golden chunk once).

## Fix

- `recall_at_k` counts unique golden chunks that were retrieved: `len(golden_chunks & set(retrieved_top_k))`.
- `ndcg_at_k` credits each golden chunk at most once (tracks consumed golden chunks while building the relevance vector).

Non-duplicate behavior is unchanged. `precision_at_k` is unaffected because its denominator grows with the retrieved list.

## Tests

Adds `tests/unit/test_groundtruth_ir_metrics.py` covering both metrics on duplicate chunks plus non-duplicate sanity cases. The duplicate cases fail on `main` (recall 2.0, ndcg ~1.63) and pass here. Lint and format clean under the pinned ruff.
