### PR TITLE
fix(groundtruth): refuse a score list that does not match the labels in recall and precision

### DIFF
--- a/src/feedback/trulens/feedback/groundtruth.py
+++ b/src/feedback/trulens/feedback/groundtruth.py
@@ -1018,6 +1018,22 @@ class GroundTruthAggregator(
 
         setattr(self, name, lambda scores: func(scores, self))
 
+    def _check_length(self, scores: list) -> None:
+        """Refuse a score list that does not line up with the labels.
+
+        recall and precision walk the two lists with zip, which stops at the
+        shorter one. A score list that lost a row somewhere upstream is then
+        scored against the wrong labels for every row after the gap, and the
+        result is an ordinary-looking number. brier_score, ece and
+        cohens_kappa already refuse this; this makes the classification
+        metrics do the same.
+        """
+        if len(scores) != len(self.true_labels):
+            raise ValueError(
+                "The length of true_labels and scores must be the same; "
+                f"got {len(self.true_labels)} labels and {len(scores)} scores."
+            )
+
     def auc(self, scores: list[float]) -> float:
         """
         Calculate the area under the ROC curve. Can be used for meta-evaluation.
@@ -1158,15 +1174,10 @@ class GroundTruthAggregator(
         - float: The recall score.
         """
 
-        try:
-            if isinstance(scores[0], list):
-                scores = [score for score, _ in scores]
-        except Exception as e:  # noqa: BLE001
-            import traceback
+        if isinstance(scores[0], list):
+            scores = [score for score, _ in scores]
+        self._check_length(scores)
 
-            traceback.print_exc()
-            logger.error(f"scores processing failed in Recall aggregator: {e}")
-            print(f"scores processing failed in Recall aggregator: {e}")
         # Convert scores to binary predictions based on the threshold
         predictions = [1 if score >= threshold else 0 for score in scores]
 
@@ -1206,6 +1217,7 @@ class GroundTruthAggregator(
         """
         if isinstance(scores[0], list):
             scores = [score for score, _ in scores]
+        self._check_length(scores)
 
         # Convert scores to binary predictions based on the threshold
         predictions = [1 if score >= threshold else 0 for score in scores]

--- a/tests/unit/test_groundtruth_aggregator.py
+++ b/tests/unit/test_groundtruth_aggregator.py
@@ -67,6 +67,21 @@ class TestGroundTruthAggregator(TestCase):
         ):
             self.aggregator.ece([(0.5, 0.8), (0.3, 0.7)])
 
+        # recall, precision and f1_score used to zip past the gap and score
+        # the surviving rows against the wrong labels.
+        for method in (
+            self.aggregator.recall,
+            self.aggregator.precision,
+            self.aggregator.f1_score,
+        ):
+            with self.assertRaises(
+                ValueError,
+                msg=f"{method.__name__} should reject mismatched lengths",
+            ):
+                method(short_scores)
+        with self.assertRaises(ValueError):
+            self.aggregator.recall([0.9] * (len(self.true_labels) + 1))
+
         # Test with invalid score types (should handle gracefully or raise clear errors)
         with self.assertRaises(
             (TypeError, ValueError), msg="Methods should handle invalid types"


### PR DESCRIPTION
`recall` and `precision` walk `scores` and `true_labels` with `zip`, which stops at the shorter list. If the score list lost a row somewhere upstream, every row after the gap is scored against the wrong label, and the result is an ordinary-looking number.

On `main`, with `true_labels=[1, 0, 1, 0, 1]` and four scores `[0.9, 0.9, 0.1, 0.9]` (one row missing):

```
recall    -> 0.5
precision -> 0.3333
```

Nothing raises. `brier_score`, `ece` and `cohens_kappa` in the same class already refuse a length mismatch, so the classification metrics were the odd ones out.

## Change

- A small `_check_length` helper, called from `recall` and `precision` after the list-of-lists unpack, raising `ValueError` with both lengths in the message (the same shape `cohens_kappa` uses). `f1_score` inherits it through the two calls it makes.
- The `try/except` around the unpack in `recall`, which printed a traceback and carried on, is removed. `precision` never had it, and the comparison on the next line would have raised anyway.

## Not changed

`mae` builds two arrays and subtracts, so a mismatch already raises from numpy, except when one side has length 1 and broadcasts. I have left that alone here rather than widen this.

## Tests

Folded into `test_input_validation_comprehensive`, next to the existing brier and ECE cases: `recall`, `precision` and `f1_score` each reject a short list, and `recall` rejects a long one. With the source change reverted, that test fails on `main`; with it, the file passes (22 passed, `TEST_OPTIONAL=true`).
