### PR TITLE
fix(dashboard): label conversation-scoped thread columns as latest, not avg

### DIFF
--- a/src/dashboard/trulens/dashboard/tabs/Records.py
+++ b/src/dashboard/trulens/dashboard/tabs/Records.py
@@ -931,6 +931,7 @@ def _build_thread_grid_options(
     df: pd.DataFrame,
     feedback_col_names: Sequence[str],
     feedback_directions: Dict[str, bool],
+    conversation_cols: Optional[Sequence[str]] = None,
 ):
     from st_aggrid.grid_options_builder import GridOptionsBuilder
 
@@ -1028,6 +1029,7 @@ def _build_thread_grid_options(
         filter="agDateColumnFilter",
     )
 
+    conversation_cols = set(conversation_cols or ())
     for fcol in feedback_col_names:
         if fcol not in df.columns:
             continue
@@ -1036,9 +1038,12 @@ def _build_thread_grid_options(
             if feedback_directions.get(fcol, default_direction)
             else "LOWER_IS_BETTER"
         )
+        # Conversation-scoped metrics are shown as the latest value per thread,
+        # not an average, so they must not carry an "(avg)" header.
+        suffix = "(latest)" if fcol in conversation_cols else "(avg)"
         gb.configure_column(
             fcol,
-            header_name=f"{fcol} (avg)",
+            header_name=f"{fcol} {suffix}",
             cellClassRules=cell_rules[feedback_direction],
             hide=False,
         )
@@ -1058,6 +1063,7 @@ def _render_thread_grid(
     df: pd.DataFrame,
     feedback_col_names: Sequence[str],
     feedback_directions: Dict[str, bool],
+    conversation_cols: Optional[Sequence[str]] = None,
 ):
     if not is_sis_compatibility_enabled():
         try:
@@ -1071,6 +1077,7 @@ def _render_thread_grid(
                     df=df,
                     feedback_col_names=feedback_col_names,
                     feedback_directions=feedback_directions,
+                    conversation_cols=conversation_cols,
                 ),
                 update_on=["selectionChanged"],
                 custom_css={**aggrid_css, **radio_button_css},
@@ -1415,10 +1422,15 @@ def _render_thread_view(
         st.info("No threads to display.", icon="ℹ️")
         return
 
+    # Conversation-scoped columns show the latest value, not an average (see
+    # _build_thread_summary), so they must not be labelled "(avg)".
+    conversation_cols, _ = _partition_feedback_scopes(df, feedback_col_names)
+
     selected = _render_thread_grid(
         thread_summary,
         feedback_col_names=feedback_col_names,
         feedback_directions=feedback_directions,
+        conversation_cols=conversation_cols,
     )
 
     valid_keys = set(thread_summary["thread_key"].tolist())

--- a/tests/unit/streamlit/test_streamlit_records.py
+++ b/tests/unit/streamlit/test_streamlit_records.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from trulens.dashboard.tabs.Records import _build_thread_grid_options
 from trulens.dashboard.tabs.Records import _build_thread_summary
 from trulens.dashboard.tabs.Records import _conversation_metric_row
 from trulens.dashboard.tabs.Records import _conversation_turn_html
@@ -248,3 +249,49 @@ def test_thread_summary_turn_metric_still_averaged():
 
     summary = _build_thread_summary(df, ["Answer Relevance"])
     assert summary.iloc[0]["Answer Relevance"] == 0.5
+
+
+def test_thread_grid_header_labels_conversation_vs_turn_metrics():
+    """Regression for the #2725 follow-up: conversation-scoped metric columns
+    show the latest value per thread, so their header must read "(latest)",
+    while turn-scoped metrics keep "(avg)"."""
+    summary = pd.DataFrame({
+        "thread_key": ["t1"],
+        "app_name": ["a"],
+        "app_version": ["v1"],
+        "app_id": ["id"],
+        "num_messages": [2],
+        "matched_turn_count": [1],
+        "total_turn_count": [2],
+        "first_input": ["q"],
+        "last_output": ["o"],
+        "start_ts": ["2026-01-01"],
+        "ts": ["2026-01-02"],
+        "total_tokens": [1],
+        "total_cost": [0.0],
+        "cost_currency": ["USD"],
+        "latency": [1.0],
+        "is_thread": [True],
+        "conversation_id": ["c1"],
+        "record_id": [None],
+        "Topic Adherence": [0.0],
+        "Answer Relevance": [0.5],
+    })
+
+    options = _build_thread_grid_options(
+        df=summary,
+        feedback_col_names=["Topic Adherence", "Answer Relevance"],
+        feedback_directions={
+            "Topic Adherence": True,
+            "Answer Relevance": True,
+        },
+        conversation_cols=["Topic Adherence"],
+    )
+
+    headers = {
+        c["field"]: c.get("headerName")
+        for c in options["columnDefs"]
+        if c.get("field") in ("Topic Adherence", "Answer Relevance")
+    }
+    assert headers["Topic Adherence"] == "Topic Adherence (latest)"
+    assert headers["Answer Relevance"] == "Answer Relevance (avg)"


### PR DESCRIPTION
Follow-up to #2725.

## Problem

#2725 fixed the thread summary table to show the latest value for conversation-scoped metrics (like Topic Adherence) instead of the mean. That change touched the value computation but not the grid header, which still labels every feedback column `"(avg)"`. So a conversation-scoped metric now reads as an average in the header while the cell shows the latest value. This inconsistency was introduced by #2725.

## Fix

`_render_thread_view` already has the records DataFrame, so it computes the conversation-scoped columns via `_partition_feedback_scopes` and threads them through `_render_thread_grid` into `_build_thread_grid_options`. Conversation-scoped columns are labelled `"(latest)"`; turn-scoped columns keep `"(avg)"`.

## Tests

Adds `test_thread_grid_header_labels_conversation_vs_turn_metrics` in `tests/unit/streamlit/test_streamlit_records.py`, asserting a conversation-scoped column gets `"(latest)"` and a turn-scoped column gets `"(avg)"`. Lint and format clean under the pinned ruff.
