### PR TITLE
fix(providers/openai): moderation_harassment_threatening reads its own category (#2751)

### DIFF
--- a/src/providers/openai/trulens/providers/openai/provider.py
+++ b/src/providers/openai/trulens/providers/openai/provider.py
@@ -753,7 +753,7 @@ class OpenAI(llm_provider.LLMProvider):
         return float(openai_response.category_scores.harassment)
 
     def moderation_harassment_threatening(self, text: str) -> float:
-        """A function that checks if text is about graphic violence.
+        """A function that checks if text is about harassment/threatening.
 
         Example:
             ```python
@@ -779,7 +779,7 @@ class OpenAI(llm_provider.LLMProvider):
         """
         openai_response = self._moderation(text)
 
-        return float(openai_response.category_scores.harassment)
+        return float(openai_response.category_scores.harassment_threatening)
 
 
 class AzureOpenAI(OpenAI):

--- a/tests/unit/providers/test_openai_moderation.py
+++ b/tests/unit/providers/test_openai_moderation.py
@@ -1,0 +1,39 @@
+"""Regression test: each moderation_* method must report its own category.
+
+moderation_harassment_threatening read category_scores.harassment (a copy-paste
+of moderation_harassment) instead of harassment_threatening, so it silently
+returned the plain harassment score.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+import unittest
+
+try:
+    from trulens.providers.openai import OpenAI
+except Exception:  # pragma: no cover
+    OpenAI = None
+
+
+class TestOpenAIModerationCategories(unittest.TestCase):
+    def setUp(self):
+        if OpenAI is None:
+            self.skipTest("trulens-providers-openai not available.")
+
+    def _provider(self, **category_scores):
+        provider = OpenAI.__new__(OpenAI)  # skip __init__ (needs an API key)
+        response = SimpleNamespace(
+            category_scores=SimpleNamespace(**category_scores)
+        )
+        provider._moderation = lambda text: response
+        return provider
+
+    def test_harassment_and_threatening_read_distinct_fields(self):
+        provider = self._provider(harassment=0.11, harassment_threatening=0.99)
+        self.assertEqual(provider.moderation_harassment("x"), 0.11)
+        self.assertEqual(provider.moderation_harassment_threatening("x"), 0.99)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2751

## Problem

`OpenAI.moderation_harassment_threatening` returns `category_scores.harassment` instead of `category_scores.harassment_threatening`, so it silently reports the plain harassment score. Every other `moderation_*` method reads its own distinct category field. The method's summary docstring was also copy-pasted from the graphic-violence method.

## Fix

Read `category_scores.harassment_threatening`, and correct the docstring summary line. `moderation_harassment` is unchanged.

## Tests

Adds `tests/unit/providers/test_openai_moderation.py` asserting the two methods return distinct fields (harassment vs harassment_threatening). It fails on `main` and passes with this change. Lint and format clean under the pinned ruff.
