### PR TITLE
fix(apps): use Lens.get for methods_to_instrument existence check (#2753)

### DIFF
--- a/src/core/trulens/apps/app.py
+++ b/src/core/trulens/apps/app.py
@@ -410,7 +410,7 @@ class TruApp(core_app.App):
             # Check whether the path/location of the method is in json serialization and
             # if not, add a placeholder to app_extra_json.
             try:
-                next(full_path(json))
+                next(full_path.get(json))
 
                 print(
                     f"{text_utils.UNICODE_CHECK} Added method {m.__name__} under component at path {full_path}"

--- a/tests/unit/test_truapp_methods_to_instrument.py
+++ b/tests/unit/test_truapp_methods_to_instrument.py
@@ -1,0 +1,35 @@
+"""Regression guard for the methods_to_instrument path-existence check.
+
+TruApp.__init__ checks whether an instrumented method's component exists in the
+serialized app before adding a placeholder. It used `next(full_path(json))`,
+but a Lens is not callable as a lookup: `Lens.__call__` only accepts a path
+ending in `collect` and otherwise raises TypeError. So the check always failed,
+the "Added method ... under component" success branch was dead, and users saw a
+spurious "App has no component at path" warning even when the component existed.
+The fix uses `full_path.get(json)`, matching the sibling check in the same
+method. This test pins the Lens contract that makes `.get` mandatory.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from trulens.core.utils.serial import Lens
+
+
+class TestLensLookupContract(unittest.TestCase):
+    def test_get_reads_existing_path_but_call_raises(self):
+        json = {"app": {"component": {"leaf": 42}}}
+        full_path = Lens().app.component.leaf
+
+        # The read the fix relies on.
+        self.assertEqual(next(full_path.get(json)), 42)
+
+        # Calling a non-`collect` Lens is not a lookup and raises, which is why
+        # the existence check must use `.get`, not `__call__`.
+        with self.assertRaises(TypeError):
+            next(full_path(json))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2753

## Problem

`TruApp.__init__` checks whether an instrumented method's component exists in the serialized app using `next(full_path(json))`. A `Lens` is not callable as a lookup: `Lens.__call__` only accepts a path ending in `collect` and otherwise raises `TypeError`. Since `full_path` never ends in `collect`, the check always raises. As a result the `✓ Added method ... under component` success branch is dead code, and users who pass `methods_to_instrument` always get a spurious `App has no component at path ...` warning even when the component exists.

The sibling existence check in the same method already uses the correct `full_path.get(json)`.

## Fix

Use `full_path.get(json)` for the existence check, matching the sibling.

## Tests

Adds `tests/unit/test_truapp_methods_to_instrument.py` pinning the Lens lookup contract: a non-`collect` path is read with `.get()` and yields the value, while calling it raises `TypeError` (the misuse the fix corrects). Lint and format clean under the pinned ruff.
