### PR TITLE
fix(providers/anthropic): Anthropic cost tracking crashes on core_endpoint.Cost (#2755)

### DIFF
--- a/src/providers/anthropic/trulens/providers/anthropic/endpoint.py
+++ b/src/providers/anthropic/trulens/providers/anthropic/endpoint.py
@@ -13,6 +13,7 @@ from typing import (
 from litellm import model_cost
 import pydantic
 from trulens.core.feedback import endpoint as core_endpoint
+from trulens.core.schema import base as base_schema
 from trulens.otel.semconv.trace import SpanAttributes
 
 import anthropic
@@ -91,9 +92,9 @@ class AnthropicCallback(core_endpoint.EndpointCallback):
         super().handle_generation(response)
         cost_info = AnthropicCostComputer.handle_response(response)
 
-        addl_cost = core_endpoint.Cost(
+        addl_cost = base_schema.Cost(
             cost=cost_info.get(SpanAttributes.COST.COST, 0.0),
-            currency=cost_info.get(SpanAttributes.COST.CURRENCY, "USD"),
+            cost_currency=cost_info.get(SpanAttributes.COST.CURRENCY, "USD"),
             n_tokens=cost_info.get(SpanAttributes.COST.NUM_TOKENS, 0),
             n_prompt_tokens=cost_info.get(
                 SpanAttributes.COST.NUM_PROMPT_TOKENS, 0
@@ -190,9 +191,11 @@ class AnthropicEndpoint(core_endpoint.Endpoint):
 
         cost_info = AnthropicCostComputer.handle_response(response)
         for cb in callbacks:
-            addl_cost = core_endpoint.Cost(
+            addl_cost = base_schema.Cost(
                 cost=cost_info.get(SpanAttributes.COST.COST, 0.0),
-                currency=cost_info.get(SpanAttributes.COST.CURRENCY, "USD"),
+                cost_currency=cost_info.get(
+                    SpanAttributes.COST.CURRENCY, "USD"
+                ),
                 n_tokens=cost_info.get(SpanAttributes.COST.NUM_TOKENS, 0),
                 n_prompt_tokens=cost_info.get(
                     SpanAttributes.COST.NUM_PROMPT_TOKENS, 0

--- a/tests/unit/providers/test_anthropic_cost.py
+++ b/tests/unit/providers/test_anthropic_cost.py
@@ -1,0 +1,41 @@
+"""Regression test: Anthropic cost callback must not crash.
+
+AnthropicCallback.handle_generation and AnthropicEndpoint.handle_wrapped_call
+built cost with core_endpoint.Cost, but trulens.core.feedback.endpoint has no
+Cost symbol, so every Anthropic call through the cost callback raised
+AttributeError. They also passed currency= where the field is cost_currency.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+import unittest
+
+try:
+    from trulens.core.schema import base as base_schema
+    from trulens.providers.anthropic.endpoint import AnthropicCallback
+except Exception:  # pragma: no cover
+    AnthropicCallback = None
+
+
+class TestAnthropicCostCallback(unittest.TestCase):
+    def setUp(self):
+        if AnthropicCallback is None:
+            self.skipTest("trulens-providers-anthropic not available.")
+
+    def test_handle_generation_accumulates_cost_without_crashing(self):
+        cb = AnthropicCallback.model_construct(cost=base_schema.Cost())
+        response = SimpleNamespace(
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+            model="claude-3-5-sonnet-20241022",
+        )
+
+        cb.handle_generation(response)  # raised AttributeError on main
+
+        self.assertEqual(cb.cost.n_tokens, 15)
+        self.assertEqual(cb.cost.n_prompt_tokens, 10)
+        self.assertEqual(cb.cost.cost_currency, "USD")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2755

## Problem

The Anthropic endpoint builds cost with `core_endpoint.Cost(...)` in two places, but `trulens.core.feedback.endpoint` exposes no `Cost` symbol, so every Anthropic call through the cost callback raises `AttributeError: module 'trulens.core.feedback.endpoint' has no attribute 'Cost'`. Both sites also pass `currency=`, but the `Cost` field is `cost_currency`, so a non-USD currency would be dropped once the crash is fixed. The sibling OpenAI endpoint uses `base_schema.Cost(...)`.

## Fix

Import `trulens.core.schema.base as base_schema` (as the OpenAI endpoint does), use `base_schema.Cost(...)` at both sites, and pass `cost_currency=` instead of `currency=`.

## Tests

Adds `tests/unit/providers/test_anthropic_cost.py`, which runs `AnthropicCallback.handle_generation` end to end and asserts cost/tokens accumulate. It fails on `main` with the `AttributeError` above and passes with this change. Lint and format clean under the pinned ruff.
