### PR TITLE
TruLens 2.14.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -12063,7 +12063,7 @@ reference = "pypi-public"
 
 [[package]]
 name = "trulens-apps-claude"
-version = "2.13.1"
+version = "2.14.0"
 description = "Claude Code hook instrumentation plugin for TruLens."
 optional = false
 python-versions = "^3.9"
@@ -12080,7 +12080,7 @@ url = "src/apps/claude"
 
 [[package]]
 name = "trulens-apps-cursor"
-version = "2.13.1"
+version = "2.14.0"
 description = "Cursor hook instrumentation plugin for TruLens."
 optional = false
 python-versions = "^3.9"
@@ -12097,7 +12097,7 @@ url = "src/apps/cursor"
 
 [[package]]
 name = "trulens-apps-gepa"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -12114,7 +12114,7 @@ url = "src/apps/gepa"
 
 [[package]]
 name = "trulens-apps-langchain"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -12135,7 +12135,7 @@ url = "src/apps/langchain"
 
 [[package]]
 name = "trulens-apps-langgraph"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LangGraph based applications."
 optional = false
 python-versions = "^3.9"
@@ -12161,7 +12161,7 @@ url = "src/apps/langgraph"
 
 [[package]]
 name = "trulens-apps-llamaindex"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -12185,7 +12185,7 @@ url = "src/apps/llamaindex"
 
 [[package]]
 name = "trulens-apps-opencode"
-version = "2.13.1"
+version = "2.14.0"
 description = "OpenCode hook instrumentation plugin for TruLens."
 optional = false
 python-versions = "^3.9"
@@ -12202,7 +12202,7 @@ url = "src/apps/opencode"
 
 [[package]]
 name = "trulens-apps-rl"
-version = "2.13.1"
+version = "2.14.0"
 description = "RL reward integration for TruLens feedback metrics."
 optional = false
 python-versions = "^3.9"
@@ -12219,7 +12219,7 @@ url = "src/apps/rl"
 
 [[package]]
 name = "trulens-benchmark"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -12237,7 +12237,7 @@ url = "src/benchmark"
 
 [[package]]
 name = "trulens-connectors-snowflake"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9,<3.14"
@@ -12257,7 +12257,7 @@ url = "src/connectors/snowflake"
 
 [[package]]
 name = "trulens-core"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -12296,7 +12296,7 @@ url = "src/core"
 
 [[package]]
 name = "trulens-dashboard"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9,!=3.9.7"
@@ -12326,7 +12326,7 @@ url = "src/dashboard"
 
 [[package]]
 name = "trulens-eval"
-version = "2.13.1"
+version = "2.14.0"
 description = "Backwards-compatibility package for API of trulens_eval<1.0.0 using API of trulens-*>=1.0.0."
 optional = false
 python-versions = "^3.9,!=3.9.7"
@@ -12345,7 +12345,7 @@ url = "src/trulens_eval"
 
 [[package]]
 name = "trulens-feedback"
-version = "2.13.1"
+version = "2.14.0"
 description = "A TruLens extension package implementing feedback functions for LLM App evaluation."
 optional = false
 python-versions = "^3.9"
@@ -12368,7 +12368,7 @@ url = "src/feedback"
 
 [[package]]
 name = "trulens-hotspots"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library and command-line tool to list features lowering your evaluation score."
 optional = false
 python-versions = "^3.9"
@@ -12388,7 +12388,7 @@ url = "src/hotspots"
 
 [[package]]
 name = "trulens-otel-semconv"
-version = "2.13.1"
+version = "2.14.0"
 description = "Semantic conventions for spans produced by TruLens."
 optional = false
 python-versions = "^3.9"
@@ -12406,7 +12406,7 @@ url = "src/otel/semconv"
 
 [[package]]
 name = "trulens-providers-anthropic"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -12426,7 +12426,7 @@ url = "src/providers/anthropic"
 
 [[package]]
 name = "trulens-providers-bedrock"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -12446,7 +12446,7 @@ url = "src/providers/bedrock"
 
 [[package]]
 name = "trulens-providers-cortex"
-version = "2.13.1"
+version = "2.14.0"
 description = "A TruLens extension package adding Snowflake Cortex support for LLM App evaluation."
 optional = false
 python-versions = "^3.9,<3.14"
@@ -12469,7 +12469,7 @@ url = "src/providers/cortex"
 
 [[package]]
 name = "trulens-providers-google"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -12489,7 +12489,7 @@ url = "src/providers/google"
 
 [[package]]
 name = "trulens-providers-huggingface"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -12512,7 +12512,7 @@ url = "src/providers/huggingface"
 
 [[package]]
 name = "trulens-providers-langchain"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -12531,7 +12531,7 @@ url = "src/providers/langchain"
 
 [[package]]
 name = "trulens-providers-litellm"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -12550,7 +12550,7 @@ url = "src/providers/litellm"
 
 [[package]]
 name = "trulens-providers-ollama"
-version = "2.13.0"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"
@@ -12572,7 +12572,7 @@ url = "src/providers/ollama"
 
 [[package]]
 name = "trulens-providers-openai"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 optional = false
 python-versions = "^3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires = [
 # early with a clear message rather than letting either surprise happen.
 requires-poetry = ">=2.0"
 name = "trulens"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/claude/pyproject.toml
+++ b/src/apps/claude/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-claude"
-version = "2.13.1"
+version = "2.14.0"
 description = "Claude Code hook instrumentation plugin for TruLens."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/cursor/pyproject.toml
+++ b/src/apps/cursor/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-cursor"
-version = "2.13.1"
+version = "2.14.0"
 description = "Cursor hook instrumentation plugin for TruLens."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/gepa/pyproject.toml
+++ b/src/apps/gepa/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-gepa"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/langchain/meta.yaml
+++ b/src/apps/langchain/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-apps-langchain" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.13.1" %}
+{% set version = "2.14.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/apps/langchain/pyproject.toml
+++ b/src/apps/langchain/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-langchain"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/langgraph/meta.yaml
+++ b/src/apps/langgraph/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-apps-langgraph" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.13.1" %}
+{% set version = "2.14.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/apps/langgraph/pyproject.toml
+++ b/src/apps/langgraph/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-langgraph"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LangGraph based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/llamaindex/pyproject.toml
+++ b/src/apps/llamaindex/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-llamaindex"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/nemo/pyproject.toml
+++ b/src/apps/nemo/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-nemo"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/opencode/pyproject.toml
+++ b/src/apps/opencode/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-opencode"
-version = "2.13.1"
+version = "2.14.0"
 description = "OpenCode hook instrumentation plugin for TruLens."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/apps/rl/pyproject.toml
+++ b/src/apps/rl/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-apps-rl"
-version = "2.13.1"
+version = "2.14.0"
 description = "RL reward integration for TruLens feedback metrics."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/benchmark/pyproject.toml
+++ b/src/benchmark/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-benchmark"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/connectors/snowflake/meta.yaml
+++ b/src/connectors/snowflake/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-connectors-snowflake" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.13.1" %}
+{% set version = "2.14.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/connectors/snowflake/pyproject.toml
+++ b/src/connectors/snowflake/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-connectors-snowflake"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/core/meta.yaml
+++ b/src/core/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-core" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.13.1" %}
+{% set version = "2.14.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-core"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/dashboard/meta.yaml
+++ b/src/dashboard/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-dashboard" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.13.1" %}
+{% set version = "2.14.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/dashboard/pyproject.toml
+++ b/src/dashboard/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-dashboard"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/feedback/meta.yaml
+++ b/src/feedback/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-feedback" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.13.1" %}
+{% set version = "2.14.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/feedback/pyproject.toml
+++ b/src/feedback/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-feedback"
-version = "2.13.1"
+version = "2.14.0"
 description = "A TruLens extension package implementing feedback functions for LLM App evaluation."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/hotspots/pyproject.toml
+++ b/src/hotspots/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-hotspots"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library and command-line tool to list features lowering your evaluation score."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/otel/semconv/meta.yaml
+++ b/src/otel/semconv/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-otel-semconv" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.13.1" %}
+{% set version = "2.14.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/otel/semconv/pyproject.toml
+++ b/src/otel/semconv/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-otel-semconv"
-version = "2.13.1"
+version = "2.14.0"
 description = "Semantic conventions for spans produced by TruLens."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/anthropic/pyproject.toml
+++ b/src/providers/anthropic/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-anthropic"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/bedrock/pyproject.toml
+++ b/src/providers/bedrock/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-bedrock"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/cortex/meta.yaml
+++ b/src/providers/cortex/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "trulens-providers-cortex" %}
 {% set pyname = name.replace('-', '.') %}
-{% set version = "2.13.1" %}
+{% set version = "2.14.0" %}
 
 package:
   name: {{ name|lower }}

--- a/src/providers/cortex/pyproject.toml
+++ b/src/providers/cortex/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-cortex"
-version = "2.13.1"
+version = "2.14.0"
 description = "A TruLens extension package adding Snowflake Cortex support for LLM App evaluation."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/google/pyproject.toml
+++ b/src/providers/google/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-google"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/huggingface/pyproject.toml
+++ b/src/providers/huggingface/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-huggingface"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/langchain/pyproject.toml
+++ b/src/providers/langchain/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-langchain"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/litellm/pyproject.toml
+++ b/src/providers/litellm/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-litellm"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/ollama/pyproject.toml
+++ b/src/providers/ollama/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-ollama"
-version = "2.13.0"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/providers/openai/pyproject.toml
+++ b/src/providers/openai/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens-providers-openai"
-version = "2.13.1"
+version = "2.14.0"
 description = "Library to systematically track and evaluate LLM based applications."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",

--- a/src/trulens_eval/pyproject.toml
+++ b/src/trulens_eval/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [tool.poetry]
 name = "trulens_eval"
-version = "2.13.1"
+version = "2.14.0"
 description = "Backwards-compatibility package for API of trulens_eval<1.0.0 using API of trulens-*>=1.0.0."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",


### PR DESCRIPTION
## TruLens 2.14.0 Release Notes

### Headline Features

#### Coding Agent Instrumentation
Instrument IDE hooks and coding agent workflows — including Claude Code and Cursor — with TruLens tracing. Capture the full execution trace of agentic coding sessions for evaluation and observability. (#2732) by @joshreini1

#### Production Trace Curation into Evaluation Datasets
Curate production traces into persisted evaluation datasets. Select and save real-world traces directly from your running application, building ground-truth datasets for offline evaluation without manual data collection. (#2722) by @Payal2000

#### Connector-Backed Prompt Management with Version Evaluation
Store, version, and evaluate prompt templates through the connector interface. Track prompt changes over time and evaluate the impact of prompt edits against your existing datasets and feedback functions. (#2717) by @dylanpulver

#### OTLP-Native Export and OTel Metrics Signal
Export traces and metrics directly via the OpenTelemetry Protocol, enabling integration with any OTLP-compatible backend. (#2681) by @RyanFlowerYes

---

### Additional Features

- **Streaming token tracking with TTFT and throughput metrics** — OTEL instrumentation now captures streaming token counts, time-to-first-token, and throughput for LLM calls. (#2708) by @Abelo9996
- **Ollama provider** — New `trulens-providers-ollama` package for running feedback functions against local Ollama models. (#2688) by @connectsudhindra-gif
- **Conversation metric customization** — `additional_instructions` and chain-of-thought reasons support for conversation-scoped metrics. (#2710) by @dylanpulver

### Dashboard Improvements

- **Leaderboard record counts** — Leaderboard metrics now show how many records each metric actually scored. (#2698) by @CTWalk
- **TTFT in the Records page** — Time-to-first-token is now visible in the latency view on the Records page. (#2696) by @connectsudhindra-gif
- **Conversation thread column labels** — Conversation-scoped thread columns are now labeled "latest" instead of "avg" to reflect their actual semantics. (#2750) by @Abelo9996
- **Topic Adherence score consistency** — Topic Adherence scores now match between the results table and conversation metrics view. (#2733) by @Abelo9996

### Bug Fixes

- **LLM judge rating extraction** — Fixed a bug where the judge's stated scale description was incorrectly parsed as its numeric rating. (#2726) by @arthi-arumugam-git
- **`ndcg_at_k` shape crash and `cohens_kappa` label mutation** — `ndcg_at_k` no longer crashes on mismatched shapes; `cohens_kappa` no longer mutates its input labels. (#2709) by @ClaireXi99
- **Ground-truth row ordering** — Benchmark scoring now processes ground-truth rows in row order, not index-label order. (#2737) by @arthi-arumugam-git
- **IR metric undefined results** — IR metrics now report `nan` instead of `0.0` when undefined (e.g., empty relevance lists). (#2738) by @arthi-arumugam-git
- **Duplicate chunk handling in IR metrics** — `recall_at_k` and `ndcg_at_k` are now correctly bounded when retrieved chunks contain duplicates. (#2747) by @Abelo9996
- **Temperature argument for conversation metrics** — `temperature` stays positional on conversation metric calls, fixing a regression. (#2728) by @BetterAndBetterII
- **Dataset and ground-truth read round-trips** — Fixed serialization round-trip errors when reading datasets and ground-truth entries from the database. (#2735) by @Abelo9996
- **Feedback definition re-insert** — Feedback definition updates are now persisted correctly on re-insert. (#2743) by @Abelo9996
- **`compute_metrics` message formatting** — Status messages now build from metric names, not raw objects. (#2745) by @Abelo9996
- **Anthropic cost tracking** — Fixed a crash in the Anthropic provider when tracking costs via `core_endpoint.Cost`. (#2756) by @Abelo9996
- **`methods_to_instrument` existence check** — App wrappers now use `Lens.get` for safer instrumentation target checks. (#2754) by @Abelo9996
- **OpenAI `moderation_harassment_threatening`** — This moderation method now reads the correct category from the API response. (#2752) by @Abelo9996
- **OTEL tracing default cleanup** — Removed stale enablement references; TruLens now warns when OTEL tracing is explicitly disabled. (#2724) by @sfc-gh-jreini
- **Ruff version alignment** — All three ruff pins are now aligned on 0.16.3. (#2720) by @dylanpulver
- **Conda recipe updates** — Conda recipes updated for TruLens 2.13.0. (#2713) by @sfc-gh-jreini
- **Missing docstring fix** — Added missing docstring on public function `pytest_collection_modi`. (#2706) by @nickhac

### New example

- **Trace debugging cookbook** — New notebook walking through common trace debugging workflows. (#2716) by @dylanpulver

### New Contributors

* @dylanpulver made their first contribution in #2710
* @ClaireXi99 made their first contribution in #2709
* @Abelo9996 made their first contribution in #2708
* @nickhac made their first contribution in #2706
* @CTWalk made their first contribution in #2698
* @arthi-arumugam-git made their first contribution in #2726
* @connectsudhindra-gif made their first contribution in #2688
* @BetterAndBetterII made their first contribution in #2728
