### PR TITLE
feat(otel): persist span events and let Selector read event attributes

### DIFF
--- a/docs/otel/semantic_conventions.md
+++ b/docs/otel/semantic_conventions.md
@@ -265,6 +265,46 @@ attributes used by selectors and evaluations. `gen_ai.input.messages` and
 collectors. They carry the same captured content but have different semantic
 scope and structure.
 
+### Selecting span event attributes
+
+Span events are persisted alongside their span, so event attributes can be
+evaluated directly. Because they live in a separate container from span
+attributes, they need their own selector field rather than `span_attribute`:
+
+```python
+from trulens.core import Metric, Selector
+from trulens.otel.semconv.trace import GenAIEvents, SpanAttributes
+
+metric = Metric(
+    implementation=my_metric,
+    name="Prompt Check",
+    selectors={
+        "messages": Selector(
+            span_type=SpanAttributes.SpanType.GENERATION,
+            span_event_attribute=GenAIEvents.EventAttributes.INPUT_MESSAGES,
+            # Optional; when omitted, every event on the span is searched.
+            span_event_name=GenAIEvents.CLIENT_INFERENCE_OPERATION_DETAILS,
+        ),
+    },
+)
+```
+
+`span_event_attribute` is one of the mutually exclusive extraction modes, so it
+cannot be combined with `span_attribute`, `function_attribute`,
+`span_attributes_processor`, or `dataset_column`. When several events on a span
+carry the attribute, the values arrive as a list and `collect_list` applies as it
+does for any list-valued selection.
+
+The field is named `span_event_attribute` rather than `event_attribute` because
+`Trace.events` already refers to the spans of a trace.
+
+Two caveats. Event attributes are only present when content capture is opted in,
+so a selector reading them scores nothing by default. And span events are
+currently persisted for the local database and OTLP destinations only: the
+Snowflake AI observability event table exposes a fixed column set and does not
+surface span events through `GET_AI_OBSERVABILITY_EVENTS`, so this selector finds
+nothing against a Snowflake-backed session until that backend support lands.
+
 Separately, `gen_ai.tool.name` identifies the logical tool that ran, such as
 `Read`, `Bash`, or `ApplyPatch`. `ai.observability.coding_agent.native_event`
 preserves the coding client's lifecycle hook name. A completed tool span pairs

--- a/src/core/trulens/core/feedback/selector.py
+++ b/src/core/trulens/core/feedback/selector.py
@@ -485,9 +485,22 @@ class Selector:
     function_attribute: Optional[str] = None
     conversation_attribute: Optional[str] = None
 
+    # Reads an attribute from the span's OTEL *events* rather than from the
+    # span's attributes. Span events carry GenAI message content such as
+    # `gen_ai.input.messages` and `gen_ai.output.messages`, which are emitted as
+    # events (not attributes) and only when content capture is opted in.
+    # Named `span_event_*` rather than `event_*` because `Trace.events` already
+    # refers to the spans of a trace.
+    span_event_attribute: Optional[str] = None
+
+    # Optionally restrict `span_event_attribute` to events with this name, e.g.
+    # `gen_ai.client.inference.operation.details`. When None, every event on the
+    # span is searched.
+    span_event_name: Optional[str] = None
+
     # If the value extracted from the span is None (i.e. from
-    # `span_attributes_processor`, `span_attribute`, or `function_attribute`),
-    # then whether to ignore it or not.
+    # `span_attributes_processor`, `span_attribute`, `function_attribute`, or
+    # `span_event_attribute`), then whether to ignore it or not.
     ignore_none_values: bool = False
 
     # If this selector describes a list, which of the following two should we
@@ -526,6 +539,8 @@ class Selector:
         span_attribute: Optional[str] = None,
         function_attribute: Optional[str] = None,
         conversation_attribute: Optional[str] = None,
+        span_event_attribute: Optional[str] = None,
+        span_event_name: Optional[str] = None,
         ignore_none_values: bool = False,
         collect_list: bool = True,
         match_only_if_no_ancestor_matched: bool = False,
@@ -552,11 +567,12 @@ class Selector:
                 span_attributes_processor is not None,
                 span_attribute is not None,
                 function_attribute is not None,
+                span_event_attribute is not None,
             ]):
                 raise ValueError(
                     "`dataset_column` cannot be combined with "
-                    "`span_attributes_processor`, `span_attribute`, or "
-                    "`function_attribute`."
+                    "`span_attributes_processor`, `span_attribute`, "
+                    "`function_attribute`, or `span_event_attribute`."
                 )
         elif (
             not trace_level
@@ -565,11 +581,17 @@ class Selector:
                 span_attributes_processor is not None,
                 span_attribute is not None,
                 function_attribute is not None,
+                span_event_attribute is not None,
             ])
             != 1
         ):
             raise ValueError(
-                "Must specify exactly one of `span_attributes_processor`, `span_attribute`, or `function_attribute`!"
+                "Must specify exactly one of `span_attributes_processor`, `span_attribute`, `function_attribute`, or `span_event_attribute`!"
+            )
+        if span_event_name is not None and span_event_attribute is None:
+            raise ValueError(
+                "`span_event_name` only filters `span_event_attribute`, which "
+                "is not set."
             )
         self.trace_level = trace_level
         self.conversation_level = conversation_level
@@ -580,6 +602,8 @@ class Selector:
         self.span_attribute = span_attribute
         self.function_attribute = function_attribute
         self.conversation_attribute = conversation_attribute
+        self.span_event_attribute = span_event_attribute
+        self.span_event_name = span_event_name
         self.ignore_none_values = ignore_none_values
         self.collect_list = collect_list
         self.match_only_if_no_ancestor_matched = (
@@ -674,14 +698,59 @@ class Selector:
             )
         return ret
 
+    def _extract_from_span_events(
+        self, span_events: Optional[List[Dict[str, Any]]]
+    ) -> Any:
+        """Read `span_event_attribute` from a span's OTEL events.
+
+        Args:
+            span_events: The span's serialised events, as stored under
+                `record["events"]`.
+
+        Returns:
+            The single matching value, a list when several events match, or
+            None when nothing matches.
+        """
+        values = []
+        for event in span_events or ():
+            if not isinstance(event, dict):
+                continue
+            if (
+                self.span_event_name is not None
+                and event.get("name") != self.span_event_name
+            ):
+                continue
+            event_attributes = event.get("attributes") or {}
+            if self.span_event_attribute in event_attributes:
+                values.append(event_attributes[self.span_event_attribute])
+        if not values:
+            return None
+        # A single match is returned bare so feedback functions receive a scalar
+        # rather than a one-element list; several matches behave like any other
+        # list-valued selection and honour `collect_list`.
+        return values[0] if len(values) == 1 else values
+
     def process_span(
-        self, span_id: str, attributes: Dict[str, Any]
+        self,
+        span_id: str,
+        attributes: Dict[str, Any],
+        span_events: Optional[List[Dict[str, Any]]] = None,
     ) -> FeedbackFunctionInput:
         ret = FeedbackFunctionInput(
             span_id=span_id, collect_list=self.collect_list
         )
         if self.span_attributes_processor is not None:
             ret.value = self.span_attributes_processor(attributes)
+        elif self.span_event_attribute is not None:
+            # Record where the value came from so evaluation provenance and the
+            # already-computed check can distinguish it from a span attribute of
+            # the same name.
+            ret.span_attribute = (
+                f"{self.span_event_name}/{self.span_event_attribute}"
+                if self.span_event_name is not None
+                else f"event/{self.span_event_attribute}"
+            )
+            ret.value = self._extract_from_span_events(span_events)
         else:
             if self.span_attribute is not None:
                 ret.span_attribute = self.span_attribute
@@ -692,7 +761,7 @@ class Selector:
                     ret.span_attribute = f"{SpanAttributes.CALL.KWARGS}.{self.function_attribute}"
             elif not self.trace_level and not self.conversation_level:
                 raise ValueError(
-                    "None of `span_attributes_processor`, `span_attribute`, or `function_attribute` are set!"
+                    "None of `span_attributes_processor`, `span_attribute`, `function_attribute`, or `span_event_attribute` are set!"
                 )
             ret.value = attributes.get(ret.span_attribute, None)
         return ret

--- a/src/core/trulens/experimental/otel_tracing/core/exporter/utils.py
+++ b/src/core/trulens/experimental/otel_tracing/core/exporter/utils.py
@@ -120,7 +120,40 @@ def convert_readable_span_to_proto(span: ReadableSpan) -> SpanProto:
     span_proto.attributes.append(
         KeyValue(key="name", value=convert_to_any_value(span.name))
     )
+    for event in span.events or ():
+        proto_event = span_proto.events.add()
+        proto_event.name = event.name
+        proto_event.time_unix_nano = event.timestamp or 0
+        for key, value in (event.attributes or {}).items():
+            proto_event.attributes.append(
+                KeyValue(key=key, value=convert_to_any_value(value))
+            )
     return span_proto
+
+
+def convert_span_events(span: ReadableSpan) -> list:
+    """Serialise a span's OTEL events into JSON-friendly dictionaries.
+
+    Span events carry GenAI message content (see
+    [add_genai_inference_event][trulens.experimental.otel_tracing.core.span.add_genai_inference_event]),
+    which is gated behind the content-capture policy and therefore absent unless
+    the user opted in.
+
+    Args:
+        span: The span whose events should be serialised.
+
+    Returns:
+        One dictionary per event, each with `name`, `timestamp`, and
+        `attributes`. Empty when the span has no events.
+    """
+    return [
+        {
+            "name": event.name,
+            "timestamp": event.timestamp,
+            "attributes": dict(event.attributes or {}),
+        }
+        for event in span.events or ()
+    ]
 
 
 def to_timestamp(timestamp: Optional[int]) -> datetime:
@@ -164,18 +197,25 @@ def construct_event(span: ReadableSpan) -> event_schema.Event:
     if context is None:
         raise ValueError("Span context is None")
 
+    record = {
+        "name": span.name,
+        "kind": _SPAN_KIND_TO_PROTO.get(
+            span.kind, SpanProto.SpanKind.SPAN_KIND_INTERNAL
+        ),
+        "parent_span_id": str(parent.span_id if parent else ""),
+        "status": "STATUS_CODE_ERROR"
+        if span.status.status_code == StatusCode.ERROR
+        else "STATUS_CODE_UNSET",
+    }
+    # Only present the key when there is something to record, so spans without
+    # events (the default, since content capture is opt-in) are unchanged.
+    events = convert_span_events(span)
+    if events:
+        record["events"] = events
+
     ret = event_schema.Event(
         event_id=str(context.span_id),
-        record={
-            "name": span.name,
-            "kind": _SPAN_KIND_TO_PROTO.get(
-                span.kind, SpanProto.SpanKind.SPAN_KIND_INTERNAL
-            ),
-            "parent_span_id": str(parent.span_id if parent else ""),
-            "status": "STATUS_CODE_ERROR"
-            if span.status.status_code == StatusCode.ERROR
-            else "STATUS_CODE_UNSET",
-        },
+        record=record,
         record_attributes=span.attributes,
         record_type=event_schema.EventRecordType.SPAN,
         resource_attributes=span.resource.attributes,

--- a/src/feedback/trulens/feedback/computer.py
+++ b/src/feedback/trulens/feedback/computer.py
@@ -461,11 +461,12 @@ def _dfs_collect_trace_level_inputs_from_events(
     record_id = record_attributes[SpanAttributes.RECORD_ID]
     span_id = curr_event["trace"]["span_id"]
     span_name = curr_event["record"]["name"]
+    span_events = curr_event["record"].get("events")
     # Check if row satisfies selector conditions.
     curr_processed_content_node = None
     if sole_selector.matches_span(span_name, record_attributes):
         processed_content = sole_selector.process_span(
-            span_id, record_attributes
+            span_id, record_attributes, span_events
         ).value
         if (
             processed_content is not None
@@ -516,6 +517,7 @@ def _dfs_collect_inputs_from_events(
     selector = kwarg_to_selector[kwarg_group[0]]
     span_id = curr_event["trace"]["span_id"]
     span_name = curr_event["record"]["name"]
+    span_events = curr_event["record"].get("events")
     # Handle span groups.
     span_groups = record_attributes.get(SpanAttributes.SPAN_GROUPS, [None])
     if isinstance(span_groups, str):
@@ -530,7 +532,7 @@ def _dfs_collect_inputs_from_events(
         kwarg_group_inputs = {}
         for kwarg in kwarg_group:
             val = kwarg_to_selector[kwarg].process_span(
-                span_id, record_attributes
+                span_id, record_attributes, span_events
             )
             kwarg_group_inputs[kwarg] = val
             if (

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -4,9 +4,27 @@ from opentelemetry.proto.common.v1.common_pb2 import AnyValue
 from opentelemetry.proto.common.v1.common_pb2 import ArrayValue
 from opentelemetry.proto.common.v1.common_pb2 import KeyValue
 from opentelemetry.proto.common.v1.common_pb2 import KeyValueList
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import Event
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.trace import SpanContext
+from opentelemetry.trace import SpanKind
+from opentelemetry.trace.status import Status
+from opentelemetry.trace.status import StatusCode
+from trulens.experimental.otel_tracing.core.exporter.utils import (
+    construct_event,
+)
+from trulens.experimental.otel_tracing.core.exporter.utils import (
+    convert_readable_span_to_proto,
+)
+from trulens.experimental.otel_tracing.core.exporter.utils import (
+    convert_span_events,
+)
 from trulens.experimental.otel_tracing.core.exporter.utils import (
     convert_to_any_value,
 )
+from trulens.otel.semconv.trace import GenAIEvents
+from trulens.otel.semconv.trace import ResourceAttributes
 
 
 class TestExporterUtils(unittest.TestCase):
@@ -96,3 +114,102 @@ class TestExporterUtils(unittest.TestCase):
                     ]
                 ),
             )
+
+
+def _readable_span(events=()) -> ReadableSpan:
+    """A minimal ReadableSpan carrying the attributes construct_event needs."""
+    return ReadableSpan(
+        name="test_span",
+        context=SpanContext(trace_id=0x1234, span_id=0x5678, is_remote=False),
+        parent=None,
+        resource=Resource.create({}),
+        attributes={ResourceAttributes.APP_NAME: "test_app"},
+        events=events,
+        kind=SpanKind.INTERNAL,
+        status=Status(StatusCode.UNSET),
+        start_time=1_000_000_000,
+        end_time=2_000_000_000,
+    )
+
+
+_INFERENCE_EVENT = Event(
+    name=GenAIEvents.CLIENT_INFERENCE_OPERATION_DETAILS,
+    attributes={
+        GenAIEvents.EventAttributes.INPUT_MESSAGES: '[{"role": "user"}]',
+        GenAIEvents.EventAttributes.OUTPUT_MESSAGES: '[{"role": "assistant"}]',
+    },
+    timestamp=1_500_000_000,
+)
+
+
+class TestSpanEventSerialization(unittest.TestCase):
+    """Span events carry GenAI message content and must survive export."""
+
+    def test_convert_span_events_serializes_name_timestamp_and_attributes(self):
+        events = convert_span_events(_readable_span(events=[_INFERENCE_EVENT]))
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(
+            events[0]["name"], GenAIEvents.CLIENT_INFERENCE_OPERATION_DETAILS
+        )
+        self.assertEqual(events[0]["timestamp"], 1_500_000_000)
+        self.assertEqual(
+            events[0]["attributes"][GenAIEvents.EventAttributes.INPUT_MESSAGES],
+            '[{"role": "user"}]',
+        )
+        self.assertEqual(
+            events[0]["attributes"][
+                GenAIEvents.EventAttributes.OUTPUT_MESSAGES
+            ],
+            '[{"role": "assistant"}]',
+        )
+
+    def test_convert_span_events_returns_empty_without_events(self):
+        self.assertEqual(convert_span_events(_readable_span()), [])
+
+    def test_construct_event_records_span_events(self):
+        event = construct_event(_readable_span(events=[_INFERENCE_EVENT]))
+
+        self.assertIn("events", event.record)
+        self.assertEqual(len(event.record["events"]), 1)
+        self.assertEqual(
+            event.record["events"][0]["attributes"][
+                GenAIEvents.EventAttributes.INPUT_MESSAGES
+            ],
+            '[{"role": "user"}]',
+        )
+
+    def test_construct_event_omits_events_key_when_span_has_none(self):
+        # Content capture is opt-in, so most spans have no events. The key must
+        # be absent rather than empty so persisted rows are unchanged.
+        event = construct_event(_readable_span())
+
+        self.assertNotIn("events", event.record)
+        self.assertEqual(
+            set(event.record),
+            {"name", "kind", "parent_span_id", "status"},
+        )
+
+    def test_proto_conversion_populates_events(self):
+        span_proto = convert_readable_span_to_proto(
+            _readable_span(events=[_INFERENCE_EVENT])
+        )
+
+        self.assertEqual(len(span_proto.events), 1)
+        proto_event = span_proto.events[0]
+        self.assertEqual(
+            proto_event.name, GenAIEvents.CLIENT_INFERENCE_OPERATION_DETAILS
+        )
+        self.assertEqual(proto_event.time_unix_nano, 1_500_000_000)
+        self.assertEqual(
+            {kv.key for kv in proto_event.attributes},
+            {
+                GenAIEvents.EventAttributes.INPUT_MESSAGES,
+                GenAIEvents.EventAttributes.OUTPUT_MESSAGES,
+            },
+        )
+
+    def test_proto_conversion_has_no_events_when_span_has_none(self):
+        span_proto = convert_readable_span_to_proto(_readable_span())
+
+        self.assertEqual(len(span_proto.events), 0)

--- a/tests/unit/test_otel_selector.py
+++ b/tests/unit/test_otel_selector.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from trulens.core.feedback.feedback_function_input import FeedbackFunctionInput
 from trulens.core.feedback.selector import Selector
+from trulens.otel.semconv.trace import GenAIEvents
 from trulens.otel.semconv.trace import SpanAttributes
 
 from tests.util.otel_test_case import OtelTestCase
@@ -180,3 +181,127 @@ class TestOtelSelector(OtelTestCase):
                 span_attribute=f"{SpanAttributes.CALL.KWARGS}.arg1",
             ),
         )
+
+    def test_span_event_attribute_is_an_extraction_mode(self) -> None:
+        # Satisfies the "exactly one extraction mode" requirement on its own.
+        selector = Selector(
+            span_event_attribute=GenAIEvents.EventAttributes.INPUT_MESSAGES
+        )
+        self.assertEqual(
+            selector.span_event_attribute,
+            GenAIEvents.EventAttributes.INPUT_MESSAGES,
+        )
+
+        with self.subTest("cannot combine with span_attribute"):
+            with self.assertRaises(ValueError):
+                Selector(
+                    span_attribute="a",
+                    span_event_attribute=GenAIEvents.EventAttributes.INPUT_MESSAGES,
+                )
+
+        with self.subTest("cannot combine with dataset_column"):
+            with self.assertRaises(ValueError):
+                Selector(
+                    dataset_column="a",
+                    span_event_attribute=GenAIEvents.EventAttributes.INPUT_MESSAGES,
+                )
+
+        with self.subTest("span_event_name requires span_event_attribute"):
+            with self.assertRaises(ValueError):
+                Selector(
+                    span_attribute="a",
+                    span_event_name=GenAIEvents.CLIENT_INFERENCE_OPERATION_DETAILS,
+                )
+
+    def test_process_span_reads_span_event_attributes(self) -> None:
+        span_events = [
+            {
+                "name": GenAIEvents.CLIENT_INFERENCE_OPERATION_DETAILS,
+                "timestamp": 1,
+                "attributes": {
+                    GenAIEvents.EventAttributes.INPUT_MESSAGES: "in",
+                    GenAIEvents.EventAttributes.OUTPUT_MESSAGES: "out",
+                },
+            }
+        ]
+
+        with self.subTest("single match returns a scalar"):
+            result = Selector(
+                span_event_attribute=GenAIEvents.EventAttributes.INPUT_MESSAGES
+            ).process_span("1", {}, span_events)
+            self.assertEqual(result.value, "in")
+            # Provenance distinguishes an event attribute from a span attribute
+            # of the same name.
+            self.assertEqual(
+                result.span_attribute,
+                f"event/{GenAIEvents.EventAttributes.INPUT_MESSAGES}",
+            )
+
+        with self.subTest("span_event_name filters by event"):
+            self.assertEqual(
+                Selector(
+                    span_event_attribute=GenAIEvents.EventAttributes.INPUT_MESSAGES,
+                    span_event_name=GenAIEvents.CLIENT_INFERENCE_OPERATION_DETAILS,
+                )
+                .process_span("1", {}, span_events)
+                .value,
+                "in",
+            )
+            self.assertIsNone(
+                Selector(
+                    span_event_attribute=GenAIEvents.EventAttributes.INPUT_MESSAGES,
+                    span_event_name="some.other.event",
+                )
+                .process_span("1", {}, span_events)
+                .value,
+            )
+
+        with self.subTest("missing attribute yields None"):
+            self.assertIsNone(
+                Selector(span_event_attribute="nope")
+                .process_span("1", {}, span_events)
+                .value
+            )
+
+        with self.subTest("no events yields None"):
+            self.assertIsNone(
+                Selector(
+                    span_event_attribute=GenAIEvents.EventAttributes.INPUT_MESSAGES
+                )
+                .process_span("1", {}, None)
+                .value
+            )
+
+        with self.subTest("several matching events yield a list"):
+            repeated = span_events + [
+                {
+                    "name": GenAIEvents.CLIENT_INFERENCE_OPERATION_DETAILS,
+                    "timestamp": 2,
+                    "attributes": {
+                        GenAIEvents.EventAttributes.INPUT_MESSAGES: "in2"
+                    },
+                }
+            ]
+            self.assertEqual(
+                Selector(
+                    span_event_attribute=GenAIEvents.EventAttributes.INPUT_MESSAGES
+                )
+                .process_span("1", {}, repeated)
+                .value,
+                ["in", "in2"],
+            )
+
+        with self.subTest("span attributes are not consulted"):
+            # An event selector must not silently fall back to a span attribute
+            # that happens to share the key.
+            self.assertIsNone(
+                Selector(
+                    span_event_attribute=GenAIEvents.EventAttributes.INPUT_MESSAGES
+                )
+                .process_span(
+                    "1",
+                    {GenAIEvents.EventAttributes.INPUT_MESSAGES: "from_span"},
+                    None,
+                )
+                .value
+            )

--- a/tests/unit/test_otel_span_events.py
+++ b/tests/unit/test_otel_span_events.py
@@ -1,0 +1,143 @@
+"""
+Tests for persisting and selecting OTEL span events.
+
+GenAI message content (`gen_ai.input.messages`, `gen_ai.output.messages`) is
+emitted as a span *event* rather than a span attribute, and only when content
+capture is opted in. These tests cover the round trip: emission, persistence,
+and selection by a metric.
+"""
+
+import pytest
+from trulens.apps.app import TruApp
+from trulens.core import Metric
+from trulens.core.feedback.selector import Selector
+from trulens.core.otel.instrument import instrument
+from trulens.core.session import TruSession
+from trulens.experimental.otel_tracing.core.span import set_content_capture
+from trulens.otel.semconv.trace import GenAIEvents
+from trulens.otel.semconv.trace import SpanAttributes
+
+from tests.util.otel_test_case import OtelTestCase
+
+_QUESTION = "Who is the best baby?"
+
+
+class _GenerationApp:
+    @instrument(
+        span_type=SpanAttributes.SpanType.GENERATION,
+        attributes=lambda ret, exception, *args, **kwargs: {
+            "prompt": kwargs.get("question"),
+            "completion": ret,
+        },
+    )
+    def generate(self, question: str) -> str:
+        return "Kojikun"
+
+    @instrument(
+        span_type=SpanAttributes.SpanType.RECORD_ROOT,
+        attributes={
+            SpanAttributes.RECORD_ROOT.INPUT: "question",
+            SpanAttributes.RECORD_ROOT.OUTPUT: "return",
+        },
+    )
+    def answer(self, question: str) -> str:
+        return self.generate(question=question)
+
+
+def _echo_input_messages(messages: str) -> float:
+    return 1.0 if messages == _QUESTION else 0.0
+
+
+@pytest.mark.optional
+class TestOtelSpanEvents(OtelTestCase):
+    def _record(self, app_name: str, feedbacks=None) -> TruApp:
+        app = _GenerationApp()
+        tru_app = TruApp(
+            app,
+            app_name=app_name,
+            app_version="v1",
+            main_method=app.answer,
+            feedbacks=feedbacks or [],
+        )
+        with tru_app:
+            app.answer(_QUESTION)
+        TruSession().force_flush()
+        return tru_app
+
+    def test_span_events_are_persisted_when_content_capture_is_on(self) -> None:
+        set_content_capture(True)
+        self.addCleanup(set_content_capture, None)
+
+        self._record("Span Event App")
+
+        events = self._get_events()
+        with_events = [
+            curr["record"]
+            for _, curr in events.iterrows()
+            if "events" in curr["record"]
+        ]
+        # Only the generation span emits an inference event.
+        self.assertEqual(1, len(with_events))
+        self.assertEqual(
+            GenAIEvents.CLIENT_INFERENCE_OPERATION_DETAILS,
+            with_events[0]["events"][0]["name"],
+        )
+        attributes = with_events[0]["events"][0]["attributes"]
+        self.assertEqual(
+            _QUESTION, attributes[GenAIEvents.EventAttributes.INPUT_MESSAGES]
+        )
+        self.assertEqual(
+            "Kojikun",
+            attributes[GenAIEvents.EventAttributes.OUTPUT_MESSAGES],
+        )
+
+    def test_no_events_recorded_when_content_capture_is_off(self) -> None:
+        # Content capture is opt-in, so the default must leave persisted rows
+        # untouched: no `events` key at all.
+        set_content_capture(False)
+        self.addCleanup(set_content_capture, None)
+
+        self._record("No Span Event App")
+
+        events = self._get_events()
+        self.assertGreater(len(events), 0)
+        for _, curr in events.iterrows():
+            self.assertNotIn("events", curr["record"])
+
+    def test_metric_can_select_a_span_event_attribute(self) -> None:
+        set_content_capture(True)
+        self.addCleanup(set_content_capture, None)
+
+        metric = Metric(
+            implementation=_echo_input_messages,
+            name="input_messages",
+            selectors={
+                "messages": Selector(
+                    span_type=SpanAttributes.SpanType.GENERATION,
+                    span_event_attribute=GenAIEvents.EventAttributes.INPUT_MESSAGES,
+                    span_event_name=GenAIEvents.CLIENT_INFERENCE_OPERATION_DETAILS,
+                ),
+            },
+        )
+
+        tru_app = self._record("Span Event Metric App", feedbacks=[metric])
+        tru_app.compute_feedbacks()
+        TruSession().force_flush()
+
+        eval_roots = [
+            curr["record_attributes"]
+            for _, curr in self._get_events().iterrows()
+            if curr["record_attributes"][SpanAttributes.SPAN_TYPE]
+            == SpanAttributes.SpanType.EVAL_ROOT
+        ]
+        self.assertEqual(1, len(eval_roots))
+        self.assertEqual(1.0, eval_roots[0][SpanAttributes.EVAL_ROOT.SCORE])
+        # Provenance must show the value came from an event, so it is
+        # distinguishable from a span attribute of the same name.
+        self.assertEqual(
+            f"{GenAIEvents.CLIENT_INFERENCE_OPERATION_DETAILS}/"
+            f"{GenAIEvents.EventAttributes.INPUT_MESSAGES}",
+            eval_roots[0][
+                SpanAttributes.EVAL_ROOT.ARGS_SPAN_ATTRIBUTE + ".messages"
+            ],
+        )


### PR DESCRIPTION
# Description

GenAI message content is emitted as a span event rather than a span attribute, per the OTEL GenAI spec and for PII safety. construct_event and convert_readable_span_to_proto both ignored span.events, so that content was discarded at export and gen_ai.input.messages / gen_ai.output.messages could never be evaluated.

Persist events under record["events"], and only when the span has events, so spans without them (the default, since content capture is opt-in) serialise byte-identically and no golden fixture changes. record is already a free-form JSON column, so this needs no migration, no ORM column, and no change to get_events, which enumerates no columns.

Add span_event_attribute and span_event_name to Selector as a fourth mutually exclusive extraction mode. Event attributes deliberately do not merge into record_attributes: keeping them separate preserves the OTEL attribute-vs-event distinction, avoids key collisions, and keeps repeated events distinct. Several matching events yield a list so collect_list applies as usual, and FeedbackFunctionInput.span_attribute records "<event>/<attribute>" so evaluation provenance and the already-computed check keep working.

Two examples:

```python
Selector(
    span_type=SpanAttributes.SpanType.RETRIEVAL,
    span_event_attribute=GenAIEvents.EventAttributes.DOCUMENTS,
    span_event_name=GenAIEvents.RETRIEVAL_DOCUMENTS,
    collect_list=False,  # one call per document
)
```

```python
Selector(
    span_type=SpanAttributes.SpanType.Generation,
    span_event_attribute=.EventAttributes.INPUT_MESSAGES,
    span_event_name=GenAIEvents.CLIENT_INFERENCE_OPERATION_DETAILS,
)
```

Also populate span_proto.events, which is the correct OTLP representation.

## Other details good to know for developers

Please include any other details of this change useful for _TruLens_ developers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update
