### PR TITLE
fix: skip invalid spans during trace compression

### DIFF
--- a/src/core/trulens/core/utils/trace_compression.py
+++ b/src/core/trulens/core/utils/trace_compression.py
@@ -297,7 +297,7 @@ class TraceCompressor:
                         if important_attrs:
                             compressed_span["span_attributes"] = important_attrs
 
-            compressed_spans.append(compressed_span)
+                compressed_spans.append(compressed_span)
 
         return compressed_spans
 

--- a/tests/unit/core/utils/test_trace_provider.py
+++ b/tests/unit/core/utils/test_trace_provider.py
@@ -423,6 +423,19 @@ class TestTraceProviderRegistry:
 class TestTraceCompression:
     """Tests for trace compression utilities."""
 
+    def test_basic_compression_skips_non_mapping_spans(self):
+        compressor = TraceCompressor()
+
+        result = compressor._basic_compression({
+            "spans": [
+                None,
+                {"span_name": "valid", "span_id": "span-1"},
+                "invalid",
+            ]
+        })
+
+        assert result["spans"] == [{"span_name": "valid", "span_id": "span-1"}]
+
     def test_compress_trace_for_feedback_basic(self):
         """Basic trace compression should work."""
         trace_data = {


### PR DESCRIPTION
## Summary

Basic trace compression conditionally creates `compressed_span` only for dictionary spans, but appends it unconditionally. A non-mapping span before any valid span raises `UnboundLocalError`; later invalid spans can duplicate stale output.

Skip non-dictionary values before constructing and appending the compressed span.

## Testing

- Added regression coverage with `None`, a valid span, and a string span.
- Verified the changed compression method returns only the valid span.
- Ruff check, formatting check, and `compileall` on both changed files.