### PR TITLE
fix(database): report leaderboard cost per currency, not summed across currencies

### DIFF
--- a/src/core/trulens/core/database/sqlalchemy.py
+++ b/src/core/trulens/core/database/sqlalchemy.py
@@ -1222,10 +1222,28 @@ class SQLAlchemyDB(core_db.DB):
                     "Latest Record Timestamp"
                 ),
                 latency_expr.label("Average Latency (s)"),
-                sa.func.sum(sa.cast(cost_col, sa.Float)).label("total_cost"),
-                sa.func.coalesce(
-                    sa.func.max(currency_col), sa.literal("USD")
-                ).label("cost_currency"),
+                # Sum cost per currency rather than summing every record's cost
+                # into one number and labelling it with whichever currency
+                # sorts last. Mixing currencies in a single total is wrong and
+                # is what Cost.__add__ refuses to do.
+                sa.func.sum(
+                    sa.case(
+                        (
+                            currency_col == sa.literal("USD"),
+                            sa.cast(cost_col, sa.Float),
+                        ),
+                        else_=0.0,
+                    )
+                ).label("Total Cost (USD)"),
+                sa.func.sum(
+                    sa.case(
+                        (
+                            currency_col == sa.literal("Snowflake credits"),
+                            sa.cast(cost_col, sa.Float),
+                        ),
+                        else_=0.0,
+                    )
+                ).label("Total Cost (Snowflake Credits)"),
                 sa.func.sum(
                     sa.cast(
                         sa.func.coalesce(tokens_col, sa.literal("0")),
@@ -1320,32 +1338,14 @@ class SQLAlchemyDB(core_db.DB):
                 "Recent Records",
                 "Latest Record Timestamp",
                 "Average Latency (s)",
-                "total_cost",
-                "cost_currency",
+                "Total Cost (USD)",
+                "Total Cost (Snowflake Credits)",
                 "Total Tokens",
             ],
         )
 
         if base_df.empty:
             return base_df, []
-
-        base_df["Total Cost (USD)"] = base_df.apply(
-            lambda r: (
-                float(r["total_cost"] or 0)
-                if r["cost_currency"] == "USD"
-                else 0.0
-            ),
-            axis=1,
-        )
-        base_df["Total Cost (Snowflake Credits)"] = base_df.apply(
-            lambda r: (
-                float(r["total_cost"] or 0)
-                if r["cost_currency"] == "Snowflake credits"
-                else 0.0
-            ),
-            axis=1,
-        )
-        base_df.drop(columns=["total_cost", "cost_currency"], inplace=True)
 
         feedback_col_names = []
         if eval_rows:

--- a/tests/unit/test_leaderboard_mixed_currency.py
+++ b/tests/unit/test_leaderboard_mixed_currency.py
@@ -1,0 +1,76 @@
+"""Regression test: the leaderboard must not sum costs across currencies.
+
+The OTel leaderboard summed every record's cost into one number and labelled it
+with whichever currency sorted last (max), so an app with records in USD and in
+Snowflake credits had both amounts added together and attributed to a single
+currency. Cost per currency must be reported separately.
+"""
+
+from trulens.core.schema.event import Event
+from trulens.otel.semconv.trace import SpanAttributes
+
+from tests.util.otel_test_case import OtelTestCase
+
+
+class TestLeaderboardMixedCurrency(OtelTestCase):
+    def _record_root(self, record_id, cost, currency):
+        app = {
+            "ai.observability.app_name": "mixed",
+            "ai.observability.app_version": "v1",
+            "ai.observability.app_id": "app-mixed",
+        }
+        return Event.model_validate({
+            "event_id": f"evt-{record_id}",
+            "record": {
+                "kind": 1,
+                "name": "app.query",
+                "parent_span_id": "",
+                "status": "STATUS_CODE_UNSET",
+            },
+            "record_attributes": {
+                **app,
+                "ai.observability.record_id": record_id,
+                "ai.observability.span_type": SpanAttributes.SpanType.RECORD_ROOT.value,
+                "ai.observability.record_root.input": "in",
+                "ai.observability.record_root.output": "out",
+                SpanAttributes.COST.COST: cost,
+                SpanAttributes.COST.CURRENCY: currency,
+                SpanAttributes.COST.NUM_TOKENS: 10,
+            },
+            "record_type": "SPAN",
+            "resource_attributes": {
+                "service.name": "trulens",
+                "telemetry.sdk.language": "python",
+                "telemetry.sdk.name": "opentelemetry",
+                "telemetry.sdk.version": "1.31.0",
+                **app,
+            },
+            "start_timestamp": "2026-01-01T00:00:00",
+            "timestamp": "2026-01-01T00:00:01",
+            "trace": {
+                "parent_id": "",
+                "span_id": f"span-{record_id}",
+                "trace_id": f"trace-{record_id}",
+            },
+        })
+
+    def test_costs_are_reported_per_currency(self):
+        from trulens.core.session import TruSession
+
+        db = TruSession().connector.db
+        db.insert_event(self._record_root("r1", 0.03, "USD"))
+        db.insert_event(self._record_root("r2", 0.05, "Snowflake credits"))
+
+        leaderboard, _ = db.get_leaderboard_aggregates()
+        self.assertEqual(len(leaderboard), 1)
+        row = leaderboard.iloc[0]
+
+        # USD and Snowflake-credit costs must not be summed together.
+        self.assertAlmostEqual(row["Total Cost (USD)"], 0.03)
+        self.assertAlmostEqual(row["Total Cost (Snowflake Credits)"], 0.05)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
Addresses the mixed-currency half of #2759.

## Problem

The OTel leaderboard summed every record's cost into one `total_cost = sum(cost)` and labelled it with `coalesce(max(cost_currency), "USD")`, then in post-processing attributed the whole sum to that single currency. For an app whose records carry mixed currencies (the `Cost` model supports `cost_currency`), amounts in USD and in Snowflake credits are added together and reported under whichever currency sorts last. This is exactly the cross-currency addition that `Cost.__add__` refuses to do.

## Fix

Sum cost per currency directly in SQL with a conditional sum for each supported currency, producing `Total Cost (USD)` and `Total Cost (Snowflake Credits)` as separate aggregates. Single-currency apps are unaffected; only the mixed-currency case changes (from one mislabelled total to two correct per-currency totals). The returned columns are unchanged, and the now-redundant post-processing split is removed.

## Tests

Adds `tests/unit/test_leaderboard_mixed_currency.py`: an app with one USD record and one Snowflake-credits record asserts the two totals are reported separately, not summed. It fails on `main` (the USD column shows the combined total) and passes with this change. Lint and format clean under the pinned ruff.

## Note

This covers the mixed-currency issue in #2759. The other half of that issue (pre-OTel "Total Tokens" being an average rather than a sum) lives in `_get_leaderboard_aggregates_pre_otel`, which #2765 is currently rewriting, so it is best addressed there to avoid a conflicting edit.
