### PR TITLE
fix(dashboard): coerce Records search columns to string before .str.contains

### DIFF
--- a/src/dashboard/trulens/dashboard/tabs/Records.py
+++ b/src/dashboard/trulens/dashboard/tabs/Records.py
@@ -425,10 +425,18 @@ def _preprocess_df(
     #     records_df = records_df.drop(columns="app_json")
 
     if record_query:
+
+        def _searchable(col: str) -> pd.Series:
+            # Columns can arrive as non-string dtypes (e.g. all-NaN output
+            # columns come back float64, app_version can be numeric), and
+            # `.str` accessors raise AttributeError on those. Coerce to
+            # string first so the search box never crashes on such data.
+            return records_df[col].fillna("").astype(str)
+
         records_df = records_df[
-            records_df["app_version"].str.contains(record_query, case=False)
-            | records_df["input"].str.contains(record_query, case=False)
-            | records_df["output"].str.contains(record_query, case=False)
+            _searchable("app_version").str.contains(record_query, case=False)
+            | _searchable("input").str.contains(record_query, case=False)
+            | _searchable("output").str.contains(record_query, case=False)
         ]
     if online_eval_filter == "Selected":
         records_df = records_df[records_df["online_eval_status"] == "Selected"]

--- a/tests/unit/streamlit/test_streamlit_records.py
+++ b/tests/unit/streamlit/test_streamlit_records.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 from trulens.dashboard.tabs.Records import _build_thread_grid_options
 from trulens.dashboard.tabs.Records import _build_thread_summary
@@ -48,6 +49,27 @@ def test_preprocess_filters_skipped_records():
     result = _preprocess_df(_records(), online_eval_filter="Skipped")
 
     assert set(result["record_id"]) == {"record-1", "record-2"}
+
+
+def test_preprocess_search_query_survives_nan_output_column():
+    # A column of all-missing outputs (e.g. SQL NULLs) round-trips as
+    # float64, not object/string, which used to crash the search box's
+    # `.str.contains` call with an AttributeError.
+    df = _records()
+    df["output"] = pd.Series([np.nan] * 5, index=df.index, dtype="float64")
+
+    result = _preprocess_df(df, record_query="input 2")
+
+    assert set(result["record_id"]) == {"record-2"}
+
+
+def test_preprocess_search_query_survives_numeric_app_version():
+    df = _records()
+    df["app_version"] = [1, 1, 1, 1, 1]
+
+    result = _preprocess_df(df, record_query="input 3")
+
+    assert set(result["record_id"]) == {"record-3"}
 
 
 def test_conversation_bubbles_use_theme_colors():


### PR DESCRIPTION
## Summary
- The Records page search box calls `.str.contains` directly on the `app_version`, `input`, and `output` columns in `_preprocess_df`. When any of those columns arrives as a non-string dtype - an all-NaN `output` column (e.g. from SQL NULLs, which comes back `float64`), or a numeric `app_version` - pandas raises `AttributeError: Can only use .str accessor with string values`, crashing the page as soon as a search query is entered.
- Added a small `_searchable()` helper that coerces each column with `.fillna("").astype(str)` before matching, so the search box works regardless of the incoming dtype. This matches the coerce-then-match idiom already used elsewhere in this file (`.astype(str).str.len()` in `_has_conversations` / `_thread_membership`).

Fixes #1749

## Test plan
- [x] Added `tests/unit/streamlit/test_streamlit_records.py::test_preprocess_search_query_survives_nan_output_column`, which builds a `float64` all-NaN `output` column and confirms the search filter runs without raising and returns the correct match.
- [x] Added `tests/unit/streamlit/test_streamlit_records.py::test_preprocess_search_query_survives_numeric_app_version`, covering a numeric `app_version` column the same way.
- [x] Verified the underlying pandas behavior (crash before the fix, correct filtering after) with a standalone repro against the exact operations used in `_preprocess_df`.
- [ ] CI run on this PR