### PR TITLE
Add Payal as an Area Triager

### DIFF
--- a/.github/area-reviewers.yml
+++ b/.github/area-reviewers.yml
@@ -47,14 +47,14 @@ areas:
   - name: OpenTelemetry semantic conventions
     paths:
       - src/otel/
-    reviewers: []
-    # reviewers: [<handle>]
+    reviewers: [Payal2000]
 
-  - name: Feedback functions
+  - name: Feedback functions and metrics
     paths:
       - src/feedback/
-    reviewers: []
-    # reviewers: [<handle>]
+      - src/core/trulens/core/feedback/
+      - src/core/trulens/core/metric/
+    reviewers: [Payal2000]
 
   - name: Feedback templates
     paths:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -3,8 +3,8 @@ name: CLA
 # Asks contributors to sign the Contributor License Agreement in /CLA.md, and
 # records the signature.
 #
-# NOT YET IN FORCE. CLA.md needs Snowflake Legal approval first, and `CLA` should
-# not be added to the required status checks on main until it has been approved.
+# Signatures are stored on the unprotected `cla-signatures` branch. The CLA check
+# is active but is not a required status check on `main`.
 #
 # HOW A CONTRIBUTOR SIGNS: the bot comments on their pull request with a link to
 # the agreement. They reply with one comment containing exactly:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -3,8 +3,8 @@ name: CLA
 # Asks contributors to sign the Contributor License Agreement in /CLA.md, and
 # records the signature.
 #
-# Signatures are stored on the unprotected `cla-signatures` branch. The CLA check
-# is active but is not a required status check on `main`.
+# NOT YET IN FORCE. CLA.md needs Snowflake Legal approval first, and `CLA` should
+# not be added to the required status checks on main until it has been approved.
 #
 # HOW A CONTRIBUTOR SIGNS: the bot comments on their pull request with a link to
 # the agreement. They reply with one comment containing exactly:

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -37,7 +37,7 @@ Issue and pull request triage in a named area. No write access to the codebase.
 
 | Name | Affiliation | GitHub | Area |
 | ---- | ----------- | ------ | ---- |
-| Payal Nagaonkar | Northeastern University | Payal2000 | Feedback functions and metrics; OpenTelemetry semantic conventions |
+| Payal Nagaonkar | Peeker AI | Payal2000 | Feedback functions and metrics; OpenTelemetry semantic conventions |
 
 ## Emeritus
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -37,8 +37,7 @@ Issue and pull request triage in a named area. No write access to the codebase.
 
 | Name | Affiliation | GitHub | Area |
 | ---- | ----------- | ------ | ---- |
-
-_Nominations in progress._
+| Payal Nagaonkar | Northeastern University | Payal2000 | Feedback functions and metrics; OpenTelemetry semantic conventions |
 
 ## Emeritus
 


### PR DESCRIPTION
## Summary
- add Payal Nagaonkar (`Payal2000`) to the Area Triager roster
- route advisory reviews for feedback functions, metrics, and OpenTelemetry semantic conventions to Payal
- keep routing scoped to package-level paths rather than individual tests

## Test plan
- [x] Validate `.github/area-reviewers.yml` as YAML
- [x] Dry-run the area-review router against feedback, metric, and OTel semantic-convention paths
- [x] Run pre-commit hooks

## Certification
- [x] This change follows the TruLens standards (https://www.trulens.org/contributing/standards/)

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)