### PR TITLE
fix(database): make re-evaluated record score deterministic (latest wins) (#2768)

### DIFF
--- a/src/core/trulens/core/database/base.py
+++ b/src/core/trulens/core/database/base.py
@@ -1036,13 +1036,22 @@ class DB(serial_utils.SerialModel, abc.ABC, text_utils.WithIdentString):
                         record_attributes.get(SpanAttributes.SPAN_TYPE)
                         == SpanAttributes.SpanType.EVAL_ROOT.value
                     ):
-                        # NOTE: EVAL_ROOT.SCORE should provide the mean score of all related EVAL spans
-                        feedback_result["mean_score"] = eval_root_score
-                        # TODO(SNOW-2112879): HIGHER_IS_BETTER has not been populated in the OTEL spans yet
-                        feedback_result["direction"] = record_attributes.get(
-                            SpanAttributes.EVAL_ROOT.HIGHER_IS_BETTER,
-                            None,
-                        )
+                        # A record and metric can have several EVAL_ROOT spans
+                        # when the metric is re-evaluated. Keep the latest one by
+                        # timestamp so the reported score is deterministic rather
+                        # than whichever span happens to be iterated last.
+                        prev_ts = feedback_result.get("_score_ts")
+                        if prev_ts is None or event.start_timestamp >= prev_ts:
+                            feedback_result["_score_ts"] = event.start_timestamp
+                            # NOTE: EVAL_ROOT.SCORE should provide the mean score of all related EVAL spans
+                            feedback_result["mean_score"] = eval_root_score
+                            # TODO(SNOW-2112879): HIGHER_IS_BETTER has not been populated in the OTEL spans yet
+                            feedback_result["direction"] = (
+                                record_attributes.get(
+                                    SpanAttributes.EVAL_ROOT.HIGHER_IS_BETTER,
+                                    None,
+                                )
+                            )
                         # Add call data for EVAL_ROOT spans
                         args_span_id = self._extract_namespaced_attributes(
                             record_attributes,

--- a/src/core/trulens/core/database/base.py
+++ b/src/core/trulens/core/database/base.py
@@ -1190,6 +1190,9 @@ class DB(serial_utils.SerialModel, abc.ABC, text_utils.WithIdentString):
             for feedback_name, feedback_result in record_data[
                 "feedback_results"
             ].items():
+                # Drop the internal latest-score timestamp used only to pick the
+                # most recent EVAL_ROOT; it is not part of the public schema.
+                feedback_result.pop("_score_ts", None)
                 # NOTE: we use the mean score as the feedback result
                 record_row[feedback_name] = feedback_result["mean_score"]
 

--- a/tests/unit/test_records_reevaluation_score.py
+++ b/tests/unit/test_records_reevaluation_score.py
@@ -1,0 +1,108 @@
+"""Regression test: a re-evaluated metric score must be stable and deterministic.
+
+When a metric is re-evaluated on the same record there are several EVAL_ROOT
+spans for one (record, metric). The records table set the score to whichever
+span was iterated last, so the reported score changed with event order (and
+diverged from the detailed result). The score must be deterministic: the latest
+EVAL_ROOT by timestamp.
+"""
+
+from trulens.core.schema.event import Event
+from trulens.otel.semconv.trace import SpanAttributes
+
+from tests.util.otel_test_case import OtelTestCase
+
+_APP = {
+    "ai.observability.app_name": "app",
+    "ai.observability.app_version": "v1",
+    "ai.observability.app_id": "app-1",
+}
+
+
+def _record_root(record_id, ts):
+    return Event.model_validate({
+        "event_id": f"root-{record_id}",
+        "record": {
+            "kind": 1,
+            "name": "q",
+            "parent_span_id": "",
+            "status": "STATUS_CODE_UNSET",
+        },
+        "record_attributes": {
+            **_APP,
+            "ai.observability.record_id": record_id,
+            "ai.observability.span_type": SpanAttributes.SpanType.RECORD_ROOT.value,
+            "ai.observability.record_root.input": "in",
+            "ai.observability.record_root.output": "out",
+        },
+        "record_type": "SPAN",
+        "resource_attributes": {"service.name": "trulens", **_APP},
+        "start_timestamp": ts,
+        "timestamp": ts,
+        "trace": {
+            "parent_id": "",
+            "span_id": f"sr-{record_id}",
+            "trace_id": f"tr-{record_id}",
+        },
+    })
+
+
+def _eval_root(record_id, metric, score, ts, event_id):
+    return Event.model_validate({
+        "event_id": event_id,
+        "record": {
+            "kind": 1,
+            "name": "eval",
+            "parent_span_id": "",
+            "status": "STATUS_CODE_UNSET",
+        },
+        "record_attributes": {
+            **_APP,
+            "ai.observability.record_id": record_id,
+            "ai.observability.span_type": SpanAttributes.SpanType.EVAL_ROOT.value,
+            SpanAttributes.EVAL_ROOT.METRIC_NAME: metric,
+            SpanAttributes.EVAL_ROOT.SCORE: score,
+        },
+        "record_type": "SPAN",
+        "resource_attributes": {"service.name": "trulens", **_APP},
+        "start_timestamp": ts,
+        "timestamp": ts,
+        "trace": {
+            "parent_id": "",
+            "span_id": f"s-{event_id}",
+            "trace_id": f"t-{event_id}",
+        },
+    })
+
+
+class TestReevaluationScore(OtelTestCase):
+    def _db_with_two_evals(self, order):
+        from trulens.core.session import TruSession
+
+        db = TruSession().connector.db
+        db.reset_database()
+        events = {
+            "root": _record_root("r1", "2026-01-01T00:00:00"),
+            "old": _eval_root(
+                "r1", "Context Relevance", 0.67, "2026-01-01T00:00:05", "old"
+            ),
+            "new": _eval_root(
+                "r1", "Context Relevance", 1.0, "2026-01-02T00:00:05", "new"
+            ),
+        }
+        for key in order:
+            db.insert_event(events[key])
+        df, _ = db.get_records_and_feedback()
+        return df.iloc[0]["Context Relevance"]
+
+    def test_score_is_latest_regardless_of_event_order(self):
+        # Both insertion orders must yield the latest evaluation (1.0), not
+        # whichever span was iterated last.
+        self.assertEqual(self._db_with_two_evals(["root", "old", "new"]), 1.0)
+        self.assertEqual(self._db_with_two_evals(["root", "new", "old"]), 1.0)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/tests/unit/test_records_reevaluation_score.py
+++ b/tests/unit/test_records_reevaluation_score.py
@@ -95,10 +95,12 @@ class TestReevaluationScore(OtelTestCase):
         df, _ = db.get_records_and_feedback()
         return df.iloc[0]["Context Relevance"]
 
-    def test_score_is_latest_regardless_of_event_order(self):
-        # Both insertion orders must yield the latest evaluation (1.0), not
-        # whichever span was iterated last.
+    def test_score_latest_when_old_first(self):
+        # Older EVAL_ROOT inserted first: the latest (1.0) must still win.
         self.assertEqual(self._db_with_two_evals(["root", "old", "new"]), 1.0)
+
+    def test_score_latest_when_new_first(self):
+        # Newer EVAL_ROOT inserted first: the latest (1.0) must still win.
         self.assertEqual(self._db_with_two_evals(["root", "new", "old"]), 1.0)
 
 


### PR DESCRIPTION
Closes #2768

## Problem

A previously recorded evaluation score in the records table changes after a later evaluation run, and diverges from the detailed result for the same record (e.g. Context Relevance shows 0.67 in the detail but 1.00 in the table after a re-run).

When a metric is re-evaluated on the same record, there are several `EVAL_ROOT` spans for one `(record, metric)`. `_get_records_and_feedback_otel_from_events` sets the record's score with `feedback_result["mean_score"] = eval_root_score` for every `EVAL_ROOT` span it iterates, so the reported score is whichever span is processed last. The events have no defined order, so the table score is nondeterministic and can differ from the detail. This is the case the existing `# TODO(otel): This isn't going to work if there are multiple with the same name.` flags.

## Fix

Keep the latest `EVAL_ROOT` by timestamp for each `(record, metric)`, so the score is deterministic and reflects the most recent evaluation. The per-call breakdown and eval cost still accumulate across all eval spans as before.

## Tests

Adds `tests/unit/test_records_reevaluation_score.py`: two `EVAL_ROOT` spans (scores 0.67 then 1.00 at different timestamps) inserted in both orders, asserting the table score is the latest (1.00) regardless of insertion order. On `main` one order returns 0.67 and the test fails; with this change both orders return 1.00. Lint and format clean under the pinned ruff.


- [x] This change follows the TruLens standards (https://www.trulens.org/contributing/standards/)