### PR TITLE
fix(otel): pass byteorder to int.from_bytes in _otel_id for Python 3.10 (#2764)

### DIFF
--- a/src/core/trulens/core/otel/client_hooks/tracing.py
+++ b/src/core/trulens/core/otel/client_hooks/tracing.py
@@ -24,7 +24,12 @@ from trulens.otel.semconv.trace import SpanAttributes
 
 def _otel_id(seed: str, bits: int) -> int:
     size = bits // 8
-    value = int.from_bytes(hashlib.sha256(seed.encode()).digest()[:size])
+    # byteorder is required on Python 3.10 (it only became optional, defaulting
+    # to "big", in 3.11), so pass it explicitly. "big" matches the 3.11+ default,
+    # keeping ids unchanged on newer versions.
+    value = int.from_bytes(
+        hashlib.sha256(seed.encode()).digest()[:size], byteorder="big"
+    )
     return value or 1
 
 

--- a/tests/unit/test_otel_id_byteorder.py
+++ b/tests/unit/test_otel_id_byteorder.py
@@ -1,7 +1,7 @@
 """Regression test for _otel_id byte order and Python 3.10 compatibility.
 
 int.from_bytes() requires byteorder on Python 3.10 (it only became optional,
-defaulting to "big", in 3.11). _otel_id() omitted it, so every id derivation,
+defaulting to "big", in 3.11). tracing._otel_id() omitted it, so every id derivation,
 and therefore TraceAssembler.assemble(), raised TypeError on 3.10. The explicit
 byteorder must be "big" so ids are unchanged on 3.11+.
 """
@@ -9,7 +9,7 @@ byteorder must be "big" so ids are unchanged on 3.11+.
 import hashlib
 import unittest
 
-from trulens.core.otel.client_hooks.tracing import _otel_id
+from trulens.core.otel.client_hooks import tracing
 
 
 class TestOtelIdByteOrder(unittest.TestCase):
@@ -19,15 +19,15 @@ class TestOtelIdByteOrder(unittest.TestCase):
         expected = int.from_bytes(
             hashlib.sha256(seed.encode()).digest()[:size], byteorder="big"
         )
-        self.assertEqual(_otel_id(seed, bits), expected)
+        self.assertEqual(tracing._otel_id(seed, bits), expected)
 
     def test_returns_int_without_raising(self):
         # Would raise TypeError on Python 3.10 before the fix.
-        self.assertIsInstance(_otel_id("span:xyz", 64), int)
-        self.assertEqual(_otel_id("span:xyz", 64), 15422170499572505575)
+        self.assertIsInstance(tracing._otel_id("span:xyz", 64), int)
+        self.assertEqual(tracing._otel_id("span:xyz", 64), 15422170499572505575)
 
     def test_never_zero(self):
-        self.assertGreaterEqual(_otel_id("anything", 64), 1)
+        self.assertGreaterEqual(tracing._otel_id("anything", 64), 1)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_otel_id_byteorder.py
+++ b/tests/unit/test_otel_id_byteorder.py
@@ -1,0 +1,34 @@
+"""Regression test for _otel_id byte order and Python 3.10 compatibility.
+
+int.from_bytes() requires byteorder on Python 3.10 (it only became optional,
+defaulting to "big", in 3.11). _otel_id() omitted it, so every id derivation,
+and therefore TraceAssembler.assemble(), raised TypeError on 3.10. The explicit
+byteorder must be "big" so ids are unchanged on 3.11+.
+"""
+
+import hashlib
+import unittest
+
+from trulens.core.otel.client_hooks.tracing import _otel_id
+
+
+class TestOtelIdByteOrder(unittest.TestCase):
+    def test_matches_big_endian_interpretation(self):
+        seed, bits = "trace:abc", 128
+        size = bits // 8
+        expected = int.from_bytes(
+            hashlib.sha256(seed.encode()).digest()[:size], byteorder="big"
+        )
+        self.assertEqual(_otel_id(seed, bits), expected)
+
+    def test_returns_int_without_raising(self):
+        # Would raise TypeError on Python 3.10 before the fix.
+        self.assertIsInstance(_otel_id("span:xyz", 64), int)
+        self.assertEqual(_otel_id("span:xyz", 64), 15422170499572505575)
+
+    def test_never_zero(self):
+        self.assertGreaterEqual(_otel_id("anything", 64), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2764

## Problem

`_otel_id()` in `src/core/trulens/core/otel/client_hooks/tracing.py` calls `int.from_bytes()` without `byteorder`. `byteorder` only became optional (defaulting to `"big"`) in Python 3.11; on Python 3.10 it is a required positional argument. So every id derivation, and therefore `TraceAssembler.assemble()` (which calls `_otel_id` for every span id), raises `TypeError` on Python 3.10, which `pyproject.toml` still supports.

## Fix

Pass `byteorder="big"` explicitly. `"big"` matches the 3.11+ default, so ids are unchanged on newer versions and the function stops crashing on 3.10.

## Tests

Adds `tests/unit/test_otel_id_byteorder.py`, which pins the big-endian interpretation, checks the function returns an `int` without raising (the 3.10 failure path), and that the result is never zero. Lint and format clean under the pinned ruff.

Thanks to @adhabnr-ux for the report and @chrikrah for the 3.10 reproduction.


- [x] This change follows the TruLens standards (https://www.trulens.org/contributing/standards/)