### PR TITLE
Add Nikhil Thakur as an Area Triager

### DIFF
--- a/.github/area-reviewers.yml
+++ b/.github/area-reviewers.yml
@@ -28,12 +28,10 @@
 
 areas:
   - name: Core
-    # The largest area in the repo, and everything else depends on it. Routed to
-    # the whole cohort rather than to one owner, so that reviewers build context
-    # in core before owning anything that sits on top of it.
     paths:
       - src/core/
-    reviewers: [bashward]
+    reviewers: []
+    # reviewers: [<handle>]
 
   - name: Documentation
     paths:

--- a/.github/area-reviewers.yml
+++ b/.github/area-reviewers.yml
@@ -33,8 +33,7 @@ areas:
     # in core before owning anything that sits on top of it.
     paths:
       - src/core/
-    reviewers: []
-    # reviewers: [<handle>]
+    reviewers: [bashward]
 
   - name: Documentation
     paths:
@@ -66,8 +65,7 @@ areas:
     paths:
       - src/apps/gepa/
       - src/feedback/trulens/feedback/optimize.py
-    reviewers: []
-    # reviewers: [<handle>]
+    reviewers: [bashward]
 
   - name: LLM judge alignment
     paths:

--- a/.github/area-reviewers.yml
+++ b/.github/area-reviewers.yml
@@ -61,10 +61,14 @@ areas:
     reviewers: []
     # reviewers: [<handle>]
 
-  - name: Ensemble and prompt optimization
+  - name: Ensemble judges and prompt optimization
     paths:
       - src/apps/gepa/
+      - src/feedback/trulens/feedback/jury.py
       - src/feedback/trulens/feedback/optimize.py
+      - docs/cookbook/use_cases/llm_jury.ipynb
+      - examples/expositional/use_cases/llm_jury.ipynb
+      - tests/unit/test_jury.py
     reviewers: [bashward]
 
   - name: LLM judge alignment

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -37,8 +37,7 @@ Issue and pull request triage in a named area. No write access to the codebase.
 
 | Name | Affiliation | GitHub | Area |
 | ---- | ----------- | ------ | ---- |
-
-_Nominations in progress._
+| Nikhil Thakur | Not declared | bashward | Ensemble and prompt optimization |
 
 ## Emeritus
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -37,7 +37,7 @@ Issue and pull request triage in a named area. No write access to the codebase.
 
 | Name | Affiliation | GitHub | Area |
 | ---- | ----------- | ------ | ---- |
-| Nikhil Thakur | Not declared | bashward | Ensemble and prompt optimization |
+| Nikhil Thakur | InviGrid | bashward | Ensemble and prompt optimization |
 
 ## Emeritus
 


### PR DESCRIPTION
## Summary
- add Nikhil Thakur (`bashward`) to the Area Triager roster for ensemble and prompt optimization
- route advisory reviews for GEPA, feedback optimization, and shared core code to him

## Test plan
- [x] Parse `.github/area-reviewers.yml` as YAML
- [x] Dry-run area routing for GEPA, feedback optimization, and core paths
- [x] Run pre-commit hooks
- [x] Run `git diff --check`

## Certification
- [x] This change follows the TruLens standards (https://www.trulens.org/contributing/standards/)

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)