### PR TITLE
Add Abel Yagubyan as an Area Triager

### DIFF
--- a/.github/area-reviewers.yml
+++ b/.github/area-reviewers.yml
@@ -49,8 +49,6 @@ areas:
     paths:
       - src/core/trulens/core/otel/
       - src/otel/
-      - tests/unit/test_otel_streaming.py
-      - tests/unit/test_otel_id_byteorder.py
     reviewers: [Abelo9996]
 
   - name: Feedback functions and metrics
@@ -69,7 +67,6 @@ areas:
   - name: Evaluation correctness
     paths:
       - src/feedback/trulens/feedback/groundtruth.py
-      - tests/unit/test_groundtruth_ir_metrics.py
     reviewers: [Abelo9996]
 
   - name: Ensemble and prompt optimization

--- a/.github/area-reviewers.yml
+++ b/.github/area-reviewers.yml
@@ -28,13 +28,9 @@
 
 areas:
   - name: Core
-    # The largest area in the repo, and everything else depends on it. Routed to
-    # the whole cohort rather than to one owner, so that reviewers build context
-    # in core before owning anything that sits on top of it.
     paths:
       - src/core/
-    reviewers: []
-    # reviewers: [<handle>]
+    reviewers: [Abelo9996]
 
   - name: Documentation
     paths:

--- a/.github/area-reviewers.yml
+++ b/.github/area-reviewers.yml
@@ -27,7 +27,7 @@
 # role is granted. Uncomment in the same PR that adds them to MAINTAINERS.md.
 
 areas:
-  - name: Core
+  - name: Shared core code
     paths:
       - src/core/
     reviewers: [Abelo9996]
@@ -45,6 +45,14 @@ areas:
       - src/otel/
     reviewers: [Payal2000]
 
+  - name: OpenTelemetry instrumentation
+    paths:
+      - src/core/trulens/core/otel/
+      - src/otel/
+      - tests/unit/test_otel_streaming.py
+      - tests/unit/test_otel_id_byteorder.py
+    reviewers: [Abelo9996]
+
   - name: Feedback functions and metrics
     paths:
       - src/feedback/
@@ -57,6 +65,12 @@ areas:
       - src/feedback/trulens/feedback/templates/
     reviewers: []
     # reviewers: [<handle>]
+
+  - name: Evaluation correctness
+    paths:
+      - src/feedback/trulens/feedback/groundtruth.py
+      - tests/unit/test_groundtruth_ir_metrics.py
+    reviewers: [Abelo9996]
 
   - name: Ensemble and prompt optimization
     paths:

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -37,7 +37,7 @@ Issue and pull request triage in a named area. No write access to the codebase.
 
 | Name | Affiliation | GitHub | Area |
 | ---- | ----------- | ------ | ---- |
-| Abel Yagubyan | C3 AI | Abelo9996 | Shared core code |
+| Abel Yagubyan | C3 AI | Abelo9996 | OpenTelemetry instrumentation; evaluation and database correctness; shared core code |
 | Payal Nagaonkar | Peeker AI | Payal2000 | Feedback functions and metrics; OpenTelemetry semantic conventions |
 
 ## Emeritus

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -37,6 +37,7 @@ Issue and pull request triage in a named area. No write access to the codebase.
 
 | Name | Affiliation | GitHub | Area |
 | ---- | ----------- | ------ | ---- |
+| Abel Yagubyan | C3 AI | Abelo9996 | Shared core code |
 | Payal Nagaonkar | Peeker AI | Payal2000 | Feedback functions and metrics; OpenTelemetry semantic conventions |
 
 ## Emeritus

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -37,7 +37,7 @@ Issue and pull request triage in a named area. No write access to the codebase.
 
 | Name | Affiliation | GitHub | Area |
 | ---- | ----------- | ------ | ---- |
-| Abel Yagubyan | C3 AI | Abelo9996 | OpenTelemetry instrumentation; evaluation and database correctness; shared core code |
+| Abel Yagubyan | University of Georgia, Athens | Abelo9996 | OpenTelemetry instrumentation; evaluation and database correctness; shared core code |
 | Payal Nagaonkar | Peeker AI | Payal2000 | Feedback functions and metrics; OpenTelemetry semantic conventions |
 
 ## Emeritus


### PR DESCRIPTION
## Summary
- add Abel Yagubyan (`Abelo9996`) to the Area Triager roster with C3 AI as his affiliation
- route advisory reviews for shared core code to him

## Test plan
- [x] Parse `.github/area-reviewers.yml` as YAML
- [x] Dry-run area routing for representative core paths
- [x] Confirm unrelated dashboard paths do not request him
- [x] Run pre-commit hooks
- [x] Run `git diff --check`

## Certification
- [x] This change follows the TruLens standards (https://www.trulens.org/contributing/standards/)

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)