### PR TITLE
fix(hotspots): point README at the actual Streamlit module path

### DIFF
--- a/src/hotspots/README.md
+++ b/src/hotspots/README.md
@@ -71,7 +71,7 @@ hotspots_df = get_hotspots(session, feedback="Comprehensiveness")
 
 ### As a part of a stand-alone Streamlit app
 
-It's easy to run TruLens Hotspots as a part of a [Streamlit](https://streamlit.io/) app, see [trulens/streamlit.py](trulens/streamlit.py) for helper
+It's easy to run TruLens Hotspots as a part of a [Streamlit](https://streamlit.io/) app, see [trulens/hotspots/hotspots_streamlit.py](trulens/hotspots/hotspots_streamlit.py) for helper
 functions and an example. You can run it as follows:
 
 ```bash


### PR DESCRIPTION
## Problem

The "As a part of a stand-alone Streamlit app" section of `src/hotspots/README.md` links to `trulens/streamlit.py`, which does not exist under `src/hotspots/` and never has — the path has no history in this repository. The line directly below it already runs the real module, `python -m trulens.hotspots.hotspots_streamlit`. `src/hotspots/README.md` is the `trulens-hotspots` package readme, so the dead link ships to PyPI as well.

## Fix

Point the link at `trulens/hotspots/hotspots_streamlit.py` (`hotspots_in_streamlit`, `hotspots_in_streamlit_with_config`, and the `sample_main` example the sentence promises).

## Validation

- `git ls-files src/hotspots/` confirms the target path is tracked.
- `git grep "trulens/streamlit.py"` returns nothing after the change.
- A relative-link check across all tracked markdown reports `src/hotspots/README.md:74` as missing before the change and not after.

Docs-only; no behavior changes and no tests affected.

- [x] This change follows the TruLens standards (https://www.trulens.org/contributing/standards/)
