### PR TITLE
Fix the CLA document link in bot comments

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -67,8 +67,11 @@ jobs:
             under the project's licence.
 
 
-            Please read $pathToCLADocument and then post a comment on this pull
-            request containing exactly:
+            Please read the [CLA](https://github.com/truera/trulens/blob/main/CLA.md)
+            and then post a comment on this pull request containing exactly:
+
+            The TruLens standards checkbox is a separate certification and does
+            not sign the CLA.
           custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
           custom-allsigned-prcomment: >-
             All contributors have signed the CLA. Thanks — you will not be asked


### PR DESCRIPTION
## Summary

- replace the unsupported `$pathToCLADocument` placeholder with an explicit link to `CLA.md`
- clarify that the TruLens standards checkbox does not sign the CLA

The pinned CLA Assistant action only substitutes `$you` in custom unsigned-contributor comments, so PR #2777 displayed the document-path placeholder literally.

## Test plan

- [x] Confirm `CLA.md` exists on `main`
- [x] Parse `.github/workflows/cla.yml` as YAML
- [x] Run pre-commit hooks for the commit

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)