### PR TITLE
docs: add New Relic to OTLP export destinations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ TruLens instrumentation is built on [OpenTelemetry](https://opentelemetry.io/).
 Every function call, LLM generation, retrieval, and tool invocation is captured
 as a structured OTEL span. This makes TruLens interoperable with existing
 observability infrastructure — export traces to Jaeger, Grafana Tempo, Datadog,
-or any OTLP-compatible backend.
+New Relic, or any OTLP-compatible backend.
 
 ```python
 from trulens.core.otel.instrument import instrument


### PR DESCRIPTION
## Why

TruLens exports OTEL spans to any OTLP backend, and the README names Jaeger, Grafana Tempo, and Datadog as examples. New Relic ingests OTLP natively, so it belongs in that sentence.

This replaces #2779, which was rightly closed: its branch was built from a checkout silently truncated by a missing git-lfs binary, which turned most of the repository into staged deletions. This PR was rebuilt from a verified-clean clone and touches one line.

## Scope

One sentence in README.md. "Jaeger, Grafana Tempo, Datadog" becomes "Jaeger, Grafana Tempo, Datadog, New Relic". Plain text, matching the existing style.

## Verification

`git show --stat` confirms 1 file changed, 1 insertion, 1 deletion. New Relic's OTLP documentation (https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/) confirms native OTLP ingest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KybsFC28cLtu6pCdwdwBBw
