### PR TITLE
Deprecate the Hotspots package

### DIFF
--- a/POLICIES.md
+++ b/POLICIES.md
@@ -32,6 +32,12 @@ will occur at the introduction of the warning period.
 
 ## Currently Deprecated Features
 
+### TruLens Hotspots
+
+The `trulens-hotspots` package is deprecated and has no direct replacement. It
+will continue to work during the warning period and will be removed after the
+deprecation process described above.
+
 ### Legacy Instrumentation
 
 The legacy stack-based instrumentation system is deprecated in favor of

--- a/src/hotspots/README.md
+++ b/src/hotspots/README.md
@@ -1,5 +1,10 @@
 # TruLens Hotspots
 
+> **Deprecated:** The `trulens-hotspots` package is deprecated and will be
+> removed after the deprecation process documented in
+> [POLICIES.md](../../POLICIES.md). There is no direct replacement. Existing
+> installations continue to work during the warning period.
+
 TruLens Hotspots is a tool for listing features in your evaluation data that correlate with worse results, according to your evaluation metric.
 
 TruLens Hotspots:

--- a/src/hotspots/pyproject.toml
+++ b/src/hotspots/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 [tool.poetry]
 name = "trulens-hotspots"
 version = "2.14.0"
-description = "Library and command-line tool to list features lowering your evaluation score."
+description = "Deprecated library and CLI for finding features that lower evaluation scores."
 authors = [
   "Snowflake Inc. <ml-observability-wg-dl@snowflake.com>",
 ]
@@ -22,7 +22,7 @@ repository = "https://github.com/truera/trulens"
 classifiers = [
   "Programming Language :: Python :: 3",
   "Operating System :: OS Independent",
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 7 - Inactive",
   "License :: OSI Approved :: MIT License",
 ]
 

--- a/src/hotspots/trulens/hotspots/__init__.py
+++ b/src/hotspots/trulens/hotspots/__init__.py
@@ -1,6 +1,7 @@
 # WARNING: This file does not follow the no-init aliases import standard.
 
 from importlib.metadata import version
+import warnings
 
 from trulens.core.utils import imports as import_utils
 from trulens.hotspots.hotspots import HotspotsConfig
@@ -9,6 +10,14 @@ from trulens.hotspots.hotspots import hotspots
 from trulens.hotspots.hotspots import hotspots_as_df
 from trulens.hotspots.hotspots import hotspots_dict_to_df
 from trulens.hotspots.hotspots import main
+
+warnings.warn(
+    "The `trulens-hotspots` package is deprecated and will be removed after "
+    "the deprecation process documented in POLICIES.md. There is no direct "
+    "replacement.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __version__ = version(
     import_utils.safe_importlib_package_name(__package__ or __name__)

--- a/tests/unit/test_hotspots.py
+++ b/tests/unit/test_hotspots.py
@@ -1,4 +1,8 @@
+import os
+from pathlib import Path
 import re
+import subprocess
+import sys
 from unittest import TestCase
 
 import pytest
@@ -12,6 +16,32 @@ def clean_up_feature(feat: str) -> str:
 
 class TestHotspots(TestCase):
     """Tests for hotspots."""
+
+    def test_package_deprecation_warning(self) -> None:
+        """Importing the package emits its deprecation warning."""
+        package_root = Path(__file__).parents[2] / "src" / "hotspots"
+        env = os.environ.copy()
+        env["PYTHONPATH"] = os.pathsep.join([
+            str(package_root),
+            env.get("PYTHONPATH", ""),
+        ])
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-W",
+                "always::DeprecationWarning",
+                "-c",
+                "import trulens.hotspots",
+            ],
+            check=True,
+            capture_output=True,
+            env=env,
+            text=True,
+        )
+
+        self.assertIn(
+            "The `trulens-hotspots` package is deprecated", result.stderr
+        )
 
     @pytest.mark.optional
     def test_simple(self) -> None:


### PR DESCRIPTION
## Summary
- emit a deprecation warning when `trulens.hotspots` is imported
- mark `trulens-hotspots` inactive and document its policy-based retirement
- preserve the package API and verify the warning in a fresh Python process

## Test plan
- [x] `TEST_OPTIONAL=true poetry run pytest tests/unit/test_hotspots.py -v`
- [x] `poetry run ruff check src/hotspots tests/unit/test_hotspots.py`
- [x] `poetry run ruff format --check src/hotspots tests/unit/test_hotspots.py`
- [x] pre-commit hooks

## Certification

- [x] This change follows the TruLens standards (https://www.trulens.org/contributing/standards/)

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)