### PR TITLE
Add New Relic OTLP export example notebook

### DIFF
--- a/examples/expositional/logging/otlp_export_to_new_relic.ipynb
+++ b/examples/expositional/logging/otlp_export_to_new_relic.ipynb
@@ -18,12 +18,12 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "# !pip install \"trulens[otlp]\""
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -38,7 +38,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "import os\n",
     "\n",
@@ -46,9 +48,7 @@
     "os.environ[\"OTEL_EXPORTER_OTLP_HEADERS\"] = (\n",
     "    \"api-key=\" + os.environ[\"NEW_RELIC_LICENSE_KEY\"]\n",
     ")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -63,14 +63,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "from trulens.core import TruSession\n",
     "\n",
     "session = TruSession(otel_exporter=\"otlp\")"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -83,7 +83,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "from trulens.core.otel.instrument import instrument\n",
     "from trulens.otel.semconv.trace import SpanAttributes\n",
@@ -114,9 +116,7 @@
     "\n",
     "\n",
     "app = SimpleRAGApp()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -129,7 +129,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "from trulens.apps.app import TruApp\n",
     "\n",
@@ -144,9 +146,7 @@
     "    print(f\"Answer: {result}\")\n",
     "\n",
     "session.force_flush()"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",

--- a/examples/expositional/logging/otlp_export_to_new_relic.ipynb
+++ b/examples/expositional/logging/otlp_export_to_new_relic.ipynb
@@ -1,0 +1,189 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Exporting Traces to New Relic via OTLP\n",
+    "\n",
+    "TruLens can export its OpenTelemetry spans and GenAI metrics to any OTLP-compatible backend. This notebook points that export at [New Relic](https://newrelic.com/), which ingests OTLP natively.\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "1. A New Relic account and a [license key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/) for ingest.\n",
+    "2. The TruLens OTLP extra, which installs the OTLP gRPC exporter.\n",
+    "\n",
+    "TruLens exports OTLP over gRPC, so use New Relic's gRPC port `4317`, not the HTTP port `4318`. See the [New Relic OTLP documentation](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/) for endpoint and authentication details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# !pip install \"trulens[otlp]\""
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure the New Relic Endpoint\n",
+    "\n",
+    "New Relic's US OTLP endpoint is `https://otlp.nr-data.net:4317`; the EU endpoint is `https://otlp.eu01.nr-data.net:4317`. Authentication is a header named `api-key` set to your license key.\n",
+    "\n",
+    "TruLens reads the standard OpenTelemetry environment variables `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` when no explicit `otlp_endpoint` is given. Set `NEW_RELIC_LICENSE_KEY` in your environment before launching this notebook so the key never appears in the notebook itself."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"OTEL_EXPORTER_OTLP_ENDPOINT\"] = \"https://otlp.nr-data.net:4317\"\n",
+    "os.environ[\"OTEL_EXPORTER_OTLP_HEADERS\"] = (\n",
+    "    \"api-key=\" + os.environ[\"NEW_RELIC_LICENSE_KEY\"]\n",
+    ")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a TruSession with the OTLP Exporter\n",
+    "\n",
+    "Selecting `otel_exporter=\"otlp\"` sends spans and GenAI metrics to the endpoint configured above. You can also pass the endpoint directly with `TruSession(otel_exporter=\"otlp\", otlp_endpoint=\"https://otlp.nr-data.net:4317\")`.\n",
+    "\n",
+    "**Note**: OTLP mode replaces the default TruLens database exporter. Spans go to New Relic instead of the TruLens database, so the TruLens dashboard and feedback evaluations that read spans from that database will not see them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from trulens.core import TruSession\n",
+    "\n",
+    "session = TruSession(otel_exporter=\"otlp\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create an Instrumented App\n",
+    "\n",
+    "Let's create a simple RAG-style application with instrumentation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from trulens.core.otel.instrument import instrument\n",
+    "from trulens.otel.semconv.trace import SpanAttributes\n",
+    "\n",
+    "\n",
+    "class SimpleRAGApp:\n",
+    "    \"\"\"A simple RAG-style application for demonstration.\"\"\"\n",
+    "\n",
+    "    @instrument(span_type=SpanAttributes.SpanType.RETRIEVAL)\n",
+    "    def retrieve(self, query: str) -> list:\n",
+    "        \"\"\"Retrieve relevant contexts for a query.\"\"\"\n",
+    "        return [\n",
+    "            \"TruLens is an open-source library for evaluating LLM apps.\",\n",
+    "            \"TruLens exports OTEL spans to any OTLP-compatible backend.\",\n",
+    "        ]\n",
+    "\n",
+    "    @instrument(span_type=SpanAttributes.SpanType.GENERATION)\n",
+    "    def generate(self, query: str, contexts: list) -> str:\n",
+    "        \"\"\"Generate an answer based on retrieved contexts.\"\"\"\n",
+    "        context_text = \" \".join(contexts)\n",
+    "        return f\"Based on the context: {context_text[:100]}...\"\n",
+    "\n",
+    "    @instrument()\n",
+    "    def query(self, question: str) -> str:\n",
+    "        \"\"\"Main entry point: retrieve contexts and generate an answer.\"\"\"\n",
+    "        contexts = self.retrieve(question)\n",
+    "        return self.generate(question, contexts)\n",
+    "\n",
+    "\n",
+    "app = SimpleRAGApp()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wrap with TruApp and Record\n",
+    "\n",
+    "Recording works exactly as it does with the default exporter; only the destination of the spans changes. `session.force_flush()` blocks until pending trace and metric exports have been delivered, which matters in short-lived processes like this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from trulens.apps.app import TruApp\n",
+    "\n",
+    "tru_app = TruApp(\n",
+    "    app,\n",
+    "    app_name=\"NewRelicExampleApp\",\n",
+    "    app_version=\"v1\",\n",
+    ")\n",
+    "\n",
+    "with tru_app as recording:\n",
+    "    result = app.query(\"What is TruLens?\")\n",
+    "    print(f\"Answer: {result}\")\n",
+    "\n",
+    "session.force_flush()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What to Look For in New Relic\n",
+    "\n",
+    "- **Entity**: TruLens sets the `service.name` resource attribute to `trulens`, so the spans appear under **All entities > Services - OpenTelemetry** as a service named `trulens`.\n",
+    "- **Traces**: open the `trulens` entity's distributed traces, or query the raw spans with NRQL:\n",
+    "\n",
+    "  ```sql\n",
+    "  FROM Span SELECT * WHERE service.name = 'trulens' SINCE 30 minutes ago\n",
+    "  ```\n",
+    "\n",
+    "  Each recorded invocation produces a record root span with retrieval and generation child spans, carrying TruLens semantic attributes in the `ai.observability.*` namespace.\n",
+    "- **GenAI metrics**: when your app makes real LLM calls, TruLens also exports the `gen_ai.client.token.usage` and `gen_ai.client.operation.duration` histogram metrics. TruLens follows the OpenTelemetry GenAI semantic conventions (`gen_ai.*`), the same attribute family New Relic's [AI monitoring](https://docs.newrelic.com/docs/ai-monitoring/intro-to-ai-monitoring/) is built around."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Why

On #2781, @sfc-gh-jreini asked for an example showing how to use TruLens OTLP export with New Relic, to live in `examples/expositional/`. This adds that notebook.

## Scope

One new file, `examples/expositional/logging/otlp_export_to_new_relic.ipynb`, mirroring the structure of the sibling `log_in_postgres.ipynb`:

- New Relic endpoint and `api-key` header configured through `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_HEADERS`, with the license key read from an environment variable rather than hardcoded.
- `TruSession(otel_exporter="otlp")` per `docs/otel/index.md`, including the gRPC-only (port 4317) caveat and the note that OTLP mode replaces the TruLens database exporter.
- The same minimal instrumented RAG app the postgres logging example uses, recorded with `TruApp`, flushed with `session.force_flush()`.
- A closing section on where the data lands in New Relic (the `trulens` service entity, distributed traces, an NRQL span query, and the `gen_ai.*` metrics), grounded in New Relic's OTLP docs.

## Verification

- Notebook JSON validates and every code cell compiles.
- All external links return 200.
- Output-stripped and metadata-clean to match the repo's nb-clean pre-commit hook conventions.
- The notebook was **not** executed against a live New Relic account; the TruLens API usage is taken from `docs/otel/index.md` and `src/core/trulens/core/session.py`, and the New Relic endpoint/header details from the linked New Relic documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KybsFC28cLtu6pCdwdwBBw