### PR TITLE
fix(providers/ollama): treat blank env as unconfigured

### DIFF
--- a/src/providers/ollama/trulens/providers/ollama/provider.py
+++ b/src/providers/ollama/trulens/providers/ollama/provider.py
@@ -140,12 +140,19 @@ class Ollama(openai_provider.OpenAI):
             model_engine = self.DEFAULT_MODEL_ENGINE
 
         if base_url is None:
-            base_url = os.environ.get("OLLAMA_BASE_URL", self.DEFAULT_BASE_URL)
+            # A blank OLLAMA_BASE_URL (common in .env templates) is unset, not
+            # an empty server address. os.environ.get returns "" when the
+            # variable is present but empty, which would otherwise replace the
+            # local default.
+            base_url = (
+                os.environ.get("OLLAMA_BASE_URL") or self.DEFAULT_BASE_URL
+            )
 
         if api_key is None:
             # Ollama does not require an API key, but the underlying OpenAI
-            # client requires the value to be a non-empty string.
-            api_key = os.environ.get("OLLAMA_API_KEY", "ollama")
+            # client requires the value to be a non-empty string. Treat a blank
+            # OLLAMA_API_KEY the same as unset so construction still succeeds.
+            api_key = os.environ.get("OLLAMA_API_KEY") or "ollama"
 
         super().__init__(
             *args,

--- a/tests/unit/providers/test_ollama_capabilities.py
+++ b/tests/unit/providers/test_ollama_capabilities.py
@@ -43,6 +43,27 @@ def test_defaults_to_local_ollama_server(monkeypatch):
 
 
 @pytest.mark.optional
+def test_blank_env_vars_fall_back_to_defaults(monkeypatch):
+    # .env templates often export OLLAMA_BASE_URL= and OLLAMA_API_KEY= as
+    # empty strings. Those must not replace the local default URL or the
+    # dummy key the OpenAI client requires.
+    monkeypatch.setenv("OLLAMA_BASE_URL", "")
+    monkeypatch.setenv("OLLAMA_API_KEY", "")
+
+    from trulens.providers.ollama import (
+        Ollama,  # type: ignore[import-not-found]
+    )
+
+    provider = Ollama()
+
+    assert str(provider.endpoint.client.client.base_url) == (
+        "http://localhost:11434/v1/"
+    )
+    assert provider.endpoint.client.client.api_key == "ollama"
+    assert provider._native_base_url() == "http://localhost:11434"
+
+
+@pytest.mark.optional
 def test_respects_env_var_base_url(monkeypatch):
     monkeypatch.setenv("OLLAMA_BASE_URL", "http://my-ollama-host:11434/v1")
     monkeypatch.delenv("OLLAMA_API_KEY", raising=False)


### PR DESCRIPTION
# Description

Blank `OLLAMA_BASE_URL` / `OLLAMA_API_KEY` values (typical leftover `KEY=` lines in a `.env` template) were treated as configured. That replaced the documented local default URL with an empty server address, and left the OpenAI client with an empty API key so `Ollama()` failed to construct even though Ollama does not require a key.

## Other details good to know for developers

`os.environ.get("OLLAMA_BASE_URL", default)` returns `""` when the variable is present but empty, so the default never applied. The constructor now treats a blank env value the same as unset (`or` fallback). An explicit `base_url=""` / `api_key=""` argument is unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] New Tests
- [ ] This change includes re-generated golden test results
- [ ] This change requires a documentation update

## Certification

- [x] This change follows the TruLens standards (https://www.trulens.org/contributing/standards/)
